### PR TITLE
Fixed leaking “tmp” variable

### DIFF
--- a/lib/TypeLexer.js
+++ b/lib/TypeLexer.js
@@ -268,6 +268,7 @@ TypeLexer.prototype.analyzeTypeUnion = function(arg) {
  */
 TypeLexer.prototype.analyzeType = function(arg) {
   var str = arg;
+  var tmp;
 
   if (!str) {
     this.fail_('Unexpected token: ""', this.org_.length);


### PR DESCRIPTION
The tmp variable on line 282 wasn't declared and leaking. This should fix it
