### PR TITLE
Add no-hang test for Definitely Typed types

### DIFF
--- a/tests/fixtures/definitely-typed-types
+++ b/tests/fixtures/definitely-typed-types
@@ -1,0 +1,3719 @@
+{number}
+{string}
+{any}
+{boolean}
+{symbol}
+{string | number | symbol}
+{void}
+{PropertyDescriptor}
+{Function}
+{Object}
+{PropertyKey}
+{PropertyDescriptor | undefined}
+{string[]}
+{object | null}
+{PropertyDescriptorMap & ThisType<any>}
+{PropertyDescriptor & ThisType<any>}
+{T}
+{T[]}
+{ReadonlyArray<T>}
+{Readonly<T>}
+{{}}
+{ObjectConstructor}
+{any[]}
+{FunctionConstructor}
+{T extends (this: unknown, ...args: any[]) => any ? unknown : T extends (this: infer U, ...args: any[]) => any ? U : unknown}
+{unknown extends ThisParameterType<T> ? T : T extends (...args: infer A) => infer R ? (...args: A) => R : T}
+{(this: T) => R}
+{R}
+{(this: T, ...args: A) => R}
+{A}
+{ThisParameterType<T>}
+{OmitThisParameter<T>}
+{(this: T, arg0: A0, ...args: A) => R}
+{A0}
+{(...args: A) => R}
+{(this: T, arg0: A0, arg1: A1, ...args: A) => R}
+{A1}
+{(this: T, arg0: A0, arg1: A1, arg2: A2, ...args: A) => R}
+{A2}
+{(this: T, arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R}
+{A3}
+{(this: T, ...args: AX[]) => R}
+{AX[]}
+{(...args: AX[]) => R}
+{new () => T}
+{new (...args: A) => T}
+{new (arg0: A0, ...args: A) => R}
+{new (...args: A) => R}
+{new (arg0: A0, arg1: A1, ...args: A) => R}
+{new (arg0: A0, arg1: A1, arg2: A2, ...args: A) => R}
+{new (arg0: A0, arg1: A1, arg2: A2, arg3: A3, ...args: A) => R}
+{new (...args: AX[]) => R}
+{string | RegExp}
+{RegExpMatchArray | null}
+{(substring: string, ...args: any[]) => string}
+{String}
+{number[]}
+{StringConstructor}
+{Boolean}
+{BooleanConstructor}
+{Number}
+{NumberConstructor}
+{ReadonlyArray<string>}
+{Math}
+{Date}
+{number | string}
+{DateConstructor}
+{Array<string>}
+{RegExpExecArray | null}
+{this}
+{RegExp | string}
+{RegExp}
+{RegExpConstructor}
+{Error}
+{ErrorConstructor}
+{EvalError}
+{EvalErrorConstructor}
+{RangeError}
+{RangeErrorConstructor}
+{ReferenceError}
+{ReferenceErrorConstructor}
+{SyntaxError}
+{SyntaxErrorConstructor}
+{TypeError}
+{TypeErrorConstructor}
+{URIError}
+{URIErrorConstructor}
+{(this: any, key: string, value: any) => any}
+{string | number}
+{(number | string)[] | null}
+{JSON}
+{ConcatArray<T>[]}
+{(T | ConcatArray<T>)[]}
+{(value: T, index: number, array: ReadonlyArray<T>) => unknown}
+{(value: T, index: number, array: ReadonlyArray<T>) => void}
+{(value: T, index: number, array: ReadonlyArray<T>) => U}
+{U[]}
+{(value: T, index: number, array: ReadonlyArray<T>) => value is S}
+{S[]}
+{(previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T}
+{(previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U}
+{U}
+{T | undefined}
+{(a: T, b: T) => number}
+{(value: T, index: number, array: T[]) => boolean}
+{(value: T, index: number, array: T[]) => void}
+{(value: T, index: number, array: T[]) => U}
+{(value: T, index: number, array: T[]) => value is S}
+{(value: T, index: number, array: T[]) => any}
+{(previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T}
+{(previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U}
+{arg is Array<any>}
+{Array<any>}
+{ArrayConstructor}
+{() => T}
+{(value: T) => void}
+{<TFunction extends Function>(target: TFunction) => TFunction | void}
+{(target: Object, propertyKey: string | symbol) => void}
+{<T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void}
+{(target: Object, propertyKey: string | symbol, parameterIndex: number) => void}
+{new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>}
+{never}
+{((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null}
+{((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null}
+{PromiseLike<TResult1 | TResult2>}
+{Promise<TResult1 | TResult2>}
+{((reason: any) => TResult | PromiseLike<TResult>) | undefined | null}
+{Promise<T | TResult>}
+{{     [P in keyof T]?: T[P]; }}
+{{     [P in keyof T]-?: T[P]; }}
+{{     readonly [P in keyof T]: T[P]; }}
+{keyof T}
+{{     [P in K]: T[P]; }}
+{keyof any}
+{{     [P in K]: T; }}
+{T extends U ? never : T}
+{T extends U ? T : never}
+{T extends null | undefined ? never : T}
+{(...args: any) => any}
+{T extends (...args: infer P) => any ? P : never}
+{new (...args: any) => any}
+{T extends new (...args: infer P) => any ? P : never}
+{T extends (...args: any) => infer R ? R : any}
+{T extends new (...args: any) => infer R ? R : any}
+{ArrayBuffer}
+{ArrayBufferTypes[keyof ArrayBufferTypes]}
+{arg is ArrayBufferView}
+{ArrayBufferConstructor}
+{ArrayBufferLike}
+{DataView}
+{DataViewConstructor}
+{(value: number, index: number, array: Int8Array) => boolean}
+{(value: number, index: number, array: Int8Array) => any}
+{Int8Array}
+{(value: number, index: number, obj: Int8Array) => boolean}
+{number | undefined}
+{(value: number, index: number, array: Int8Array) => void}
+{(value: number, index: number, array: Int8Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Int8Array) => U}
+{ArrayLike<number>}
+{(a: number, b: number) => number}
+{ArrayLike<number> | ArrayBufferLike}
+{ArrayLike<T>}
+{(v: T, k: number) => number}
+{Int8ArrayConstructor}
+{(value: number, index: number, array: Uint8Array) => boolean}
+{(value: number, index: number, array: Uint8Array) => any}
+{Uint8Array}
+{(value: number, index: number, obj: Uint8Array) => boolean}
+{(value: number, index: number, array: Uint8Array) => void}
+{(value: number, index: number, array: Uint8Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array) => U}
+{Uint8ArrayConstructor}
+{(value: number, index: number, array: Uint8ClampedArray) => boolean}
+{(value: number, index: number, array: Uint8ClampedArray) => any}
+{Uint8ClampedArray}
+{(value: number, index: number, obj: Uint8ClampedArray) => boolean}
+{(value: number, index: number, array: Uint8ClampedArray) => void}
+{(value: number, index: number, array: Uint8ClampedArray) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => U}
+{Uint8ClampedArrayConstructor}
+{(value: number, index: number, array: Int16Array) => boolean}
+{(value: number, index: number, array: Int16Array) => any}
+{Int16Array}
+{(value: number, index: number, obj: Int16Array) => boolean}
+{(value: number, index: number, array: Int16Array) => void}
+{(value: number, index: number, array: Int16Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Int16Array) => U}
+{Int16ArrayConstructor}
+{(value: number, index: number, array: Uint16Array) => boolean}
+{(value: number, index: number, array: Uint16Array) => any}
+{Uint16Array}
+{(value: number, index: number, obj: Uint16Array) => boolean}
+{(value: number, index: number, array: Uint16Array) => void}
+{(value: number, index: number, array: Uint16Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Uint16Array) => U}
+{Uint16ArrayConstructor}
+{(value: number, index: number, array: Int32Array) => boolean}
+{(value: number, index: number, array: Int32Array) => any}
+{Int32Array}
+{(value: number, index: number, obj: Int32Array) => boolean}
+{(value: number, index: number, array: Int32Array) => void}
+{(value: number, index: number, array: Int32Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Int32Array) => U}
+{Int32ArrayConstructor}
+{(value: number, index: number, array: Uint32Array) => boolean}
+{(value: number, index: number, array: Uint32Array) => any}
+{Uint32Array}
+{(value: number, index: number, obj: Uint32Array) => boolean}
+{(value: number, index: number, array: Uint32Array) => void}
+{(value: number, index: number, array: Uint32Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Uint32Array) => U}
+{Uint32ArrayConstructor}
+{(value: number, index: number, array: Float32Array) => boolean}
+{(value: number, index: number, array: Float32Array) => any}
+{Float32Array}
+{(value: number, index: number, obj: Float32Array) => boolean}
+{(value: number, index: number, array: Float32Array) => void}
+{(value: number, index: number, array: Float32Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Float32Array) => U}
+{Float32ArrayConstructor}
+{(value: number, index: number, array: Float64Array) => boolean}
+{(value: number, index: number, array: Float64Array) => any}
+{Float64Array}
+{(value: number, index: number, obj: Float64Array) => boolean}
+{(value: number, index: number, array: Float64Array) => void}
+{(value: number, index: number, array: Float64Array) => number}
+{(previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number}
+{(previousValue: U, currentValue: number, currentIndex: number, array: Float64Array) => U}
+{Float64ArrayConstructor}
+{ResolvedCollatorOptions}
+{{         new(locales?: string | string[], options?: CollatorOptions): Collator;         (locales?: string | string[], options?: CollatorOptions): Collator;         supportedLocalesOf(locales: string | string[], options?: CollatorOptions): string[];     }}
+{ResolvedNumberFormatOptions}
+{{         new(locales?: string | string[], options?: NumberFormatOptions): NumberFormat;         (locales?: string | string[], options?: NumberFormatOptions): NumberFormat;         supportedLocalesOf(locales: string | string[], options?: NumberFormatOptions): string[];     }}
+{Date | number}
+{ResolvedDateTimeFormatOptions}
+{{         new(locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;         (locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;         supportedLocalesOf(locales: string | string[], options?: DateTimeFormatOptions): string[];     }}
+{string | string[]}
+{Intl.CollatorOptions}
+{Intl.NumberFormatOptions}
+{Intl.DateTimeFormatOptions}
+{EventListenerOptions}
+{Algorithm}
+{Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer}
+{KeyAlgorithm}
+{AudioNodeOptions}
+{EventInit}
+{number | null}
+{ScopedCredentialDescriptor[]}
+{WebAuthnExtensions}
+{AudioBuffer | null}
+{AudioContextLatencyCategory | number}
+{ChannelCountMode}
+{ChannelInterpretation}
+{AutomationRate}
+{AudioBuffer}
+{Record<string, number>}
+{BiquadFilterType}
+{EndingType}
+{string | Algorithm}
+{ClientTypes}
+{DataTransfer | null}
+{UIEventInit}
+{EffectTiming}
+{CompositeOperationOrAuto}
+{string | number | null | undefined}
+{ExceptionInformation}
+{DoubleRange}
+{LongRange}
+{VideoFacingModeEnum | VideoFacingModeEnum[]}
+{DOMMatrix2DInit}
+{DOMPointInit}
+{DeviceAccelerationDict | null}
+{DeviceRotationRateDict | null}
+{MouseEventInit}
+{NamedCurve}
+{CryptoKey}
+{HashAlgorithmIdentifier}
+{PlaybackDirection}
+{FillMode}
+{string | null}
+{BlobPropertyBag}
+{EventTarget | null}
+{FullscreenNavigationUI}
+{Gamepad}
+{string | string[] | null}
+{DOMRectInit}
+{Element}
+{Element | null}
+{number | number[]}
+{RsaOtherPrimesInfo[]}
+{EventModifierInit}
+{KeyframeEffectOptions}
+{CompositeOperation}
+{IterationCompositeOperation}
+{HTMLMediaElement}
+{ArrayBuffer | null}
+{MediaKeyMessageType}
+{MediaKeySystemMediaCapability[]}
+{MediaKeysRequirement}
+{MediaStream}
+{boolean | MediaTrackConstraints}
+{MediaStreamError | null}
+{MediaStreamTrack}
+{MediaStreamTrack | null}
+{number | DoubleRange}
+{boolean[]}
+{number | LongRange}
+{number | ConstrainDoubleRange}
+{number | ConstrainLongRange}
+{string | string[] | ConstrainDOMStringParameters}
+{boolean | ConstrainBooleanParameters}
+{MediaTrackConstraintSet}
+{MediaTrackConstraintSet[]}
+{MessagePort[]}
+{MessageEventSource | null}
+{NotificationAction[]}
+{NotificationDirection}
+{VibratePattern}
+{PeriodicWave}
+{OscillatorType}
+{DistanceModelType}
+{PanningModelType}
+{PaymentItem[]}
+{PaymentDetailsModifier[]}
+{PaymentShippingOption[]}
+{PaymentDetailsBase}
+{PaymentItem}
+{PaymentCurrencyAmount}
+{PeriodicWaveConstraints}
+{number[] | Float32Array}
+{Promise<any>}
+{CompositeOperationOrAuto | CompositeOperationOrAuto[]}
+{number | (number | null)[]}
+{string | string[] | number | null | (number | null)[] | undefined}
+{Record<string, string>}
+{BufferSource | string | null}
+{QueuingStrategySizeCallback<T>}
+{RTCOfferAnswerOptions}
+{RTCBundlePolicy}
+{RTCCertificate[]}
+{RTCIceServer[]}
+{RTCIceTransportPolicy}
+{RTCRtcpMuxPolicy}
+{RTCDataChannel}
+{RTCPriorityType}
+{RTCDtlsFingerprint[]}
+{RTCDtlsRole}
+{RTCError | null}
+{RTCStats}
+{RTCStatsIceCandidateType}
+{RTCIceProtocol}
+{RTCIceTcpCandidateType}
+{RTCIceCandidateType}
+{RTCIceCandidate}
+{RTCStatsIceCandidatePairState}
+{RTCIceGatherPolicy}
+{string | RTCOAuthCredential}
+{RTCIceCredentialType}
+{RTCRTPStreamStats}
+{RTCIceCandidate | null}
+{RTCRtpCodecCapability[]}
+{RTCRtpHeaderExtensionCapability[]}
+{RTCRtpCodingParameters}
+{RTCDtxStatus}
+{RTCRtpCodecParameters[]}
+{RTCRtpHeaderExtensionParameters[]}
+{RTCRtcpParameters}
+{RTCRtpParameters}
+{RTCRtpDecodingParameters[]}
+{RTCDegradationPreference}
+{RTCRtpEncodingParameters[]}
+{RTCRtpContributingSource}
+{RTCRtpTransceiverDirection}
+{MediaStream[]}
+{RTCSdpType}
+{RTCSrtpKeyParam[]}
+{RTCStatsType}
+{RTCStatsReport}
+{RTCRtpReceiver}
+{RTCRtpTransceiver}
+{WorkerType}
+{ServiceWorkerUpdateViaCache}
+{BodyInit | null}
+{RequestCache}
+{RequestCredentials}
+{HeadersInit}
+{RequestMode}
+{RequestRedirect}
+{ReferrerPolicy}
+{AbortSignal | null}
+{RsaKeyAlgorithm}
+{RsaKeyGenParams}
+{BigInteger}
+{Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | null}
+{Transport[]}
+{ScopedCredentialType}
+{ScrollOptions}
+{ScrollLogicalPosition}
+{ScrollBehavior}
+{MessagePort[] | null}
+{ServiceWorker | MessagePort | null}
+{ShadowRootMode}
+{Storage | null}
+{StoreExceptionsInformation}
+{Touch[]}
+{EventTarget}
+{TouchType}
+{VideoTrack | AudioTrack | TextTrack | null}
+{TransformStreamDefaultControllerCallback<O>}
+{undefined}
+{TransformStreamDefaultControllerTransformCallback<I, O>}
+{Window | null}
+{ReadableStreamErrorCallback}
+{ReadableByteStreamControllerCallback}
+{"bytes"}
+{WritableStreamErrorCallback}
+{WritableStreamDefaultControllerCloseCallback}
+{WritableStreamDefaultControllerStartCallback}
+{WritableStreamDefaultControllerWriteCallback<W>}
+{ReadableStreamDefaultControllerCallback<R>}
+{VRDisplay}
+{VRDisplayEventReason}
+{number[] | Float32Array | null}
+{HTMLCanvasElement | null}
+{OverSampleType}
+{GLboolean}
+{WebGLPowerPreference}
+{Event}
+{GLenum}
+{GLint}
+{GLsizei}
+{GLintptr}
+{GLuint}
+{AbortSignal}
+{{     prototype: AbortController;     new(): AbortController; }}
+{((this: AbortSignal, ev: Event) => any) | null}
+{keyof AbortSignalEventMap}
+{K}
+{(this: AbortSignal, ev: AbortSignalEventMap[K]) => any}
+{boolean | AddEventListenerOptions}
+{EventListenerOrEventListenerObject}
+{boolean | EventListenerOptions}
+{{     prototype: AbortSignal;     new(): AbortSignal; }}
+{Node}
+{{     prototype: AbstractRange;     new(): AbstractRange; }}
+{ErrorEvent}
+{((this: AbstractWorker, ev: ErrorEvent) => any) | null}
+{keyof AbstractWorkerEventMap}
+{(this: AbstractWorker, ev: AbstractWorkerEventMap[K]) => any}
+{AudioNode}
+{{     prototype: AnalyserNode;     new(context: BaseAudioContext, options?: AnalyserOptions): AnalyserNode; }}
+{Keyframe[] | PropertyIndexedKeyframes | null}
+{number | KeyframeAnimationOptions}
+{Animation}
+{Animation[]}
+{AnimationPlaybackEvent}
+{AnimationEffect | null}
+{Promise<Animation>}
+{((this: Animation, ev: AnimationPlaybackEvent) => any) | null}
+{AnimationPlayState}
+{AnimationTimeline | null}
+{keyof AnimationEventMap}
+{(this: Animation, ev: AnimationEventMap[K]) => any}
+{{     prototype: Animation;     new(effect?: AnimationEffect | null, timeline?: AnimationTimeline | null): Animation; }}
+{ComputedEffectTiming}
+{OptionalEffectTiming}
+{{     prototype: AnimationEffect;     new(): AnimationEffect; }}
+{{     prototype: AnimationEvent;     new(type: string, animationEventInitDict?: AnimationEventInit): AnimationEvent; }}
+{{     prototype: AnimationPlaybackEvent;     new(type: string, eventInitDict?: AnimationPlaybackEventInit): AnimationPlaybackEvent; }}
+{{     prototype: AnimationTimeline;     new(): AnimationTimeline; }}
+{ProgressEvent}
+{((this: ApplicationCache, ev: Event) => any) | null}
+{((this: ApplicationCache, ev: ProgressEvent) => any) | null}
+{keyof ApplicationCacheEventMap}
+{(this: ApplicationCache, ev: ApplicationCacheEventMap[K]) => any}
+{{     prototype: ApplicationCache;     new(): ApplicationCache;     readonly CHECKING: number;     readonly DOWNLOADING: number;     readonly IDLE: number;     readonly OBSOLETE: number;     readonly UNCACHED: number;     readonly UPDATEREADY: number; }}
+{{     prototype: Attr;     new(): Attr; }}
+{{     prototype: AudioBuffer;     new(options: AudioBufferOptions): AudioBuffer; }}
+{AudioScheduledSourceNode}
+{AudioParam}
+{keyof AudioScheduledSourceNodeEventMap}
+{(this: AudioBufferSourceNode, ev: AudioScheduledSourceNodeEventMap[K]) => any}
+{{     prototype: AudioBufferSourceNode;     new(context: BaseAudioContext, options?: AudioBufferSourceOptions): AudioBufferSourceNode; }}
+{BaseAudioContext}
+{Promise<void>}
+{MediaElementAudioSourceNode}
+{MediaStreamAudioDestinationNode}
+{MediaStreamAudioSourceNode}
+{MediaStreamTrackAudioSourceNode}
+{AudioTimestamp}
+{keyof BaseAudioContextEventMap}
+{(this: AudioContext, ev: BaseAudioContextEventMap[K]) => any}
+{{     prototype: AudioContext;     new(contextOptions?: AudioContextOptions): AudioContext; }}
+{{     prototype: AudioDestinationNode;     new(): AudioDestinationNode; }}
+{{     prototype: AudioListener;     new(): AudioListener; }}
+{{     prototype: AudioNode;     new(): AudioNode; }}
+{{     prototype: AudioParam;     new(): AudioParam; }}
+{(value: AudioParam, key: string, parent: AudioParamMap) => void}
+{{     prototype: AudioParamMap;     new(): AudioParamMap; }}
+{{     prototype: AudioProcessingEvent;     new(type: string, eventInitDict: AudioProcessingEventInit): AudioProcessingEvent; }}
+{((this: AudioScheduledSourceNode, ev: Event) => any) | null}
+{(this: AudioScheduledSourceNode, ev: AudioScheduledSourceNodeEventMap[K]) => any}
+{{     prototype: AudioScheduledSourceNode;     new(): AudioScheduledSourceNode; }}
+{SourceBuffer | null}
+{{     prototype: AudioTrack;     new(): AudioTrack; }}
+{TrackEvent}
+{((this: AudioTrackList, ev: TrackEvent) => any) | null}
+{((this: AudioTrackList, ev: Event) => any) | null}
+{AudioTrack | null}
+{AudioTrack}
+{keyof AudioTrackListEventMap}
+{(this: AudioTrackList, ev: AudioTrackListEventMap[K]) => any}
+{{     prototype: AudioTrackList;     new(): AudioTrackList; }}
+{Worklet}
+{{     prototype: AudioWorklet;     new(): AudioWorklet; }}
+{((this: AudioWorkletNode, ev: Event) => any) | null}
+{AudioParamMap}
+{MessagePort}
+{keyof AudioWorkletNodeEventMap}
+{(this: AudioWorkletNode, ev: AudioWorkletNodeEventMap[K]) => any}
+{{     prototype: AudioWorkletNode;     new(context: BaseAudioContext, name: string, options?: AudioWorkletNodeOptions): AudioWorkletNode; }}
+{{     prototype: BarProp;     new(): BarProp; }}
+{AudioWorklet}
+{AudioDestinationNode}
+{AudioListener}
+{((this: BaseAudioContext, ev: Event) => any) | null}
+{AudioContextState}
+{AnalyserNode}
+{BiquadFilterNode}
+{AudioBufferSourceNode}
+{ChannelMergerNode}
+{ChannelSplitterNode}
+{ConstantSourceNode}
+{ConvolverNode}
+{DelayNode}
+{DynamicsCompressorNode}
+{GainNode}
+{IIRFilterNode}
+{OscillatorNode}
+{PannerNode}
+{ScriptProcessorNode}
+{StereoPannerNode}
+{WaveShaperNode}
+{DecodeSuccessCallback | null}
+{DecodeErrorCallback | null}
+{Promise<AudioBuffer>}
+{(this: BaseAudioContext, ev: BaseAudioContextEventMap[K]) => any}
+{{     prototype: BaseAudioContext;     new(): BaseAudioContext; }}
+{{     prototype: BeforeUnloadEvent;     new(): BeforeUnloadEvent; }}
+{DOMException}
+{{     prototype: BhxBrowser;     new(): BhxBrowser; }}
+{{     prototype: BiquadFilterNode;     new(context: BaseAudioContext, options?: BiquadFilterOptions): BiquadFilterNode; }}
+{Blob}
+{{     prototype: Blob;     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob; }}
+{ReadableStream<Uint8Array> | null}
+{Promise<ArrayBuffer>}
+{Promise<Blob>}
+{Promise<FormData>}
+{Promise<string>}
+{MessageEvent}
+{((this: BroadcastChannel, ev: MessageEvent) => any) | null}
+{keyof BroadcastChannelEventMap}
+{(this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any}
+{{     prototype: BroadcastChannel;     new(name: string): BroadcastChannel; }}
+{QueuingStrategy<ArrayBufferView>}
+{ArrayBufferView}
+{{     prototype: ByteLengthQueuingStrategy;     new(options: { highWaterMark: number }): ByteLengthQueuingStrategy; }}
+{Text}
+{{     prototype: CDATASection;     new(): CDATASection; }}
+{CSS}
+{CSSGroupingRule}
+{{     prototype: CSSConditionRule;     new(): CSSConditionRule; }}
+{CSSRule}
+{CSSStyleDeclaration}
+{{     prototype: CSSFontFaceRule;     new(): CSSFontFaceRule; }}
+{CSSRuleList}
+{{     prototype: CSSGroupingRule;     new(): CSSGroupingRule; }}
+{MediaList}
+{CSSStyleSheet}
+{{     prototype: CSSImportRule;     new(): CSSImportRule; }}
+{{     prototype: CSSKeyframeRule;     new(): CSSKeyframeRule; }}
+{CSSKeyframeRule | null}
+{{     prototype: CSSKeyframesRule;     new(): CSSKeyframesRule; }}
+{CSSConditionRule}
+{{     prototype: CSSMediaRule;     new(): CSSMediaRule; }}
+{{     prototype: CSSNamespaceRule;     new(): CSSNamespaceRule; }}
+{{     prototype: CSSPageRule;     new(): CSSPageRule; }}
+{CSSRule | null}
+{CSSStyleSheet | null}
+{{     prototype: CSSRule;     new(): CSSRule;     readonly CHARSET_RULE: number;     readonly FONT_FACE_RULE: number;     readonly IMPORT_RULE: number;     readonly KEYFRAMES_RULE: number;     readonly KEYFRAME_RULE: number;     readonly MEDIA_RULE: number;     readonly NAMESPACE_RULE: number;     readonly PAGE_RULE: number;     readonly STYLE_RULE: number;     readonly SUPPORTS_RULE: number;     readonly UNKNOWN_RULE: number;     readonly VIEWPORT_RULE: number; }}
+{{     prototype: CSSRuleList;     new(): CSSRuleList; }}
+{{     prototype: CSSStyleDeclaration;     new(): CSSStyleDeclaration; }}
+{{     prototype: CSSStyleRule;     new(): CSSStyleRule; }}
+{StyleSheet}
+{StyleSheetList}
+{{     prototype: CSSStyleSheet;     new(): CSSStyleSheet; }}
+{{     prototype: CSSSupportsRule;     new(): CSSSupportsRule; }}
+{RequestInfo}
+{RequestInfo[]}
+{CacheQueryOptions}
+{Promise<boolean>}
+{Promise<ReadonlyArray<Request>>}
+{Promise<Response | undefined>}
+{Promise<ReadonlyArray<Response>>}
+{Response}
+{{     prototype: Cache;     new(): Cache; }}
+{Promise<string[]>}
+{Promise<Cache>}
+{{     prototype: CacheStorage;     new(): CacheStorage; }}
+{CanvasImageSource}
+{CanvasFillRule}
+{Path2D}
+{string | CanvasGradient | CanvasPattern}
+{CanvasGradient}
+{CanvasPattern | null}
+{{     prototype: CanvasGradient;     new(): CanvasGradient; }}
+{ImageData}
+{ImageSmoothingQuality}
+{CanvasLineCap}
+{CanvasLineJoin}
+{{     prototype: CanvasPattern;     new(): CanvasPattern; }}
+{CanvasState}
+{CanvasTransform}
+{CanvasCompositing}
+{CanvasImageSmoothing}
+{CanvasFillStrokeStyles}
+{CanvasShadowStyles}
+{CanvasFilters}
+{CanvasRect}
+{CanvasDrawPath}
+{CanvasUserInterface}
+{CanvasText}
+{CanvasDrawImage}
+{CanvasImageData}
+{CanvasPathDrawingStyles}
+{CanvasTextDrawingStyles}
+{CanvasPath}
+{HTMLCanvasElement}
+{{     prototype: CanvasRenderingContext2D;     new(): CanvasRenderingContext2D; }}
+{TextMetrics}
+{CanvasDirection}
+{CanvasTextAlign}
+{CanvasTextBaseline}
+{DOMMatrix}
+{DOMRect | null}
+{{     prototype: CaretPosition;     new(): CaretPosition; }}
+{{     prototype: ChannelMergerNode;     new(context: BaseAudioContext, options?: ChannelMergerOptions): ChannelMergerNode; }}
+{{     prototype: ChannelSplitterNode;     new(context: BaseAudioContext, options?: ChannelSplitterOptions): ChannelSplitterNode; }}
+{NonDocumentTypeChildNode}
+{ChildNode}
+{{     prototype: CharacterData;     new(): CharacterData; }}
+{(Node | string)[]}
+{{     prototype: ClientRect;     new(): ClientRect; }}
+{ClientRect}
+{{     prototype: ClientRectList;     new(): ClientRectList; }}
+{{     prototype: Clipboard;     new(): Clipboard; }}
+{{     prototype: ClipboardEvent;     new(type: string, eventInitDict?: ClipboardEventInit): ClipboardEvent; }}
+{{     prototype: CloseEvent;     new(type: string, eventInitDict?: CloseEventInit): CloseEvent; }}
+{CharacterData}
+{{     prototype: Comment;     new(data?: string): Comment; }}
+{UIEvent}
+{Window}
+{{     prototype: CompositionEvent;     new(typeArg: string, eventInitDict?: CompositionEventInit): CompositionEvent; }}
+{{     prototype: Console;     new(): Console; }}
+{(this: ConstantSourceNode, ev: AudioScheduledSourceNodeEventMap[K]) => any}
+{{     prototype: ConstantSourceNode;     new(context: BaseAudioContext, options?: ConstantSourceOptions): ConstantSourceNode; }}
+{{     prototype: ConvolverNode;     new(context: BaseAudioContext, options?: ConvolverOptions): ConvolverNode; }}
+{QueuingStrategy}
+{1}
+{{     prototype: CountQueuingStrategy;     new(options: { highWaterMark: number }): CountQueuingStrategy; }}
+{SubtleCrypto}
+{Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | null}
+{{     prototype: Crypto;     new(): Crypto; }}
+{KeyType}
+{KeyUsage[]}
+{{     prototype: CryptoKey;     new(): CryptoKey; }}
+{{     prototype: CryptoKeyPair;     new(): CryptoKeyPair; }}
+{ElementDefinitionOptions}
+{{     prototype: CustomElementRegistry;     new(): CustomElementRegistry; }}
+{{     prototype: CustomEvent;     new<T>(typeArg: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>; }}
+{{     prototype: DOMError;     new(): DOMError; }}
+{{     prototype: DOMException;     new(message?: string, name?: string): DOMException;     readonly ABORT_ERR: number;     readonly DATA_CLONE_ERR: number;     readonly DOMSTRING_SIZE_ERR: number;     readonly HIERARCHY_REQUEST_ERR: number;     readonly INDEX_SIZE_ERR: number;     readonly INUSE_ATTRIBUTE_ERR: number;     readonly INVALID_ACCESS_ERR: number;     readonly INVALID_CHARACTER_ERR: number;     readonly INVALID_MODIFICATION_ERR: number;     readonly INVALID_NODE_TYPE_ERR: number;     readonly INVALID_STATE_ERR: number;     readonly NAMESPACE_ERR: number;     readonly NETWORK_ERR: number;     readonly NOT_FOUND_ERR: number;     readonly NOT_SUPPORTED_ERR: number;     readonly NO_DATA_ALLOWED_ERR: number;     readonly NO_MODIFICATION_ALLOWED_ERR: number;     readonly QUOTA_EXCEEDED_ERR: number;     readonly SECURITY_ERR: number;     readonly SYNTAX_ERR: number;     readonly TIMEOUT_ERR: number;     readonly TYPE_MISMATCH_ERR: number;     readonly URL_MISMATCH_ERR: number;     readonly VALIDATION_ERR: number;     readonly WRONG_DOCUMENT_ERR: number; }}
+{DocumentType | null}
+{Document}
+{DocumentType}
+{true}
+{{     prototype: DOMImplementation;     new(): DOMImplementation; }}
+{DOMMatrixReadOnly}
+{DOMMatrixInit}
+{{     prototype: DOMMatrix;     new(init?: string | number[]): DOMMatrix;     fromFloat32Array(array32: Float32Array): DOMMatrix;     fromFloat64Array(array64: Float64Array): DOMMatrix;     fromMatrix(other?: DOMMatrixInit): DOMMatrix; }}
+{typeof DOMMatrix}
+{DOMPoint}
+{{     prototype: DOMMatrixReadOnly;     new(init?: string | number[]): DOMMatrixReadOnly;     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;     fromMatrix(other?: DOMMatrixInit): DOMMatrixReadOnly; }}
+{SupportedType}
+{{     prototype: DOMParser;     new(): DOMParser; }}
+{DOMPointReadOnly}
+{{     prototype: DOMPoint;     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;     fromPoint(other?: DOMPointInit): DOMPoint; }}
+{typeof DOMPoint}
+{{     prototype: DOMPointReadOnly;     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;     fromPoint(other?: DOMPointInit): DOMPointReadOnly; }}
+{DOMRect}
+{{     prototype: DOMQuad;     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;     fromQuad(other?: DOMQuadInit): DOMQuad;     fromRect(other?: DOMRectInit): DOMQuad; }}
+{DOMRectReadOnly}
+{{     prototype: DOMRect;     new(x?: number, y?: number, width?: number, height?: number): DOMRect;     fromRect(other?: DOMRectInit): DOMRect; }}
+{typeof DOMRect}
+{{     prototype: DOMRectList;     new(): DOMRectList; }}
+{{     prototype: DOMRectReadOnly;     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;     fromRect(other?: DOMRectInit): DOMRectReadOnly; }}
+{DOMTokenList}
+{{     prototype: DOMSettableTokenList;     new(): DOMSettableTokenList; }}
+{{     prototype: DOMStringList;     new(): DOMStringList; }}
+{string | undefined}
+{{     prototype: DOMStringMap;     new(): DOMStringMap; }}
+{(value: string, key: number, parent: DOMTokenList) => void}
+{{     prototype: DOMTokenList;     new(): DOMTokenList; }}
+{TextTrackCue}
+{keyof TextTrackCueEventMap}
+{(this: DataCue, ev: TextTrackCueEventMap[K]) => any}
+{{     prototype: DataCue;     new(): DataCue; }}
+{FileList}
+{DataTransferItemList}
+{{     prototype: DataTransfer;     new(): DataTransfer; }}
+{File | null}
+{FunctionStringCallback | null}
+{{     prototype: DataTransferItem;     new(): DataTransferItem; }}
+{DataTransferItem | null}
+{File}
+{DataTransferItem}
+{{     prototype: DataTransferItemList;     new(): DataTransferItemList; }}
+{MSWebViewPermissionType}
+{{     prototype: DeferredPermissionRequest;     new(): DeferredPermissionRequest; }}
+{{     prototype: DelayNode;     new(context: BaseAudioContext, options?: DelayOptions): DelayNode; }}
+{{     prototype: DeviceAcceleration;     new(): DeviceAcceleration; }}
+{{     prototype: DeviceLightEvent;     new(typeArg: string, eventInitDict?: DeviceLightEventInit): DeviceLightEvent; }}
+{DeviceAcceleration | null}
+{DeviceRotationRate | null}
+{{     prototype: DeviceMotionEvent;     new(typeArg: string, eventInitDict?: DeviceMotionEventInit): DeviceMotionEvent; }}
+{{     prototype: DeviceOrientationEvent;     new(typeArg: string, eventInitDict?: DeviceOrientationEventInit): DeviceOrientationEvent; }}
+{{     prototype: DeviceRotationRate;     new(): DeviceRotationRate; }}
+{GlobalEventHandlersEventMap}
+{DocumentAndElementEventHandlersEventMap}
+{NonElementParentNode}
+{DocumentOrShadowRoot}
+{ParentNode}
+{GlobalEventHandlers}
+{DocumentAndElementEventHandlers}
+{HTMLAllCollection}
+{HTMLCollectionOf<HTMLAnchorElement>}
+{HTMLCollectionOf<HTMLAppletElement>}
+{HTMLElement}
+{HTMLOrSVGScriptElement | null}
+{WindowProxy | null}
+{HTMLCollectionOf<HTMLEmbedElement>}
+{HTMLCollectionOf<HTMLFormElement>}
+{HTMLHeadElement}
+{HTMLCollectionOf<HTMLImageElement>}
+{DOMImplementation}
+{HTMLCollectionOf<HTMLAnchorElement | HTMLAreaElement>}
+{Location}
+{((this: Document, ev: Event) => any) | null}
+{((this: Document, ev: ProgressEvent) => any) | null}
+{DocumentReadyState}
+{HTMLCollectionOf<HTMLScriptElement>}
+{DocumentTimeline}
+{VisibilityState}
+{CaretPosition | null}
+{Range}
+{Attr}
+{CDATASection}
+{Comment}
+{DocumentFragment}
+{keyof HTMLElementTagNameMap}
+{ElementCreationOptions}
+{HTMLElementTagNameMap[K]}
+{keyof HTMLElementDeprecatedTagNameMap}
+{HTMLElementDeprecatedTagNameMap[K]}
+{"http://www.w3.org/1999/xhtml"}
+{keyof SVGElementTagNameMap}
+{"http://www.w3.org/2000/svg"}
+{SVGElementTagNameMap[K]}
+{"a"}
+{SVGAElement}
+{"script"}
+{SVGScriptElement}
+{"style"}
+{SVGStyleElement}
+{"title"}
+{SVGTitleElement}
+{SVGElement}
+{string | ElementCreationOptions}
+{"AnimationEvent"}
+{AnimationEvent}
+{"AnimationPlaybackEvent"}
+{"AudioProcessingEvent"}
+{AudioProcessingEvent}
+{"BeforeUnloadEvent"}
+{BeforeUnloadEvent}
+{"ClipboardEvent"}
+{ClipboardEvent}
+{"CloseEvent"}
+{CloseEvent}
+{"CompositionEvent"}
+{CompositionEvent}
+{"CustomEvent"}
+{CustomEvent}
+{"DeviceLightEvent"}
+{DeviceLightEvent}
+{"DeviceMotionEvent"}
+{DeviceMotionEvent}
+{"DeviceOrientationEvent"}
+{DeviceOrientationEvent}
+{"DragEvent"}
+{DragEvent}
+{"ErrorEvent"}
+{"Event"}
+{"Events"}
+{"FocusEvent"}
+{FocusEvent}
+{"FocusNavigationEvent"}
+{FocusNavigationEvent}
+{"GamepadEvent"}
+{GamepadEvent}
+{"HashChangeEvent"}
+{HashChangeEvent}
+{"IDBVersionChangeEvent"}
+{IDBVersionChangeEvent}
+{"KeyboardEvent"}
+{KeyboardEvent}
+{"ListeningStateChangedEvent"}
+{ListeningStateChangedEvent}
+{"MSGestureEvent"}
+{MSGestureEvent}
+{"MSMediaKeyMessageEvent"}
+{MSMediaKeyMessageEvent}
+{"MSMediaKeyNeededEvent"}
+{MSMediaKeyNeededEvent}
+{"MSPointerEvent"}
+{MSPointerEvent}
+{"MediaEncryptedEvent"}
+{MediaEncryptedEvent}
+{"MediaKeyMessageEvent"}
+{MediaKeyMessageEvent}
+{"MediaQueryListEvent"}
+{MediaQueryListEvent}
+{"MediaStreamErrorEvent"}
+{MediaStreamErrorEvent}
+{"MediaStreamEvent"}
+{MediaStreamEvent}
+{"MediaStreamTrackEvent"}
+{MediaStreamTrackEvent}
+{"MessageEvent"}
+{"MouseEvent"}
+{MouseEvent}
+{"MouseEvents"}
+{"MutationEvent"}
+{MutationEvent}
+{"MutationEvents"}
+{"OfflineAudioCompletionEvent"}
+{OfflineAudioCompletionEvent}
+{"OverflowEvent"}
+{OverflowEvent}
+{"PageTransitionEvent"}
+{PageTransitionEvent}
+{"PaymentRequestUpdateEvent"}
+{PaymentRequestUpdateEvent}
+{"PermissionRequestedEvent"}
+{PermissionRequestedEvent}
+{"PointerEvent"}
+{PointerEvent}
+{"PopStateEvent"}
+{PopStateEvent}
+{"ProgressEvent"}
+{"PromiseRejectionEvent"}
+{PromiseRejectionEvent}
+{"RTCDTMFToneChangeEvent"}
+{RTCDTMFToneChangeEvent}
+{"RTCDataChannelEvent"}
+{RTCDataChannelEvent}
+{"RTCDtlsTransportStateChangedEvent"}
+{RTCDtlsTransportStateChangedEvent}
+{"RTCErrorEvent"}
+{RTCErrorEvent}
+{"RTCIceCandidatePairChangedEvent"}
+{RTCIceCandidatePairChangedEvent}
+{"RTCIceGathererEvent"}
+{RTCIceGathererEvent}
+{"RTCIceTransportStateChangedEvent"}
+{RTCIceTransportStateChangedEvent}
+{"RTCPeerConnectionIceErrorEvent"}
+{RTCPeerConnectionIceErrorEvent}
+{"RTCPeerConnectionIceEvent"}
+{RTCPeerConnectionIceEvent}
+{"RTCSsrcConflictEvent"}
+{RTCSsrcConflictEvent}
+{"RTCStatsEvent"}
+{RTCStatsEvent}
+{"RTCTrackEvent"}
+{RTCTrackEvent}
+{"SVGZoomEvent"}
+{SVGZoomEvent}
+{"SVGZoomEvents"}
+{"SecurityPolicyViolationEvent"}
+{SecurityPolicyViolationEvent}
+{"ServiceWorkerMessageEvent"}
+{ServiceWorkerMessageEvent}
+{"SpeechRecognitionError"}
+{SpeechRecognitionError}
+{"SpeechRecognitionEvent"}
+{SpeechRecognitionEvent}
+{"SpeechSynthesisErrorEvent"}
+{SpeechSynthesisErrorEvent}
+{"SpeechSynthesisEvent"}
+{SpeechSynthesisEvent}
+{"StorageEvent"}
+{StorageEvent}
+{"TextEvent"}
+{TextEvent}
+{"TouchEvent"}
+{TouchEvent}
+{"TrackEvent"}
+{"TransitionEvent"}
+{TransitionEvent}
+{"UIEvent"}
+{"UIEvents"}
+{"VRDisplayEvent"}
+{VRDisplayEvent}
+{"VRDisplayEvent "}
+{"WebGLContextEvent"}
+{WebGLContextEvent}
+{"WheelEvent"}
+{WheelEvent}
+{NodeFilter | null}
+{NodeIterator}
+{ProcessingInstruction}
+{WindowProxy}
+{Touch}
+{TouchList}
+{TreeWalker}
+{Element[]}
+{XPathNSResolver | ((prefix: string) => string | null) | null}
+{XPathResult | null}
+{XPathResult}
+{HTMLElement | null}
+{HTMLCollectionOf<Element>}
+{NodeListOf<HTMLElement>}
+{HTMLCollectionOf<HTMLElementTagNameMap[K]>}
+{HTMLCollectionOf<SVGElementTagNameMap[K]>}
+{HTMLCollectionOf<HTMLElement>}
+{HTMLCollectionOf<SVGElement>}
+{Selection | null}
+{keyof DocumentEventMap}
+{(this: Document, ev: DocumentEventMap[K]) => any}
+{{     prototype: Document;     new(): Document; }}
+{((this: DocumentAndElementEventHandlers, ev: ClipboardEvent) => any) | null}
+{keyof DocumentAndElementEventHandlersEventMap}
+{(this: DocumentAndElementEventHandlers, ev: DocumentAndElementEventHandlersEventMap[K]) => any}
+{{     prototype: DocumentFragment;     new(): DocumentFragment; }}
+{AnimationTimeline}
+{{     prototype: DocumentTimeline;     new(options?: DocumentTimelineOptions): DocumentTimeline; }}
+{{     prototype: DocumentType;     new(): DocumentType; }}
+{{     prototype: DragEvent;     new(type: string, eventInitDict?: DragEventInit): DragEvent; }}
+{{     prototype: DynamicsCompressorNode;     new(context: BaseAudioContext, options?: DynamicsCompressorOptions): DynamicsCompressorNode; }}
+{Slotable}
+{Animatable}
+{HTMLSlotElement | null}
+{NamedNodeMap}
+{((this: Element, ev: Event) => any) | null}
+{ShadowRoot | null}
+{ShadowRootInit}
+{ShadowRoot}
+{HTMLElementTagNameMap[K] | null}
+{SVGElementTagNameMap[K] | null}
+{Attr | null}
+{ClientRect | DOMRect}
+{ClientRectList | DOMRectList}
+{InsertPosition}
+{FullscreenOptions}
+{ScrollToOptions}
+{boolean | ScrollIntoViewOptions}
+{keyof ElementEventMap}
+{(this: Element, ev: ElementEventMap[K]) => any}
+{{     prototype: Element;     new(): Element; }}
+{{     prototype: ErrorEvent;     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent; }}
+{EventTarget[]}
+{{     prototype: Event;     new(type: string, eventInitDict?: EventInit): Event;     readonly AT_TARGET: number;     readonly BUBBLING_PHASE: number;     readonly CAPTURING_PHASE: number;     readonly NONE: number; }}
+{((this: EventSource, ev: Event) => any) | null}
+{((this: EventSource, ev: MessageEvent) => any) | null}
+{keyof EventSourceEventMap}
+{(this: EventSource, ev: EventSourceEventMap[K]) => any}
+{{     prototype: EventSource;     new(url: string, eventSourceInitDict?: EventSourceInit): EventSource;     readonly CLOSED: number;     readonly CONNECTING: number;     readonly OPEN: number; }}
+{EventListenerOrEventListenerObject | null}
+{EventListenerOptions | boolean}
+{{     prototype: EventTarget;     new(): EventTarget; }}
+{{     prototype: ExtensionScriptApis;     new(): ExtensionScriptApis; }}
+{{     prototype: File;     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File; }}
+{{     prototype: FileList;     new(): FileList; }}
+{DOMException | null}
+{((this: FileReader, ev: ProgressEvent) => any) | null}
+{string | ArrayBuffer | null}
+{keyof FileReaderEventMap}
+{(this: FileReader, ev: FileReaderEventMap[K]) => any}
+{{     prototype: FileReader;     new(): FileReader;     readonly DONE: number;     readonly EMPTY: number;     readonly LOADING: number; }}
+{{     prototype: FocusEvent;     new(typeArg: string, eventInitDict?: FocusEventInit): FocusEvent; }}
+{NavigationReason}
+{{     prototype: FocusNavigationEvent;     new(type: string, eventInitDict?: FocusNavigationEventInit): FocusNavigationEvent; }}
+{string | Blob}
+{FormDataEntryValue | null}
+{FormDataEntryValue[]}
+{(value: FormDataEntryValue, key: string, parent: FormData) => void}
+{{     prototype: FormData;     new(form?: HTMLFormElement): FormData; }}
+{{     prototype: GainNode;     new(context: BaseAudioContext, options?: GainOptions): GainNode; }}
+{ReadonlyArray<number>}
+{ReadonlyArray<GamepadButton>}
+{GamepadHand}
+{ReadonlyArray<GamepadHapticActuator>}
+{GamepadMappingType}
+{GamepadPose | null}
+{{     prototype: Gamepad;     new(): Gamepad; }}
+{{     prototype: GamepadButton;     new(): GamepadButton; }}
+{{     prototype: GamepadEvent;     new(type: string, eventInitDict: GamepadEventInit): GamepadEvent; }}
+{GamepadHapticActuatorType}
+{{     prototype: GamepadHapticActuator;     new(): GamepadHapticActuator; }}
+{Float32Array | null}
+{{     prototype: GamepadPose;     new(): GamepadPose; }}
+{PositionCallback}
+{PositionErrorCallback}
+{PositionOptions}
+{((this: GlobalEventHandlers, ev: UIEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: AnimationEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: Event) => any) | null}
+{((this: GlobalEventHandlers, ev: FocusEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: MouseEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: DragEvent) => any) | null}
+{OnErrorEventHandler}
+{((this: GlobalEventHandlers, ev: PointerEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: KeyboardEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: ProgressEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: SecurityPolicyViolationEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: TouchEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: TransitionEvent) => any) | null}
+{((this: GlobalEventHandlers, ev: WheelEvent) => any) | null}
+{keyof GlobalEventHandlersEventMap}
+{(this: GlobalEventHandlers, ev: GlobalEventHandlersEventMap[K]) => any}
+{RequestInit}
+{Promise<Response>}
+{HTMLCollection | Element | null}
+{{     prototype: HTMLAllCollection;     new(): HTMLAllCollection; }}
+{HTMLHyperlinkElementUtils}
+{keyof HTMLElementEventMap}
+{(this: HTMLAnchorElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLAnchorElement;     new(): HTMLAnchorElement; }}
+{HTMLFormElement | null}
+{(this: HTMLAppletElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLAppletElement;     new(): HTMLAppletElement; }}
+{(this: HTMLAreaElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLAreaElement;     new(): HTMLAreaElement; }}
+{keyof HTMLMediaElementEventMap}
+{(this: HTMLAudioElement, ev: HTMLMediaElementEventMap[K]) => any}
+{{     prototype: HTMLAudioElement;     new(): HTMLAudioElement; }}
+{(this: HTMLBRElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLBRElement;     new(): HTMLBRElement; }}
+{(this: HTMLBaseElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLBaseElement;     new(): HTMLBaseElement; }}
+{DOML2DeprecatedColorProperty}
+{(this: HTMLBaseFontElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLBaseFontElement;     new(): HTMLBaseFontElement; }}
+{HTMLElementEventMap}
+{WindowEventHandlersEventMap}
+{WindowEventHandlers}
+{((this: HTMLBodyElement, ev: Event) => any) | null}
+{keyof HTMLBodyElementEventMap}
+{(this: HTMLBodyElement, ev: HTMLBodyElementEventMap[K]) => any}
+{{     prototype: HTMLBodyElement;     new(): HTMLBodyElement; }}
+{NodeListOf<HTMLLabelElement>}
+{ValidityState}
+{(this: HTMLButtonElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLButtonElement;     new(): HTMLButtonElement; }}
+{"2d"}
+{CanvasRenderingContext2DSettings}
+{CanvasRenderingContext2D | null}
+{"webgl" | "experimental-webgl"}
+{WebGLContextAttributes}
+{WebGLRenderingContext | null}
+{CanvasRenderingContext2D | WebGLRenderingContext | null}
+{BlobCallback}
+{(this: HTMLCanvasElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLCanvasElement;     new(): HTMLCanvasElement; }}
+{HTMLCollectionBase}
+{{     prototype: HTMLCollection;     new(): HTMLCollection; }}
+{T | null}
+{(this: HTMLDListElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDListElement;     new(): HTMLDListElement; }}
+{(this: HTMLDataElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDataElement;     new(): HTMLDataElement; }}
+{HTMLCollectionOf<HTMLOptionElement>}
+{(this: HTMLDataListElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDataListElement;     new(): HTMLDataListElement; }}
+{(this: HTMLDetailsElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDetailsElement;     new(): HTMLDetailsElement; }}
+{(this: HTMLDialogElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDialogElement;     new(): HTMLDialogElement; }}
+{(this: HTMLDirectoryElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDirectoryElement;     new(): HTMLDirectoryElement; }}
+{(this: HTMLDivElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLDivElement;     new(): HTMLDivElement; }}
+{(this: HTMLDocument, ev: DocumentEventMap[K]) => any}
+{{     prototype: HTMLDocument;     new(): HTMLDocument; }}
+{ElementEventMap}
+{ElementContentEditable}
+{HTMLOrSVGElement}
+{ElementCSSInlineStyle}
+{(this: HTMLElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLElement;     new(): HTMLElement; }}
+{Document | null}
+{(this: HTMLEmbedElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLEmbedElement;     new(): HTMLEmbedElement; }}
+{HTMLCollection}
+{(this: HTMLFieldSetElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLFieldSetElement;     new(): HTMLFieldSetElement; }}
+{(this: HTMLFontElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLFontElement;     new(): HTMLFontElement; }}
+{RadioNodeList | Element | null}
+{{     prototype: HTMLFormControlsCollection;     new(): HTMLFormControlsCollection; }}
+{HTMLFormControlsCollection}
+{(this: HTMLFormElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLFormElement;     new(): HTMLFormElement; }}
+{(this: HTMLFrameElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLFrameElement;     new(): HTMLFrameElement; }}
+{keyof HTMLFrameSetElementEventMap}
+{(this: HTMLFrameSetElement, ev: HTMLFrameSetElementEventMap[K]) => any}
+{{     prototype: HTMLFrameSetElement;     new(): HTMLFrameSetElement; }}
+{(this: HTMLHRElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLHRElement;     new(): HTMLHRElement; }}
+{(this: HTMLHeadElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLHeadElement;     new(): HTMLHeadElement; }}
+{(this: HTMLHeadingElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLHeadingElement;     new(): HTMLHeadingElement; }}
+{(this: HTMLHtmlElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLHtmlElement;     new(): HTMLHtmlElement; }}
+{(this: HTMLIFrameElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLIFrameElement;     new(): HTMLIFrameElement; }}
+{"async" | "sync" | "auto"}
+{(this: HTMLImageElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLImageElement;     new(): HTMLImageElement; }}
+{FileList | null}
+{NodeListOf<HTMLLabelElement> | null}
+{SelectionMode}
+{"forward" | "backward" | "none"}
+{(this: HTMLInputElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLInputElement;     new(): HTMLInputElement; }}
+{(this: HTMLLIElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLLIElement;     new(): HTMLLIElement; }}
+{(this: HTMLLabelElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLLabelElement;     new(): HTMLLabelElement; }}
+{(this: HTMLLegendElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLLegendElement;     new(): HTMLLegendElement; }}
+{LinkStyle}
+{(this: HTMLLinkElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLLinkElement;     new(): HTMLLinkElement; }}
+{(this: HTMLMainElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLMainElement;     new(): HTMLMainElement; }}
+{(this: HTMLMapElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLMapElement;     new(): HTMLMapElement; }}
+{((this: HTMLMarqueeElement, ev: Event) => any) | null}
+{keyof HTMLMarqueeElementEventMap}
+{(this: HTMLMarqueeElement, ev: HTMLMarqueeElementEventMap[K]) => any}
+{{     prototype: HTMLMarqueeElement;     new(): HTMLMarqueeElement; }}
+{AudioTrackList}
+{TimeRanges}
+{MediaError | null}
+{MediaKeys | null}
+{MSGraphicsTrust}
+{MSMediaKeys}
+{((this: HTMLMediaElement, ev: MediaEncryptedEvent) => any) | null}
+{((this: HTMLMediaElement, ev: Event) => any) | null}
+{MediaStream | MediaSource | Blob | null}
+{TextTrackList}
+{VideoTrackList}
+{TextTrackKind}
+{TextTrack}
+{CanPlayTypeResult}
+{(this: HTMLMediaElement, ev: HTMLMediaElementEventMap[K]) => any}
+{{     prototype: HTMLMediaElement;     new(): HTMLMediaElement;     readonly HAVE_CURRENT_DATA: number;     readonly HAVE_ENOUGH_DATA: number;     readonly HAVE_FUTURE_DATA: number;     readonly HAVE_METADATA: number;     readonly HAVE_NOTHING: number;     readonly NETWORK_EMPTY: number;     readonly NETWORK_IDLE: number;     readonly NETWORK_LOADING: number;     readonly NETWORK_NO_SOURCE: number; }}
+{(this: HTMLMenuElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLMenuElement;     new(): HTMLMenuElement; }}
+{(this: HTMLMetaElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLMetaElement;     new(): HTMLMetaElement; }}
+{(this: HTMLMeterElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLMeterElement;     new(): HTMLMeterElement; }}
+{(this: HTMLModElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLModElement;     new(): HTMLModElement; }}
+{(this: HTMLOListElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLOListElement;     new(): HTMLOListElement; }}
+{(this: HTMLObjectElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLObjectElement;     new(): HTMLObjectElement; }}
+{(this: HTMLOptGroupElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLOptGroupElement;     new(): HTMLOptGroupElement; }}
+{(this: HTMLOptionElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLOptionElement;     new(): HTMLOptionElement; }}
+{HTMLOptionElement | HTMLOptGroupElement}
+{HTMLElement | number | null}
+{{     prototype: HTMLOptionsCollection;     new(): HTMLOptionsCollection; }}
+{DOMStringMap}
+{FocusOptions}
+{(this: HTMLOutputElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLOutputElement;     new(): HTMLOutputElement; }}
+{(this: HTMLParagraphElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLParagraphElement;     new(): HTMLParagraphElement; }}
+{(this: HTMLParamElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLParamElement;     new(): HTMLParamElement; }}
+{(this: HTMLPictureElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLPictureElement;     new(): HTMLPictureElement; }}
+{(this: HTMLPreElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLPreElement;     new(): HTMLPreElement; }}
+{(this: HTMLProgressElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLProgressElement;     new(): HTMLProgressElement; }}
+{(this: HTMLQuoteElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLQuoteElement;     new(): HTMLQuoteElement; }}
+{(this: HTMLScriptElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLScriptElement;     new(): HTMLScriptElement; }}
+{HTMLOptionsCollection}
+{HTMLOptionElement | null}
+{(this: HTMLSelectElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLSelectElement;     new(): HTMLSelectElement; }}
+{AssignedNodesOptions}
+{Node[]}
+{(this: HTMLSlotElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLSlotElement;     new(): HTMLSlotElement; }}
+{(this: HTMLSourceElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLSourceElement;     new(): HTMLSourceElement; }}
+{(this: HTMLSpanElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLSpanElement;     new(): HTMLSpanElement; }}
+{(this: HTMLStyleElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLStyleElement;     new(): HTMLStyleElement; }}
+{(this: HTMLTableCaptionElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableCaptionElement;     new(): HTMLTableCaptionElement; }}
+{(this: HTMLTableCellElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableCellElement;     new(): HTMLTableCellElement; }}
+{(this: HTMLTableColElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableColElement;     new(): HTMLTableColElement; }}
+{HTMLTableCellElement}
+{(this: HTMLTableDataCellElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableDataCellElement;     new(): HTMLTableDataCellElement; }}
+{HTMLTableCaptionElement | null}
+{HTMLCollectionOf<HTMLTableRowElement>}
+{HTMLCollectionOf<HTMLTableSectionElement>}
+{HTMLTableSectionElement | null}
+{HTMLTableCaptionElement}
+{HTMLTableSectionElement}
+{HTMLTableRowElement}
+{(this: HTMLTableElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableElement;     new(): HTMLTableElement; }}
+{(this: HTMLTableHeaderCellElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableHeaderCellElement;     new(): HTMLTableHeaderCellElement; }}
+{HTMLCollectionOf<HTMLTableDataCellElement | HTMLTableHeaderCellElement>}
+{HTMLTableDataCellElement}
+{(this: HTMLTableRowElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableRowElement;     new(): HTMLTableRowElement; }}
+{(this: HTMLTableSectionElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTableSectionElement;     new(): HTMLTableSectionElement; }}
+{(this: HTMLTemplateElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTemplateElement;     new(): HTMLTemplateElement; }}
+{(this: HTMLTextAreaElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTextAreaElement;     new(): HTMLTextAreaElement; }}
+{(this: HTMLTimeElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTimeElement;     new(): HTMLTimeElement; }}
+{(this: HTMLTitleElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTitleElement;     new(): HTMLTitleElement; }}
+{(this: HTMLTrackElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLTrackElement;     new(): HTMLTrackElement;     readonly ERROR: number;     readonly LOADED: number;     readonly LOADING: number;     readonly NONE: number; }}
+{(this: HTMLUListElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLUListElement;     new(): HTMLUListElement; }}
+{(this: HTMLUnknownElement, ev: HTMLElementEventMap[K]) => any}
+{{     prototype: HTMLUnknownElement;     new(): HTMLUnknownElement; }}
+{HTMLMediaElementEventMap}
+{((this: HTMLVideoElement, ev: Event) => any) | null}
+{VideoPlaybackQuality}
+{keyof HTMLVideoElementEventMap}
+{(this: HTMLVideoElement, ev: HTMLVideoElementEventMap[K]) => any}
+{{     prototype: HTMLVideoElement;     new(): HTMLVideoElement; }}
+{{     prototype: HashChangeEvent;     new(type: string, eventInitDict?: HashChangeEventInit): HashChangeEvent; }}
+{(value: string, key: string, parent: Headers) => void}
+{{     prototype: Headers;     new(init?: HeadersInit): Headers; }}
+{ScrollRestoration}
+{{     prototype: History;     new(): History; }}
+{Array<IDBValidKey>}
+{IDBCursorDirection}
+{IDBValidKey}
+{IDBObjectStore | IDBIndex}
+{IDBRequest<undefined>}
+{IDBRequest<IDBValidKey>}
+{{     prototype: IDBCursor;     new(): IDBCursor; }}
+{IDBCursor}
+{{     prototype: IDBCursorWithValue;     new(): IDBCursorWithValue; }}
+{DOMStringList}
+{((this: IDBDatabase, ev: Event) => any) | null}
+{((this: IDBDatabase, ev: IDBVersionChangeEvent) => any) | null}
+{IDBObjectStoreParameters}
+{IDBObjectStore}
+{IDBTransactionMode}
+{IDBTransaction}
+{keyof IDBDatabaseEventMap}
+{(this: IDBDatabase, ev: IDBDatabaseEventMap[K]) => any}
+{{     prototype: IDBDatabase;     new(): IDBDatabase; }}
+{IDBFactory}
+{IDBOpenDBRequest}
+{{     prototype: IDBFactory;     new(): IDBFactory; }}
+{IDBValidKey | IDBKeyRange}
+{IDBRequest<number>}
+{IDBRequest<any | undefined>}
+{IDBRequest<any[]>}
+{IDBRequest<IDBValidKey[]>}
+{IDBRequest<IDBValidKey | undefined>}
+{IDBRequest<IDBCursorWithValue | null>}
+{IDBRequest<IDBCursor | null>}
+{{     prototype: IDBIndex;     new(): IDBIndex; }}
+{{     prototype: IDBKeyRange;     new(): IDBKeyRange;     /**      * Returns a new IDBKeyRange spanning from lower to upper.      * If lowerOpen is true, lower is not included in the range.      * If upperOpen is true, upper is not included in the range.      */     bound(lower: any, upper: any, lowerOpen?: boolean, upperOpen?: boolean): IDBKeyRange;     /**      * Returns a new IDBKeyRange starting at key with no      * upper bound. If open is true, key is not included in the      * range.      */     lowerBound(lower: any, open?: boolean): IDBKeyRange;     /**      * Returns a new IDBKeyRange spanning only key.      */     only(value: any): IDBKeyRange;     /**      * Returns a new IDBKeyRange with no lower bound and ending at key. If open is true, key is not included in the range.      */     upperBound(upper: any, open?: boolean): IDBKeyRange; }}
+{IDBIndexParameters}
+{IDBIndex}
+{{     prototype: IDBObjectStore;     new(): IDBObjectStore; }}
+{IDBRequestEventMap}
+{IDBRequest<IDBDatabase>}
+{((this: IDBOpenDBRequest, ev: Event) => any) | null}
+{((this: IDBOpenDBRequest, ev: IDBVersionChangeEvent) => any) | null}
+{keyof IDBOpenDBRequestEventMap}
+{(this: IDBOpenDBRequest, ev: IDBOpenDBRequestEventMap[K]) => any}
+{{     prototype: IDBOpenDBRequest;     new(): IDBOpenDBRequest; }}
+{((this: IDBRequest<T>, ev: Event) => any) | null}
+{IDBRequestReadyState}
+{IDBObjectStore | IDBIndex | IDBCursor}
+{IDBTransaction | null}
+{keyof IDBRequestEventMap}
+{(this: IDBRequest<T>, ev: IDBRequestEventMap[K]) => any}
+{{     prototype: IDBRequest;     new(): IDBRequest; }}
+{IDBDatabase}
+{((this: IDBTransaction, ev: Event) => any) | null}
+{keyof IDBTransactionEventMap}
+{(this: IDBTransaction, ev: IDBTransactionEventMap[K]) => any}
+{{     prototype: IDBTransaction;     new(): IDBTransaction; }}
+{{     prototype: IDBVersionChangeEvent;     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent; }}
+{{     prototype: IIRFilterNode;     new(context: BaseAudioContext, options: IIRFilterOptions): IIRFilterNode; }}
+{{     prototype: ImageBitmap;     new(): ImageBitmap; }}
+{"none" | "default"}
+{"none" | "flipY"}
+{"none" | "premultiply" | "default"}
+{"pixelated" | "low" | "medium" | "high"}
+{ImageBitmap | null}
+{{     prototype: ImageBitmapRenderingContext;     new(): ImageBitmapRenderingContext; }}
+{{     prototype: ImageData;     new(width: number, height: number): ImageData;     new(array: Uint8ClampedArray, width: number, height: number): ImageData; }}
+{IntersectionObserverEntry[]}
+{{     prototype: IntersectionObserver;     new(callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver; }}
+{{     prototype: IntersectionObserverEntry;     new(intersectionObserverEntryInit: IntersectionObserverEntryInit): IntersectionObserverEntry; }}
+{{     prototype: KeyboardEvent;     new(typeArg: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;     readonly DOM_KEY_LOCATION_JOYSTICK: number;     readonly DOM_KEY_LOCATION_LEFT: number;     readonly DOM_KEY_LOCATION_MOBILE: number;     readonly DOM_KEY_LOCATION_NUMPAD: number;     readonly DOM_KEY_LOCATION_RIGHT: number;     readonly DOM_KEY_LOCATION_STANDARD: number; }}
+{AnimationEffect}
+{ComputedKeyframe[]}
+{{     prototype: KeyframeEffect;     new(target: Element | null, keyframes: Keyframe[] | PropertyIndexedKeyframes | null, options?: number | KeyframeEffectOptions): KeyframeEffect;     new(source: KeyframeEffect): KeyframeEffect; }}
+{StyleSheet | null}
+{ListeningState}
+{{     prototype: ListeningStateChangedEvent;     new(): ListeningStateChangedEvent; }}
+{{     prototype: Location;     new(): Location; }}
+{MSCredentialType}
+{{     prototype: MSAssertion;     new(): MSAssertion; }}
+{{     prototype: MSBlobBuilder;     new(): MSBlobBuilder; }}
+{MSAssertion}
+{MSTransportType[]}
+{{     prototype: MSFIDOCredentialAssertion;     new(): MSFIDOCredentialAssertion; }}
+{{     prototype: MSFIDOSignature;     new(): MSFIDOSignature; }}
+{MSFIDOSignature}
+{{     prototype: MSFIDOSignatureAssertion;     new(): MSFIDOSignatureAssertion; }}
+{{     prototype: MSGesture;     new(): MSGesture; }}
+{{     prototype: MSGestureEvent;     new(): MSGestureEvent;     readonly MSGESTURE_FLAG_BEGIN: number;     readonly MSGESTURE_FLAG_CANCEL: number;     readonly MSGESTURE_FLAG_END: number;     readonly MSGESTURE_FLAG_INERTIA: number;     readonly MSGESTURE_FLAG_NONE: number; }}
+{{     prototype: MSGraphicsTrust;     new(): MSGraphicsTrust; }}
+{((this: MSInputMethodContext, ev: Event) => any) | null}
+{keyof MSInputMethodContextEventMap}
+{(this: MSInputMethodContext, ev: MSInputMethodContextEventMap[K]) => any}
+{{     prototype: MSInputMethodContext;     new(): MSInputMethodContext; }}
+{{     prototype: MSMediaKeyError;     new(): MSMediaKeyError;     readonly MS_MEDIA_KEYERR_CLIENT: number;     readonly MS_MEDIA_KEYERR_DOMAIN: number;     readonly MS_MEDIA_KEYERR_HARDWARECHANGE: number;     readonly MS_MEDIA_KEYERR_OUTPUT: number;     readonly MS_MEDIA_KEYERR_SERVICE: number;     readonly MS_MEDIA_KEYERR_UNKNOWN: number; }}
+{{     prototype: MSMediaKeyMessageEvent;     new(): MSMediaKeyMessageEvent; }}
+{Uint8Array | null}
+{{     prototype: MSMediaKeyNeededEvent;     new(): MSMediaKeyNeededEvent; }}
+{MSMediaKeyError | null}
+{{     prototype: MSMediaKeySession;     new(): MSMediaKeySession; }}
+{MSMediaKeySession}
+{{     prototype: MSMediaKeys;     new(keySystem: string): MSMediaKeys;     isTypeSupported(keySystem: string, type?: string | null): boolean;     isTypeSupportedWithFeatures(keySystem: string, type?: string | null): string; }}
+{ConfirmSiteSpecificExceptionsInformation}
+{StoreSiteSpecificExceptionsInformation}
+{{     prototype: MSPointerEvent;     new(typeArg: string, eventInitDict?: PointerEventInit): MSPointerEvent; }}
+{{     prototype: MSStream;     new(): MSStream; }}
+{MediaDeviceKind}
+{{     prototype: MediaDeviceInfo;     new(): MediaDeviceInfo; }}
+{((this: MediaDevices, ev: Event) => any) | null}
+{Promise<MediaDeviceInfo[]>}
+{MediaTrackSupportedConstraints}
+{MediaStreamConstraints}
+{Promise<MediaStream>}
+{keyof MediaDevicesEventMap}
+{(this: MediaDevices, ev: MediaDevicesEventMap[K]) => any}
+{{     prototype: MediaDevices;     new(): MediaDevices; }}
+{{     prototype: MediaElementAudioSourceNode;     new(context: AudioContext, options: MediaElementAudioSourceOptions): MediaElementAudioSourceNode; }}
+{{     prototype: MediaEncryptedEvent;     new(type: string, eventInitDict?: MediaEncryptedEventInit): MediaEncryptedEvent; }}
+{{     prototype: MediaError;     new(): MediaError;     readonly MEDIA_ERR_ABORTED: number;     readonly MEDIA_ERR_DECODE: number;     readonly MEDIA_ERR_NETWORK: number;     readonly MEDIA_ERR_SRC_NOT_SUPPORTED: number;     readonly MS_MEDIA_ERR_ENCRYPTED: number; }}
+{{     prototype: MediaKeyMessageEvent;     new(type: string, eventInitDict: MediaKeyMessageEventInit): MediaKeyMessageEvent; }}
+{MediaKeyStatusMap}
+{((this: MediaKeySession, ev: Event) => any) | null}
+{((this: MediaKeySession, ev: MessageEvent) => any) | null}
+{BufferSource}
+{keyof MediaKeySessionEventMap}
+{(this: MediaKeySession, ev: MediaKeySessionEventMap[K]) => any}
+{{     prototype: MediaKeySession;     new(): MediaKeySession; }}
+{(value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) => void}
+{{     prototype: MediaKeyStatusMap;     new(): MediaKeyStatusMap; }}
+{Promise<MediaKeys>}
+{MediaKeySystemConfiguration}
+{{     prototype: MediaKeySystemAccess;     new(): MediaKeySystemAccess; }}
+{MediaKeySessionType}
+{MediaKeySession}
+{{     prototype: MediaKeys;     new(): MediaKeys; }}
+{{     prototype: MediaList;     new(): MediaList; }}
+{((this: MediaQueryList, ev: MediaQueryListEvent) => any) | null}
+{keyof MediaQueryListEventMap}
+{(this: MediaQueryList, ev: MediaQueryListEventMap[K]) => any}
+{{     prototype: MediaQueryList;     new(): MediaQueryList; }}
+{{     prototype: MediaQueryListEvent;     new(type: string, eventInitDict?: MediaQueryListEventInit): MediaQueryListEvent; }}
+{SourceBufferList}
+{((this: MediaSource, ev: Event) => any) | null}
+{ReadyState}
+{SourceBuffer}
+{EndOfStreamError}
+{keyof MediaSourceEventMap}
+{(this: MediaSource, ev: MediaSourceEventMap[K]) => any}
+{{     prototype: MediaSource;     new(): MediaSource;     isTypeSupported(type: string): boolean; }}
+{((this: MediaStream, ev: Event) => any) | null}
+{((this: MediaStream, ev: MediaStreamTrackEvent) => any) | null}
+{MediaStreamTrack[]}
+{keyof MediaStreamEventMap}
+{(this: MediaStream, ev: MediaStreamEventMap[K]) => any}
+{{     prototype: MediaStream;     new(): MediaStream;     new(stream: MediaStream): MediaStream;     new(tracks: MediaStreamTrack[]): MediaStream; }}
+{{     prototype: MediaStreamAudioDestinationNode;     new(context: AudioContext, options?: AudioNodeOptions): MediaStreamAudioDestinationNode; }}
+{{     prototype: MediaStreamAudioSourceNode;     new(context: AudioContext, options: MediaStreamAudioSourceOptions): MediaStreamAudioSourceNode; }}
+{{     prototype: MediaStreamError;     new(): MediaStreamError; }}
+{{     prototype: MediaStreamErrorEvent;     new(typeArg: string, eventInitDict?: MediaStreamErrorEventInit): MediaStreamErrorEvent; }}
+{MediaStream | null}
+{{     prototype: MediaStreamEvent;     new(type: string, eventInitDict: MediaStreamEventInit): MediaStreamEvent; }}
+{((this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any) | null}
+{((this: MediaStreamTrack, ev: Event) => any) | null}
+{MediaStreamTrackState}
+{MediaTrackConstraints}
+{MediaTrackCapabilities}
+{MediaTrackSettings}
+{keyof MediaStreamTrackEventMap}
+{(this: MediaStreamTrack, ev: MediaStreamTrackEventMap[K]) => any}
+{{     prototype: MediaStreamTrack;     new(): MediaStreamTrack; }}
+{{     prototype: MediaStreamTrackAudioSourceNode;     new(context: AudioContext, options: MediaStreamTrackAudioSourceOptions): MediaStreamTrackAudioSourceNode; }}
+{{     prototype: MediaStreamTrackEvent;     new(typeArg: string, eventInitDict?: MediaStreamTrackEventInit): MediaStreamTrackEvent; }}
+{{     prototype: MessageChannel;     new(): MessageChannel; }}
+{ReadonlyArray<MessagePort>}
+{{     prototype: MessageEvent;     new(type: string, eventInitDict?: MessageEventInit): MessageEvent; }}
+{((this: MessagePort, ev: MessageEvent) => any) | null}
+{Transferable[]}
+{keyof MessagePortEventMap}
+{(this: MessagePort, ev: MessagePortEventMap[K]) => any}
+{{     prototype: MessagePort;     new(): MessagePort; }}
+{Plugin}
+{{     prototype: MimeType;     new(): MimeType; }}
+{{     prototype: MimeTypeArray;     new(): MimeTypeArray; }}
+{{     prototype: MouseEvent;     new(typeArg: string, eventInitDict?: MouseEventInit): MouseEvent; }}
+{{     prototype: MutationEvent;     new(): MutationEvent;     readonly ADDITION: number;     readonly MODIFICATION: number;     readonly REMOVAL: number; }}
+{MutationObserverInit}
+{MutationRecord[]}
+{{     prototype: MutationObserver;     new(callback: MutationCallback): MutationObserver; }}
+{NodeList}
+{Node | null}
+{MutationRecordType}
+{{     prototype: MutationRecord;     new(): MutationRecord; }}
+{{     prototype: NamedNodeMap;     new(): NamedNodeMap; }}
+{Promise<NavigationPreloadState>}
+{{     prototype: NavigationPreloadManager;     new(): NavigationPreloadManager; }}
+{NavigatorID}
+{NavigatorOnLine}
+{NavigatorContentUtils}
+{NavigatorStorageUtils}
+{MSNavigatorDoNotTrack}
+{MSFileSaver}
+{NavigatorBeacon}
+{NavigatorConcurrentHardware}
+{NavigatorUserMedia}
+{NavigatorLanguage}
+{NavigatorStorage}
+{NavigatorAutomationInformation}
+{ReadonlyArray<VRDisplay>}
+{WebAuthentication}
+{Clipboard}
+{GamepadInputEmulationType}
+{Geolocation}
+{MimeTypeArray}
+{PluginArray}
+{ServiceWorkerContainer}
+{(Gamepad | null)[]}
+{Promise<VRDisplay[]>}
+{MSLaunchUriCallback}
+{MediaKeySystemConfiguration[]}
+{Promise<MediaKeySystemAccess>}
+{{     prototype: Navigator;     new(): Navigator; }}
+{Blob | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | FormData | string | null}
+{StorageManager}
+{MediaDevices}
+{NavigatorUserMediaSuccessCallback}
+{NavigatorUserMediaErrorCallback}
+{NodeListOf<ChildNode>}
+{ChildNode | null}
+{Node & ParentNode | null}
+{GetRootNodeOptions}
+{{     prototype: Node;     new(): Node;     readonly ATTRIBUTE_NODE: number;     readonly CDATA_SECTION_NODE: number;     readonly COMMENT_NODE: number;     readonly DOCUMENT_FRAGMENT_NODE: number;     readonly DOCUMENT_NODE: number;     readonly DOCUMENT_POSITION_CONTAINED_BY: number;     readonly DOCUMENT_POSITION_CONTAINS: number;     readonly DOCUMENT_POSITION_DISCONNECTED: number;     readonly DOCUMENT_POSITION_FOLLOWING: number;     readonly DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number;     readonly DOCUMENT_POSITION_PRECEDING: number;     readonly DOCUMENT_TYPE_NODE: number;     readonly ELEMENT_NODE: number;     readonly ENTITY_NODE: number;     readonly ENTITY_REFERENCE_NODE: number;     readonly NOTATION_NODE: number;     readonly PROCESSING_INSTRUCTION_NODE: number;     readonly TEXT_NODE: number; }}
+{{     readonly FILTER_ACCEPT: number;     readonly FILTER_REJECT: number;     readonly FILTER_SKIP: number;     readonly SHOW_ALL: number;     readonly SHOW_ATTRIBUTE: number;     readonly SHOW_CDATA_SECTION: number;     readonly SHOW_COMMENT: number;     readonly SHOW_DOCUMENT: number;     readonly SHOW_DOCUMENT_FRAGMENT: number;     readonly SHOW_DOCUMENT_TYPE: number;     readonly SHOW_ELEMENT: number;     readonly SHOW_ENTITY: number;     readonly SHOW_ENTITY_REFERENCE: number;     readonly SHOW_NOTATION: number;     readonly SHOW_PROCESSING_INSTRUCTION: number;     readonly SHOW_TEXT: number; }}
+{{     prototype: NodeIterator;     new(): NodeIterator; }}
+{(value: Node, key: number, parent: NodeList) => void}
+{{     prototype: NodeList;     new(): NodeList; }}
+{TNode}
+{(value: TNode, key: number, parent: NodeListOf<TNode>) => void}
+{E | null}
+{NodeListOf<HTMLElementTagNameMap[K]>}
+{NodeListOf<SVGElementTagNameMap[K]>}
+{NodeListOf<E>}
+{ReadonlyArray<NotificationAction>}
+{((this: Notification, ev: Event) => any) | null}
+{keyof NotificationEventMap}
+{(this: Notification, ev: NotificationEventMap[K]) => any}
+{{     prototype: Notification;     new(title: string, options?: NotificationOptions): Notification;     readonly maxActions: number;     readonly permission: NotificationPermission;     requestPermission(deprecatedCallback?: NotificationPermissionCallback): Promise<NotificationPermission>; }}
+{WebGLVertexArrayObjectOES | null}
+{{     prototype: OfflineAudioCompletionEvent;     new(type: string, eventInitDict: OfflineAudioCompletionEventInit): OfflineAudioCompletionEvent; }}
+{BaseAudioContextEventMap}
+{((this: OfflineAudioContext, ev: OfflineAudioCompletionEvent) => any) | null}
+{keyof OfflineAudioContextEventMap}
+{(this: OfflineAudioContext, ev: OfflineAudioContextEventMap[K]) => any}
+{{     prototype: OfflineAudioContext;     new(contextOptions: OfflineAudioContextOptions): OfflineAudioContext;     new(numberOfChannels: number, length: number, sampleRate: number): OfflineAudioContext; }}
+{(this: OscillatorNode, ev: AudioScheduledSourceNodeEventMap[K]) => any}
+{{     prototype: OscillatorNode;     new(context: BaseAudioContext, options?: OscillatorOptions): OscillatorNode; }}
+{{     prototype: OverflowEvent;     new(): OverflowEvent;     readonly BOTH: number;     readonly HORIZONTAL: number;     readonly VERTICAL: number; }}
+{{     prototype: PageTransitionEvent;     new(): PageTransitionEvent; }}
+{{     prototype: PannerNode;     new(context: BaseAudioContext, options?: PannerOptions): PannerNode; }}
+{{     prototype: Path2D;     new(path?: Path2D | string): Path2D; }}
+{{     prototype: PaymentAddress;     new(): PaymentAddress; }}
+{((this: PaymentRequest, ev: Event) => any) | null}
+{PaymentAddress | null}
+{PaymentShippingType | null}
+{Promise<PaymentResponse>}
+{keyof PaymentRequestEventMap}
+{(this: PaymentRequest, ev: PaymentRequestEventMap[K]) => any}
+{{     prototype: PaymentRequest;     new(methodData: PaymentMethodData[], details: PaymentDetailsInit, options?: PaymentOptions): PaymentRequest; }}
+{PaymentDetailsUpdate | Promise<PaymentDetailsUpdate>}
+{{     prototype: PaymentRequestUpdateEvent;     new(type: string, eventInitDict?: PaymentRequestUpdateEventInit): PaymentRequestUpdateEvent; }}
+{PaymentComplete}
+{{     prototype: PaymentResponse;     new(): PaymentResponse; }}
+{{     prototype: PerfWidgetExternal;     new(): PerfWidgetExternal; }}
+{PerformanceNavigation}
+{((this: Performance, ev: Event) => any) | null}
+{PerformanceTiming}
+{PerformanceEntryList}
+{keyof PerformanceEventMap}
+{(this: Performance, ev: PerformanceEventMap[K]) => any}
+{{     prototype: Performance;     new(): Performance; }}
+{{     prototype: PerformanceEntry;     new(): PerformanceEntry; }}
+{PerformanceEntry}
+{{     prototype: PerformanceMark;     new(): PerformanceMark; }}
+{{     prototype: PerformanceMeasure;     new(): PerformanceMeasure; }}
+{{     prototype: PerformanceNavigation;     new(): PerformanceNavigation;     readonly TYPE_BACK_FORWARD: number;     readonly TYPE_NAVIGATE: number;     readonly TYPE_RELOAD: number;     readonly TYPE_RESERVED: number; }}
+{PerformanceResourceTiming}
+{NavigationType}
+{{     prototype: PerformanceNavigationTiming;     new(): PerformanceNavigationTiming; }}
+{PerformanceObserverInit}
+{{     prototype: PerformanceObserver;     new(callback: PerformanceObserverCallback): PerformanceObserver; }}
+{{     prototype: PerformanceObserverEntryList;     new(): PerformanceObserverEntryList; }}
+{{     prototype: PerformanceResourceTiming;     new(): PerformanceResourceTiming; }}
+{{     prototype: PerformanceTiming;     new(): PerformanceTiming; }}
+{{     prototype: PeriodicWave;     new(context: BaseAudioContext, options?: PeriodicWaveOptions): PeriodicWave; }}
+{DeferredPermissionRequest}
+{MSWebViewPermissionState}
+{{     prototype: PermissionRequest;     new(): PermissionRequest; }}
+{PermissionRequest}
+{{     prototype: PermissionRequestedEvent;     new(): PermissionRequestedEvent; }}
+{MimeType}
+{{     prototype: Plugin;     new(): Plugin; }}
+{{     prototype: PluginArray;     new(): PluginArray; }}
+{{     prototype: PointerEvent;     new(type: string, eventInitDict?: PointerEventInit): PointerEvent; }}
+{{     prototype: PopStateEvent;     new(type: string, eventInitDict?: PopStateEventInit): PopStateEvent; }}
+{Coordinates}
+{{     prototype: ProcessingInstruction;     new(): ProcessingInstruction; }}
+{{     prototype: ProgressEvent;     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent; }}
+{{     prototype: PromiseRejectionEvent;     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent; }}
+{Promise<PushSubscription | null>}
+{PushSubscriptionOptionsInit}
+{Promise<PushPermissionState>}
+{Promise<PushSubscription>}
+{{     prototype: PushManager;     new(): PushManager;     readonly supportedContentEncodings: ReadonlyArray<string>; }}
+{PushSubscriptionOptions}
+{PushEncryptionKeyName}
+{PushSubscriptionJSON}
+{{     prototype: PushSubscription;     new(): PushSubscription; }}
+{{     prototype: PushSubscriptionOptions;     new(): PushSubscriptionOptions; }}
+{{     prototype: RTCCertificate;     new(): RTCCertificate;     getSupportedAlgorithms(): AlgorithmIdentifier[]; }}
+{((this: RTCDTMFSender, ev: RTCDTMFToneChangeEvent) => any) | null}
+{keyof RTCDTMFSenderEventMap}
+{(this: RTCDTMFSender, ev: RTCDTMFSenderEventMap[K]) => any}
+{{     prototype: RTCDTMFSender;     new(): RTCDTMFSender; }}
+{{     prototype: RTCDTMFToneChangeEvent;     new(type: string, eventInitDict: RTCDTMFToneChangeEventInit): RTCDTMFToneChangeEvent; }}
+{((this: RTCDataChannel, ev: Event) => any) | null}
+{((this: RTCDataChannel, ev: RTCErrorEvent) => any) | null}
+{((this: RTCDataChannel, ev: MessageEvent) => any) | null}
+{RTCDataChannelState}
+{keyof RTCDataChannelEventMap}
+{(this: RTCDataChannel, ev: RTCDataChannelEventMap[K]) => any}
+{{     prototype: RTCDataChannel;     new(): RTCDataChannel; }}
+{{     prototype: RTCDataChannelEvent;     new(type: string, eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent; }}
+{((this: RTCDtlsTransport, ev: RTCErrorEvent) => any) | null}
+{((this: RTCDtlsTransport, ev: Event) => any) | null}
+{RTCDtlsTransportState}
+{RTCIceTransport}
+{ArrayBuffer[]}
+{keyof RTCDtlsTransportEventMap}
+{(this: RTCDtlsTransport, ev: RTCDtlsTransportEventMap[K]) => any}
+{{     prototype: RTCDtlsTransport;     new(): RTCDtlsTransport; }}
+{{     prototype: RTCDtlsTransportStateChangedEvent;     new(): RTCDtlsTransportStateChangedEvent; }}
+{((this: RTCDtmfSender, ev: RTCDTMFToneChangeEvent) => any) | null}
+{RTCRtpSender}
+{keyof RTCDtmfSenderEventMap}
+{(this: RTCDtmfSender, ev: RTCDtmfSenderEventMap[K]) => any}
+{{     prototype: RTCDtmfSender;     new(sender: RTCRtpSender): RTCDtmfSender; }}
+{{     prototype: RTCError;     new(errorDetail?: string, message?: string): RTCError; }}
+{{     prototype: RTCErrorEvent;     new(type: string, eventInitDict: RTCErrorEventInit): RTCErrorEvent; }}
+{RTCIceComponent | null}
+{RTCIceProtocol | null}
+{RTCIceTcpCandidateType | null}
+{RTCIceCandidateType | null}
+{RTCIceCandidateInit}
+{{     prototype: RTCIceCandidate;     new(candidateInitDict?: RTCIceCandidateInit): RTCIceCandidate; }}
+{RTCIceCandidatePair}
+{{     prototype: RTCIceCandidatePairChangedEvent;     new(): RTCIceCandidatePairChangedEvent; }}
+{RTCStatsProvider}
+{RTCIceComponent}
+{((this: RTCIceGatherer, ev: Event) => any) | null}
+{((this: RTCIceGatherer, ev: RTCIceGathererEvent) => any) | null}
+{RTCIceGatherer}
+{RTCIceCandidateDictionary[]}
+{RTCIceParameters}
+{keyof RTCIceGathererEventMap}
+{(this: RTCIceGatherer, ev: RTCIceGathererEventMap[K]) => any}
+{{     prototype: RTCIceGatherer;     new(options: RTCIceGatherOptions): RTCIceGatherer; }}
+{RTCIceCandidateDictionary | RTCIceCandidateComplete}
+{{     prototype: RTCIceGathererEvent;     new(): RTCIceGathererEvent; }}
+{RTCIceGathererState}
+{((this: RTCIceTransport, ev: Event) => any) | null}
+{RTCIceRole}
+{RTCIceTransportState}
+{RTCIceCandidate[]}
+{RTCIceParameters | null}
+{RTCIceCandidatePair | null}
+{keyof RTCIceTransportEventMap}
+{(this: RTCIceTransport, ev: RTCIceTransportEventMap[K]) => any}
+{{     prototype: RTCIceTransport;     new(): RTCIceTransport; }}
+{{     prototype: RTCIceTransportStateChangedEvent;     new(): RTCIceTransportStateChangedEvent; }}
+{{     prototype: RTCIdentityAssertion;     new(idp: string, name: string): RTCIdentityAssertion; }}
+{boolean | null}
+{RTCPeerConnectionState}
+{RTCSessionDescription | null}
+{RTCIceConnectionState}
+{RTCIceGatheringState}
+{((this: RTCPeerConnection, ev: Event) => any) | null}
+{((this: RTCPeerConnection, ev: RTCDataChannelEvent) => any) | null}
+{((this: RTCPeerConnection, ev: RTCPeerConnectionIceEvent) => any) | null}
+{((this: RTCPeerConnection, ev: RTCPeerConnectionIceErrorEvent) => any) | null}
+{((this: RTCPeerConnection, ev: RTCStatsEvent) => any) | null}
+{((this: RTCPeerConnection, ev: RTCTrackEvent) => any) | null}
+{Promise<RTCIdentityAssertion>}
+{RTCSctpTransport | null}
+{RTCSignalingState}
+{RTCIceCandidateInit | RTCIceCandidate}
+{MediaStreamTrack | string}
+{RTCRtpTransceiverInit}
+{RTCOfferOptions}
+{Promise<RTCSessionDescriptionInit>}
+{RTCDataChannelInit}
+{RTCConfiguration}
+{RTCRtpReceiver[]}
+{RTCRtpSender[]}
+{Promise<RTCStatsReport>}
+{RTCRtpTransceiver[]}
+{RTCIdentityProviderOptions}
+{RTCSessionDescriptionInit}
+{keyof RTCPeerConnectionEventMap}
+{(this: RTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => any}
+{{     prototype: RTCPeerConnection;     new(configuration?: RTCConfiguration): RTCPeerConnection;     generateCertificate(keygenAlgorithm: AlgorithmIdentifier): Promise<RTCCertificate>;     getDefaultIceServers(): RTCIceServer[]; }}
+{{     prototype: RTCPeerConnectionIceErrorEvent;     new(type: string, eventInitDict: RTCPeerConnectionIceErrorEventInit): RTCPeerConnectionIceErrorEvent; }}
+{{     prototype: RTCPeerConnectionIceEvent;     new(type: string, eventInitDict?: RTCPeerConnectionIceEventInit): RTCPeerConnectionIceEvent; }}
+{RTCDtlsTransport | null}
+{RTCRtpContributingSource[]}
+{RTCRtpReceiveParameters}
+{RTCRtpSynchronizationSource[]}
+{{     prototype: RTCRtpReceiver;     new(): RTCRtpReceiver;     getCapabilities(kind: string): RTCRtpCapabilities | null; }}
+{RTCDTMFSender | null}
+{RTCRtpSendParameters}
+{{     prototype: RTCRtpSender;     new(): RTCRtpSender;     getCapabilities(kind: string): RTCRtpCapabilities | null; }}
+{RTCRtpTransceiverDirection | null}
+{{     prototype: RTCRtpTransceiver;     new(): RTCRtpTransceiver; }}
+{((this: RTCSctpTransport, ev: Event) => any) | null}
+{RTCSctpTransportState}
+{RTCDtlsTransport}
+{keyof RTCSctpTransportEventMap}
+{(this: RTCSctpTransport, ev: RTCSctpTransportEventMap[K]) => any}
+{{     prototype: RTCSctpTransport;     new(): RTCSctpTransport; }}
+{{     prototype: RTCSessionDescription;     new(descriptionInitDict: RTCSessionDescriptionInit): RTCSessionDescription; }}
+{((this: RTCSrtpSdesTransport, ev: Event) => any) | null}
+{keyof RTCSrtpSdesTransportEventMap}
+{(this: RTCSrtpSdesTransport, ev: RTCSrtpSdesTransportEventMap[K]) => any}
+{{     prototype: RTCSrtpSdesTransport;     new(transport: RTCIceTransport, encryptParameters: RTCSrtpSdesParameters, decryptParameters: RTCSrtpSdesParameters): RTCSrtpSdesTransport;     getLocalParameters(): RTCSrtpSdesParameters[]; }}
+{{     prototype: RTCSsrcConflictEvent;     new(): RTCSsrcConflictEvent; }}
+{{     prototype: RTCStatsEvent;     new(type: string, eventInitDict: RTCStatsEventInit): RTCStatsEvent; }}
+{{     prototype: RTCStatsProvider;     new(): RTCStatsProvider; }}
+{(value: any, key: string, parent: RTCStatsReport) => void}
+{{     prototype: RTCStatsReport;     new(): RTCStatsReport; }}
+{ReadonlyArray<MediaStream>}
+{{     prototype: RTCTrackEvent;     new(type: string, eventInitDict: RTCTrackEventInit): RTCTrackEvent; }}
+{{     prototype: RadioNodeList;     new(): RadioNodeList; }}
+{Int8Array | Uint8ClampedArray | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array}
+{{     prototype: RandomSource;     new(): RandomSource; }}
+{AbstractRange}
+{{     prototype: Range;     new(): Range;     readonly END_TO_END: number;     readonly END_TO_START: number;     readonly START_TO_END: number;     readonly START_TO_START: number; }}
+{ReadableStreamBYOBRequest | undefined}
+{{ mode: "byob" }}
+{ReadableStreamBYOBReader}
+{ReadableStreamDefaultReader<R>}
+{{ writable: WritableStream<R>, readable: ReadableStream<T> }}
+{PipeOptions}
+{ReadableStream<T>}
+{WritableStream<R>}
+{[ReadableStream<R>, ReadableStream<R>]}
+{{     prototype: ReadableStream;     new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number, size?: undefined }): ReadableStream<Uint8Array>;     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>; }}
+{Promise<ReadableStreamReadResult<T>>}
+{{     prototype: ReadableStreamBYOBReader;     new(stream: ReadableStream<Uint8Array>): ReadableStreamBYOBReader; }}
+{Promise<ReadableStreamReadResult<R>>}
+{{     prototype: ReadableStreamReader;     new(): ReadableStreamReader; }}
+{Body}
+{RequestDestination}
+{Headers}
+{Request}
+{{     prototype: Request;     new(input: RequestInfo, init?: RequestInit): Request; }}
+{Promise<Headers>}
+{ResponseType}
+{{     prototype: Response;     new(body?: BodyInit | null, init?: ResponseInit): Response;     error(): Response;     redirect(url: string, status?: number): Response; }}
+{SVGGraphicsElement}
+{SVGURIReference}
+{SVGAnimatedString}
+{keyof SVGElementEventMap}
+{(this: SVGAElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGAElement;     new(): SVGAElement; }}
+{{     prototype: SVGAngle;     new(): SVGAngle;     readonly SVG_ANGLETYPE_DEG: number;     readonly SVG_ANGLETYPE_GRAD: number;     readonly SVG_ANGLETYPE_RAD: number;     readonly SVG_ANGLETYPE_UNKNOWN: number;     readonly SVG_ANGLETYPE_UNSPECIFIED: number; }}
+{SVGAnimationElement}
+{(this: SVGAnimateElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGAnimateElement;     new(): SVGAnimateElement; }}
+{(this: SVGAnimateMotionElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGAnimateMotionElement;     new(): SVGAnimateMotionElement; }}
+{(this: SVGAnimateTransformElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGAnimateTransformElement;     new(): SVGAnimateTransformElement; }}
+{SVGAngle}
+{{     prototype: SVGAnimatedAngle;     new(): SVGAnimatedAngle; }}
+{{     prototype: SVGAnimatedBoolean;     new(): SVGAnimatedBoolean; }}
+{{     prototype: SVGAnimatedEnumeration;     new(): SVGAnimatedEnumeration; }}
+{{     prototype: SVGAnimatedInteger;     new(): SVGAnimatedInteger; }}
+{SVGLength}
+{{     prototype: SVGAnimatedLength;     new(): SVGAnimatedLength; }}
+{SVGLengthList}
+{{     prototype: SVGAnimatedLengthList;     new(): SVGAnimatedLengthList; }}
+{{     prototype: SVGAnimatedNumber;     new(): SVGAnimatedNumber; }}
+{SVGNumberList}
+{{     prototype: SVGAnimatedNumberList;     new(): SVGAnimatedNumberList; }}
+{SVGPointList}
+{SVGPreserveAspectRatio}
+{{     prototype: SVGAnimatedPreserveAspectRatio;     new(): SVGAnimatedPreserveAspectRatio; }}
+{{     prototype: SVGAnimatedRect;     new(): SVGAnimatedRect; }}
+{{     prototype: SVGAnimatedString;     new(): SVGAnimatedString; }}
+{SVGTransformList}
+{{     prototype: SVGAnimatedTransformList;     new(): SVGAnimatedTransformList; }}
+{(this: SVGAnimationElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGAnimationElement;     new(): SVGAnimationElement; }}
+{SVGAnimatedLength}
+{(this: SVGCircleElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGCircleElement;     new(): SVGCircleElement; }}
+{SVGAnimatedEnumeration}
+{(this: SVGClipPathElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGClipPathElement;     new(): SVGClipPathElement; }}
+{SVGAnimatedNumber}
+{SVGAnimatedNumberList}
+{(this: SVGComponentTransferFunctionElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGComponentTransferFunctionElement;     new(): SVGComponentTransferFunctionElement;     readonly SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: number;     readonly SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: number;     readonly SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY: number;     readonly SVG_FECOMPONENTTRANSFER_TYPE_LINEAR: number;     readonly SVG_FECOMPONENTTRANSFER_TYPE_TABLE: number;     readonly SVG_FECOMPONENTTRANSFER_TYPE_UNKNOWN: number; }}
+{(this: SVGCursorElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGCursorElement;     new(): SVGCursorElement; }}
+{(this: SVGDefsElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGDefsElement;     new(): SVGDefsElement; }}
+{(this: SVGDescElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGDescElement;     new(): SVGDescElement; }}
+{SVGElementInstance}
+{SVGSVGElement | null}
+{SVGElement | null}
+{(this: SVGElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGElement;     new(): SVGElement; }}
+{SVGUseElement}
+{{     prototype: SVGElementInstance;     new(): SVGElementInstance; }}
+{{     prototype: SVGElementInstanceList;     new(): SVGElementInstanceList; }}
+{(this: SVGEllipseElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGEllipseElement;     new(): SVGEllipseElement; }}
+{SVGFilterPrimitiveStandardAttributes}
+{(this: SVGFEBlendElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEBlendElement;     new(): SVGFEBlendElement;     readonly SVG_FEBLEND_MODE_COLOR: number;     readonly SVG_FEBLEND_MODE_COLOR_BURN: number;     readonly SVG_FEBLEND_MODE_COLOR_DODGE: number;     readonly SVG_FEBLEND_MODE_DARKEN: number;     readonly SVG_FEBLEND_MODE_DIFFERENCE: number;     readonly SVG_FEBLEND_MODE_EXCLUSION: number;     readonly SVG_FEBLEND_MODE_HARD_LIGHT: number;     readonly SVG_FEBLEND_MODE_HUE: number;     readonly SVG_FEBLEND_MODE_LIGHTEN: number;     readonly SVG_FEBLEND_MODE_LUMINOSITY: number;     readonly SVG_FEBLEND_MODE_MULTIPLY: number;     readonly SVG_FEBLEND_MODE_NORMAL: number;     readonly SVG_FEBLEND_MODE_OVERLAY: number;     readonly SVG_FEBLEND_MODE_SATURATION: number;     readonly SVG_FEBLEND_MODE_SCREEN: number;     readonly SVG_FEBLEND_MODE_SOFT_LIGHT: number;     readonly SVG_FEBLEND_MODE_UNKNOWN: number; }}
+{(this: SVGFEColorMatrixElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEColorMatrixElement;     new(): SVGFEColorMatrixElement;     readonly SVG_FECOLORMATRIX_TYPE_HUEROTATE: number;     readonly SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: number;     readonly SVG_FECOLORMATRIX_TYPE_MATRIX: number;     readonly SVG_FECOLORMATRIX_TYPE_SATURATE: number;     readonly SVG_FECOLORMATRIX_TYPE_UNKNOWN: number; }}
+{(this: SVGFEComponentTransferElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEComponentTransferElement;     new(): SVGFEComponentTransferElement; }}
+{(this: SVGFECompositeElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFECompositeElement;     new(): SVGFECompositeElement;     readonly SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: number;     readonly SVG_FECOMPOSITE_OPERATOR_ATOP: number;     readonly SVG_FECOMPOSITE_OPERATOR_IN: number;     readonly SVG_FECOMPOSITE_OPERATOR_OUT: number;     readonly SVG_FECOMPOSITE_OPERATOR_OVER: number;     readonly SVG_FECOMPOSITE_OPERATOR_UNKNOWN: number;     readonly SVG_FECOMPOSITE_OPERATOR_XOR: number; }}
+{SVGAnimatedInteger}
+{SVGAnimatedBoolean}
+{(this: SVGFEConvolveMatrixElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEConvolveMatrixElement;     new(): SVGFEConvolveMatrixElement;     readonly SVG_EDGEMODE_DUPLICATE: number;     readonly SVG_EDGEMODE_NONE: number;     readonly SVG_EDGEMODE_UNKNOWN: number;     readonly SVG_EDGEMODE_WRAP: number; }}
+{(this: SVGFEDiffuseLightingElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEDiffuseLightingElement;     new(): SVGFEDiffuseLightingElement; }}
+{(this: SVGFEDisplacementMapElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEDisplacementMapElement;     new(): SVGFEDisplacementMapElement;     readonly SVG_CHANNEL_A: number;     readonly SVG_CHANNEL_B: number;     readonly SVG_CHANNEL_G: number;     readonly SVG_CHANNEL_R: number;     readonly SVG_CHANNEL_UNKNOWN: number; }}
+{(this: SVGFEDistantLightElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEDistantLightElement;     new(): SVGFEDistantLightElement; }}
+{(this: SVGFEFloodElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEFloodElement;     new(): SVGFEFloodElement; }}
+{SVGComponentTransferFunctionElement}
+{(this: SVGFEFuncAElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEFuncAElement;     new(): SVGFEFuncAElement; }}
+{(this: SVGFEFuncBElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEFuncBElement;     new(): SVGFEFuncBElement; }}
+{(this: SVGFEFuncGElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEFuncGElement;     new(): SVGFEFuncGElement; }}
+{(this: SVGFEFuncRElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEFuncRElement;     new(): SVGFEFuncRElement; }}
+{(this: SVGFEGaussianBlurElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEGaussianBlurElement;     new(): SVGFEGaussianBlurElement; }}
+{SVGAnimatedPreserveAspectRatio}
+{(this: SVGFEImageElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEImageElement;     new(): SVGFEImageElement; }}
+{(this: SVGFEMergeElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEMergeElement;     new(): SVGFEMergeElement; }}
+{(this: SVGFEMergeNodeElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEMergeNodeElement;     new(): SVGFEMergeNodeElement; }}
+{(this: SVGFEMorphologyElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEMorphologyElement;     new(): SVGFEMorphologyElement;     readonly SVG_MORPHOLOGY_OPERATOR_DILATE: number;     readonly SVG_MORPHOLOGY_OPERATOR_ERODE: number;     readonly SVG_MORPHOLOGY_OPERATOR_UNKNOWN: number; }}
+{(this: SVGFEOffsetElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEOffsetElement;     new(): SVGFEOffsetElement; }}
+{(this: SVGFEPointLightElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFEPointLightElement;     new(): SVGFEPointLightElement; }}
+{(this: SVGFESpecularLightingElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFESpecularLightingElement;     new(): SVGFESpecularLightingElement; }}
+{(this: SVGFESpotLightElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFESpotLightElement;     new(): SVGFESpotLightElement; }}
+{(this: SVGFETileElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFETileElement;     new(): SVGFETileElement; }}
+{(this: SVGFETurbulenceElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFETurbulenceElement;     new(): SVGFETurbulenceElement;     readonly SVG_STITCHTYPE_NOSTITCH: number;     readonly SVG_STITCHTYPE_STITCH: number;     readonly SVG_STITCHTYPE_UNKNOWN: number;     readonly SVG_TURBULENCE_TYPE_FRACTALNOISE: number;     readonly SVG_TURBULENCE_TYPE_TURBULENCE: number;     readonly SVG_TURBULENCE_TYPE_UNKNOWN: number; }}
+{(this: SVGFilterElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGFilterElement;     new(): SVGFilterElement; }}
+{SVGAnimatedRect}
+{(this: SVGForeignObjectElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGForeignObjectElement;     new(): SVGForeignObjectElement; }}
+{(this: SVGGElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGGElement;     new(): SVGGElement; }}
+{(this: SVGGeometryElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGGeometryElement;     new(): SVGGeometryElement; }}
+{SVGAnimatedTransformList}
+{(this: SVGGradientElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGGradientElement;     new(): SVGGradientElement;     readonly SVG_SPREADMETHOD_PAD: number;     readonly SVG_SPREADMETHOD_REFLECT: number;     readonly SVG_SPREADMETHOD_REPEAT: number;     readonly SVG_SPREADMETHOD_UNKNOWN: number; }}
+{SVGTests}
+{SVGBoundingBoxOptions}
+{DOMMatrix | null}
+{(this: SVGGraphicsElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGGraphicsElement;     new(): SVGGraphicsElement; }}
+{(this: SVGImageElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGImageElement;     new(): SVGImageElement; }}
+{{     prototype: SVGLength;     new(): SVGLength;     readonly SVG_LENGTHTYPE_CM: number;     readonly SVG_LENGTHTYPE_EMS: number;     readonly SVG_LENGTHTYPE_EXS: number;     readonly SVG_LENGTHTYPE_IN: number;     readonly SVG_LENGTHTYPE_MM: number;     readonly SVG_LENGTHTYPE_NUMBER: number;     readonly SVG_LENGTHTYPE_PC: number;     readonly SVG_LENGTHTYPE_PERCENTAGE: number;     readonly SVG_LENGTHTYPE_PT: number;     readonly SVG_LENGTHTYPE_PX: number;     readonly SVG_LENGTHTYPE_UNKNOWN: number; }}
+{{     prototype: SVGLengthList;     new(): SVGLengthList; }}
+{(this: SVGLineElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGLineElement;     new(): SVGLineElement; }}
+{SVGGradientElement}
+{(this: SVGLinearGradientElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGLinearGradientElement;     new(): SVGLinearGradientElement; }}
+{SVGFitToViewBox}
+{SVGAnimatedAngle}
+{(this: SVGMarkerElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGMarkerElement;     new(): SVGMarkerElement;     readonly SVG_MARKERUNITS_STROKEWIDTH: number;     readonly SVG_MARKERUNITS_UNKNOWN: number;     readonly SVG_MARKERUNITS_USERSPACEONUSE: number;     readonly SVG_MARKER_ORIENT_ANGLE: number;     readonly SVG_MARKER_ORIENT_AUTO: number;     readonly SVG_MARKER_ORIENT_UNKNOWN: number; }}
+{(this: SVGMaskElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGMaskElement;     new(): SVGMaskElement; }}
+{(this: SVGMetadataElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGMetadataElement;     new(): SVGMetadataElement; }}
+{{     prototype: SVGNumber;     new(): SVGNumber; }}
+{SVGNumber}
+{{     prototype: SVGNumberList;     new(): SVGNumberList; }}
+{SVGPathSegList}
+{SVGPathSegArcAbs}
+{SVGPathSegArcRel}
+{SVGPathSegClosePath}
+{SVGPathSegCurvetoCubicAbs}
+{SVGPathSegCurvetoCubicRel}
+{SVGPathSegCurvetoCubicSmoothAbs}
+{SVGPathSegCurvetoCubicSmoothRel}
+{SVGPathSegCurvetoQuadraticAbs}
+{SVGPathSegCurvetoQuadraticRel}
+{SVGPathSegCurvetoQuadraticSmoothAbs}
+{SVGPathSegCurvetoQuadraticSmoothRel}
+{SVGPathSegLinetoAbs}
+{SVGPathSegLinetoHorizontalAbs}
+{SVGPathSegLinetoHorizontalRel}
+{SVGPathSegLinetoRel}
+{SVGPathSegLinetoVerticalAbs}
+{SVGPathSegLinetoVerticalRel}
+{SVGPathSegMovetoAbs}
+{SVGPathSegMovetoRel}
+{SVGPoint}
+{(this: SVGPathElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGPathElement;     new(): SVGPathElement; }}
+{{     prototype: SVGPathSeg;     new(): SVGPathSeg;     readonly PATHSEG_ARC_ABS: number;     readonly PATHSEG_ARC_REL: number;     readonly PATHSEG_CLOSEPATH: number;     readonly PATHSEG_CURVETO_CUBIC_ABS: number;     readonly PATHSEG_CURVETO_CUBIC_REL: number;     readonly PATHSEG_CURVETO_CUBIC_SMOOTH_ABS: number;     readonly PATHSEG_CURVETO_CUBIC_SMOOTH_REL: number;     readonly PATHSEG_CURVETO_QUADRATIC_ABS: number;     readonly PATHSEG_CURVETO_QUADRATIC_REL: number;     readonly PATHSEG_CURVETO_QUADRATIC_SMOOTH_ABS: number;     readonly PATHSEG_CURVETO_QUADRATIC_SMOOTH_REL: number;     readonly PATHSEG_LINETO_ABS: number;     readonly PATHSEG_LINETO_HORIZONTAL_ABS: number;     readonly PATHSEG_LINETO_HORIZONTAL_REL: number;     readonly PATHSEG_LINETO_REL: number;     readonly PATHSEG_LINETO_VERTICAL_ABS: number;     readonly PATHSEG_LINETO_VERTICAL_REL: number;     readonly PATHSEG_MOVETO_ABS: number;     readonly PATHSEG_MOVETO_REL: number;     readonly PATHSEG_UNKNOWN: number; }}
+{SVGPathSeg}
+{{     prototype: SVGPathSegArcAbs;     new(): SVGPathSegArcAbs; }}
+{{     prototype: SVGPathSegArcRel;     new(): SVGPathSegArcRel; }}
+{{     prototype: SVGPathSegClosePath;     new(): SVGPathSegClosePath; }}
+{{     prototype: SVGPathSegCurvetoCubicAbs;     new(): SVGPathSegCurvetoCubicAbs; }}
+{{     prototype: SVGPathSegCurvetoCubicRel;     new(): SVGPathSegCurvetoCubicRel; }}
+{{     prototype: SVGPathSegCurvetoCubicSmoothAbs;     new(): SVGPathSegCurvetoCubicSmoothAbs; }}
+{{     prototype: SVGPathSegCurvetoCubicSmoothRel;     new(): SVGPathSegCurvetoCubicSmoothRel; }}
+{{     prototype: SVGPathSegCurvetoQuadraticAbs;     new(): SVGPathSegCurvetoQuadraticAbs; }}
+{{     prototype: SVGPathSegCurvetoQuadraticRel;     new(): SVGPathSegCurvetoQuadraticRel; }}
+{{     prototype: SVGPathSegCurvetoQuadraticSmoothAbs;     new(): SVGPathSegCurvetoQuadraticSmoothAbs; }}
+{{     prototype: SVGPathSegCurvetoQuadraticSmoothRel;     new(): SVGPathSegCurvetoQuadraticSmoothRel; }}
+{{     prototype: SVGPathSegLinetoAbs;     new(): SVGPathSegLinetoAbs; }}
+{{     prototype: SVGPathSegLinetoHorizontalAbs;     new(): SVGPathSegLinetoHorizontalAbs; }}
+{{     prototype: SVGPathSegLinetoHorizontalRel;     new(): SVGPathSegLinetoHorizontalRel; }}
+{{     prototype: SVGPathSegLinetoRel;     new(): SVGPathSegLinetoRel; }}
+{{     prototype: SVGPathSegLinetoVerticalAbs;     new(): SVGPathSegLinetoVerticalAbs; }}
+{{     prototype: SVGPathSegLinetoVerticalRel;     new(): SVGPathSegLinetoVerticalRel; }}
+{{     prototype: SVGPathSegList;     new(): SVGPathSegList; }}
+{{     prototype: SVGPathSegMovetoAbs;     new(): SVGPathSegMovetoAbs; }}
+{{     prototype: SVGPathSegMovetoRel;     new(): SVGPathSegMovetoRel; }}
+{(this: SVGPatternElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGPatternElement;     new(): SVGPatternElement; }}
+{{     prototype: SVGPointList;     new(): SVGPointList; }}
+{SVGAnimatedPoints}
+{(this: SVGPolygonElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGPolygonElement;     new(): SVGPolygonElement; }}
+{(this: SVGPolylineElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGPolylineElement;     new(): SVGPolylineElement; }}
+{{     prototype: SVGPreserveAspectRatio;     new(): SVGPreserveAspectRatio;     readonly SVG_MEETORSLICE_MEET: number;     readonly SVG_MEETORSLICE_SLICE: number;     readonly SVG_MEETORSLICE_UNKNOWN: number;     readonly SVG_PRESERVEASPECTRATIO_NONE: number;     readonly SVG_PRESERVEASPECTRATIO_UNKNOWN: number;     readonly SVG_PRESERVEASPECTRATIO_XMAXYMAX: number;     readonly SVG_PRESERVEASPECTRATIO_XMAXYMID: number;     readonly SVG_PRESERVEASPECTRATIO_XMAXYMIN: number;     readonly SVG_PRESERVEASPECTRATIO_XMIDYMAX: number;     readonly SVG_PRESERVEASPECTRATIO_XMIDYMID: number;     readonly SVG_PRESERVEASPECTRATIO_XMIDYMIN: number;     readonly SVG_PRESERVEASPECTRATIO_XMINYMAX: number;     readonly SVG_PRESERVEASPECTRATIO_XMINYMID: number;     readonly SVG_PRESERVEASPECTRATIO_XMINYMIN: number; }}
+{(this: SVGRadialGradientElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGRadialGradientElement;     new(): SVGRadialGradientElement; }}
+{(this: SVGRectElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGRectElement;     new(): SVGRectElement; }}
+{SVGElementEventMap}
+{DocumentEvent}
+{SVGZoomAndPan}
+{((this: SVGSVGElement, ev: Event) => any) | null}
+{((this: SVGSVGElement, ev: SVGZoomEvent) => any) | null}
+{SVGRect}
+{SVGMatrix}
+{SVGTransform}
+{NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>}
+{keyof SVGSVGElementEventMap}
+{(this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any}
+{{     prototype: SVGSVGElement;     new(): SVGSVGElement;     readonly SVG_ZOOMANDPAN_DISABLE: number;     readonly SVG_ZOOMANDPAN_MAGNIFY: number;     readonly SVG_ZOOMANDPAN_UNKNOWN: number; }}
+{(this: SVGScriptElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGScriptElement;     new(): SVGScriptElement; }}
+{(this: SVGStopElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGStopElement;     new(): SVGStopElement; }}
+{{     prototype: SVGStringList;     new(): SVGStringList; }}
+{(this: SVGStyleElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGStyleElement;     new(): SVGStyleElement; }}
+{(this: SVGSwitchElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGSwitchElement;     new(): SVGSwitchElement; }}
+{(this: SVGSymbolElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGSymbolElement;     new(): SVGSymbolElement; }}
+{SVGTextPositioningElement}
+{(this: SVGTSpanElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTSpanElement;     new(): SVGTSpanElement; }}
+{SVGStringList}
+{(this: SVGTextContentElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTextContentElement;     new(): SVGTextContentElement;     readonly LENGTHADJUST_SPACING: number;     readonly LENGTHADJUST_SPACINGANDGLYPHS: number;     readonly LENGTHADJUST_UNKNOWN: number; }}
+{(this: SVGTextElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTextElement;     new(): SVGTextElement; }}
+{SVGTextContentElement}
+{(this: SVGTextPathElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTextPathElement;     new(): SVGTextPathElement;     readonly TEXTPATH_METHODTYPE_ALIGN: number;     readonly TEXTPATH_METHODTYPE_STRETCH: number;     readonly TEXTPATH_METHODTYPE_UNKNOWN: number;     readonly TEXTPATH_SPACINGTYPE_AUTO: number;     readonly TEXTPATH_SPACINGTYPE_EXACT: number;     readonly TEXTPATH_SPACINGTYPE_UNKNOWN: number; }}
+{SVGAnimatedLengthList}
+{(this: SVGTextPositioningElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTextPositioningElement;     new(): SVGTextPositioningElement; }}
+{(this: SVGTitleElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGTitleElement;     new(): SVGTitleElement; }}
+{{     prototype: SVGTransform;     new(): SVGTransform;     readonly SVG_TRANSFORM_MATRIX: number;     readonly SVG_TRANSFORM_ROTATE: number;     readonly SVG_TRANSFORM_SCALE: number;     readonly SVG_TRANSFORM_SKEWX: number;     readonly SVG_TRANSFORM_SKEWY: number;     readonly SVG_TRANSFORM_TRANSLATE: number;     readonly SVG_TRANSFORM_UNKNOWN: number; }}
+{{     prototype: SVGTransformList;     new(): SVGTransformList; }}
+{{     prototype: SVGUnitTypes;     new(): SVGUnitTypes;     readonly SVG_UNIT_TYPE_OBJECTBOUNDINGBOX: number;     readonly SVG_UNIT_TYPE_UNKNOWN: number;     readonly SVG_UNIT_TYPE_USERSPACEONUSE: number; }}
+{SVGElementInstance | null}
+{(this: SVGUseElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGUseElement;     new(): SVGUseElement; }}
+{(this: SVGViewElement, ev: SVGElementEventMap[K]) => any}
+{{     prototype: SVGViewElement;     new(): SVGViewElement;     readonly SVG_ZOOMANDPAN_DISABLE: number;     readonly SVG_ZOOMANDPAN_MAGNIFY: number;     readonly SVG_ZOOMANDPAN_UNKNOWN: number; }}
+{{     readonly SVG_ZOOMANDPAN_DISABLE: number;     readonly SVG_ZOOMANDPAN_MAGNIFY: number;     readonly SVG_ZOOMANDPAN_UNKNOWN: number; }}
+{{     prototype: SVGZoomEvent;     new(): SVGZoomEvent; }}
+{{     prototype: ScopedCredential;     new(): ScopedCredential; }}
+{ScopedCredential}
+{{     prototype: ScopedCredentialInfo;     new(): ScopedCredentialInfo; }}
+{ScreenOrientation}
+{{     prototype: Screen;     new(): Screen; }}
+{((this: ScreenOrientation, ev: Event) => any) | null}
+{OrientationType}
+{OrientationLockType}
+{keyof ScreenOrientationEventMap}
+{(this: ScreenOrientation, ev: ScreenOrientationEventMap[K]) => any}
+{{     prototype: ScreenOrientation;     new(): ScreenOrientation; }}
+{((this: ScriptProcessorNode, ev: AudioProcessingEvent) => any) | null}
+{keyof ScriptProcessorNodeEventMap}
+{(this: ScriptProcessorNode, ev: ScriptProcessorNodeEventMap[K]) => any}
+{{     prototype: ScriptProcessorNode;     new(): ScriptProcessorNode; }}
+{{     prototype: SecurityPolicyViolationEvent;     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent; }}
+{{     prototype: Selection;     new(): Selection; }}
+{ServiceUIFrameContext}
+{AbstractWorkerEventMap}
+{AbstractWorker}
+{((this: ServiceWorker, ev: Event) => any) | null}
+{ServiceWorkerState}
+{keyof ServiceWorkerEventMap}
+{(this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any}
+{{     prototype: ServiceWorker;     new(): ServiceWorker; }}
+{ServiceWorker | null}
+{((this: ServiceWorkerContainer, ev: Event) => any) | null}
+{((this: ServiceWorkerContainer, ev: MessageEvent) => any) | null}
+{Promise<ServiceWorkerRegistration>}
+{Promise<ServiceWorkerRegistration | undefined>}
+{Promise<ReadonlyArray<ServiceWorkerRegistration>>}
+{RegistrationOptions}
+{keyof ServiceWorkerContainerEventMap}
+{(this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any}
+{{     prototype: ServiceWorkerContainer;     new(): ServiceWorkerContainer; }}
+{ReadonlyArray<MessagePort> | null}
+{{     prototype: ServiceWorkerMessageEvent;     new(type: string, eventInitDict?: ServiceWorkerMessageEventInit): ServiceWorkerMessageEvent; }}
+{NavigationPreloadManager}
+{((this: ServiceWorkerRegistration, ev: Event) => any) | null}
+{PushManager}
+{SyncManager}
+{GetNotificationOptions}
+{Promise<Notification[]>}
+{NotificationOptions}
+{keyof ServiceWorkerRegistrationEventMap}
+{(this: ServiceWorkerRegistration, ev: ServiceWorkerRegistrationEventMap[K]) => any}
+{{     prototype: ServiceWorkerRegistration;     new(): ServiceWorkerRegistration; }}
+{{     prototype: ShadowRoot;     new(): ShadowRoot; }}
+{AppendMode}
+{((this: SourceBuffer, ev: Event) => any) | null}
+{keyof SourceBufferEventMap}
+{(this: SourceBuffer, ev: SourceBufferEventMap[K]) => any}
+{{     prototype: SourceBuffer;     new(): SourceBuffer; }}
+{((this: SourceBufferList, ev: Event) => any) | null}
+{keyof SourceBufferListEventMap}
+{(this: SourceBufferList, ev: SourceBufferListEventMap[K]) => any}
+{{     prototype: SourceBufferList;     new(): SourceBufferList; }}
+{{     prototype: SpeechGrammar;     new(): SpeechGrammar; }}
+{SpeechGrammar}
+{{     prototype: SpeechGrammarList;     new(): SpeechGrammarList; }}
+{SpeechGrammarList}
+{((this: SpeechRecognition, ev: Event) => any) | null}
+{((this: SpeechRecognition, ev: SpeechRecognitionError) => any) | null}
+{((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any) | null}
+{keyof SpeechRecognitionEventMap}
+{(this: SpeechRecognition, ev: SpeechRecognitionEventMap[K]) => any}
+{{     prototype: SpeechRecognition;     new(): SpeechRecognition; }}
+{{     prototype: SpeechRecognitionAlternative;     new(): SpeechRecognitionAlternative; }}
+{SpeechRecognitionErrorCode}
+{{     prototype: SpeechRecognitionError;     new(): SpeechRecognitionError; }}
+{SpeechRecognitionResultList}
+{{     prototype: SpeechRecognitionEvent;     new(): SpeechRecognitionEvent; }}
+{SpeechRecognitionAlternative}
+{{     prototype: SpeechRecognitionResult;     new(): SpeechRecognitionResult; }}
+{SpeechRecognitionResult}
+{{     prototype: SpeechRecognitionResultList;     new(): SpeechRecognitionResultList; }}
+{((this: SpeechSynthesis, ev: Event) => any) | null}
+{SpeechSynthesisVoice[]}
+{SpeechSynthesisUtterance}
+{keyof SpeechSynthesisEventMap}
+{(this: SpeechSynthesis, ev: SpeechSynthesisEventMap[K]) => any}
+{{     prototype: SpeechSynthesis;     new(): SpeechSynthesis; }}
+{SpeechSynthesisErrorCode}
+{{     prototype: SpeechSynthesisErrorEvent;     new(): SpeechSynthesisErrorEvent; }}
+{{     prototype: SpeechSynthesisEvent;     new(): SpeechSynthesisEvent; }}
+{((this: SpeechSynthesisUtterance, ev: SpeechSynthesisEvent) => any) | null}
+{((this: SpeechSynthesisUtterance, ev: SpeechSynthesisErrorEvent) => any) | null}
+{SpeechSynthesisVoice}
+{keyof SpeechSynthesisUtteranceEventMap}
+{(this: SpeechSynthesisUtterance, ev: SpeechSynthesisUtteranceEventMap[K]) => any}
+{{     prototype: SpeechSynthesisUtterance;     new(): SpeechSynthesisUtterance;     new(text: string): SpeechSynthesisUtterance; }}
+{{     prototype: SpeechSynthesisVoice;     new(): SpeechSynthesisVoice; }}
+{{     prototype: StaticRange;     new(): StaticRange; }}
+{{     prototype: StereoPannerNode;     new(context: BaseAudioContext, options?: StereoPannerOptions): StereoPannerNode; }}
+{{     prototype: Storage;     new(): Storage; }}
+{{     prototype: StorageEvent;     new(type: string, eventInitDict?: StorageEventInit): StorageEvent; }}
+{Promise<StorageEstimate>}
+{{     prototype: StorageManager;     new(): StorageManager; }}
+{{     prototype: StyleMedia;     new(): StyleMedia; }}
+{{     prototype: StyleSheet;     new(): StyleSheet; }}
+{{     prototype: StyleSheetList;     new(): StyleSheetList; }}
+{string | RsaOaepParams | AesCtrParams | AesCbcParams | AesCmacParams | AesGcmParams | AesCfbParams}
+{PromiseLike<ArrayBuffer>}
+{string | EcdhKeyDeriveParams | DhKeyDeriveParams | ConcatParams | HkdfCtrParams | Pbkdf2Params}
+{string | AesDerivedKeyParams | HmacImportParams | ConcatParams | HkdfCtrParams | Pbkdf2Params}
+{PromiseLike<CryptoKey>}
+{"jwk"}
+{PromiseLike<JsonWebKey>}
+{"raw" | "pkcs8" | "spki"}
+{PromiseLike<JsonWebKey | ArrayBuffer>}
+{PromiseLike<CryptoKeyPair | CryptoKey>}
+{RsaHashedKeyGenParams | EcKeyGenParams | DhKeyGenParams}
+{PromiseLike<CryptoKeyPair>}
+{AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params}
+{JsonWebKey}
+{string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams | AesKeyAlgorithm}
+{JsonWebKey | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer}
+{string | RsaPssParams | EcdsaParams | AesCmacParams}
+{PromiseLike<boolean>}
+{{     prototype: SubtleCrypto;     new(): SubtleCrypto; }}
+{{     prototype: SyncManager;     new(): SyncManager; }}
+{{     prototype: Text;     new(data?: string): Text; }}
+{TextDecodeOptions}
+{{     prototype: TextDecoder;     new(label?: string, options?: TextDecoderOptions): TextDecoder; }}
+{{     prototype: TextEncoder;     new(): TextEncoder; }}
+{{     prototype: TextEvent;     new(): TextEvent;     readonly DOM_INPUT_METHOD_DROP: number;     readonly DOM_INPUT_METHOD_HANDWRITING: number;     readonly DOM_INPUT_METHOD_IME: number;     readonly DOM_INPUT_METHOD_KEYBOARD: number;     readonly DOM_INPUT_METHOD_MULTIMODAL: number;     readonly DOM_INPUT_METHOD_OPTION: number;     readonly DOM_INPUT_METHOD_PASTE: number;     readonly DOM_INPUT_METHOD_SCRIPT: number;     readonly DOM_INPUT_METHOD_UNKNOWN: number;     readonly DOM_INPUT_METHOD_VOICE: number; }}
+{{     prototype: TextMetrics;     new(): TextMetrics; }}
+{TextTrackCueList}
+{TextTrackMode | number}
+{((this: TextTrack, ev: Event) => any) | null}
+{keyof TextTrackEventMap}
+{(this: TextTrack, ev: TextTrackEventMap[K]) => any}
+{{     prototype: TextTrack;     new(): TextTrack;     readonly DISABLED: number;     readonly ERROR: number;     readonly HIDDEN: number;     readonly LOADED: number;     readonly LOADING: number;     readonly NONE: number;     readonly SHOWING: number; }}
+{((this: TextTrackCue, ev: Event) => any) | null}
+{(this: TextTrackCue, ev: TextTrackCueEventMap[K]) => any}
+{{     prototype: TextTrackCue;     new(startTime: number, endTime: number, text: string): TextTrackCue; }}
+{{     prototype: TextTrackCueList;     new(): TextTrackCueList; }}
+{((this: TextTrackList, ev: TrackEvent) => any) | null}
+{keyof TextTrackListEventMap}
+{(this: TextTrackList, ev: TextTrackListEventMap[K]) => any}
+{{     prototype: TextTrackList;     new(): TextTrackList; }}
+{{     prototype: TimeRanges;     new(): TimeRanges; }}
+{{     prototype: Touch;     new(touchInitDict: TouchInit): Touch; }}
+{{     prototype: TouchEvent;     new(type: string, eventInitDict?: TouchEventInit): TouchEvent; }}
+{Touch | null}
+{{     prototype: TouchList;     new(): TouchList; }}
+{{     prototype: TrackEvent;     new(typeArg: string, eventInitDict?: TrackEventInit): TrackEvent; }}
+{ReadableStream<O>}
+{WritableStream<I>}
+{{     prototype: TransformStream;     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>; }}
+{O}
+{{     prototype: TransitionEvent;     new(type: string, transitionEventInitDict?: TransitionEventInit): TransitionEvent; }}
+{{     prototype: TreeWalker;     new(): TreeWalker; }}
+{{     prototype: UIEvent;     new(typeArg: string, eventInitDict?: UIEventInit): UIEvent; }}
+{URLSearchParams}
+{{     prototype: URL;     new(url: string, base?: string | URL): URL;     createObjectURL(object: any): string;     revokeObjectURL(url: string): void; }}
+{URL}
+{typeof URL}
+{(value: string, key: string, parent: URLSearchParams) => void}
+{{     prototype: URLSearchParams;     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams; }}
+{VRDisplayCapabilities}
+{VRStageParameters | null}
+{VREyeParameters}
+{VRFrameData}
+{VRLayer[]}
+{VRPose}
+{FrameRequestCallback}
+{{     prototype: VRDisplay;     new(): VRDisplay; }}
+{{     prototype: VRDisplayCapabilities;     new(): VRDisplayCapabilities; }}
+{VRDisplayEventReason | null}
+{{     prototype: VRDisplayEvent;     new(type: string, eventInitDict: VRDisplayEventInit): VRDisplayEvent; }}
+{VRFieldOfView}
+{{     prototype: VREyeParameters;     new(): VREyeParameters; }}
+{{     prototype: VRFieldOfView;     new(): VRFieldOfView; }}
+{{     prototype: VRFrameData;     new(): VRFrameData; }}
+{{     prototype: VRPose;     new(): VRPose; }}
+{AlignSetting}
+{LineAndPositionSetting}
+{LineAlignSetting}
+{PositionAlignSetting}
+{VTTRegion | null}
+{DirectionSetting}
+{(this: VTTCue, ev: TextTrackCueEventMap[K]) => any}
+{{     prototype: VTTCue;     new(startTime: number, endTime: number, text: string): VTTCue; }}
+{ScrollSetting}
+{{     prototype: VTTRegion;     new(): VTTRegion; }}
+{{     prototype: ValidityState;     new(): ValidityState; }}
+{{     prototype: VideoPlaybackQuality;     new(): VideoPlaybackQuality; }}
+{{     prototype: VideoTrack;     new(): VideoTrack; }}
+{((this: VideoTrackList, ev: TrackEvent) => any) | null}
+{((this: VideoTrackList, ev: Event) => any) | null}
+{VideoTrack | null}
+{VideoTrack}
+{keyof VideoTrackListEventMap}
+{(this: VideoTrackList, ev: VideoTrackListEventMap[K]) => any}
+{{     prototype: VideoTrackList;     new(): VideoTrackList; }}
+{WebGLShader}
+{GLenum[]}
+{{     prototype: WaveShaperNode;     new(context: BaseAudioContext, options?: WaveShaperOptions): WaveShaperNode; }}
+{AssertionOptions}
+{Promise<WebAuthnAssertion>}
+{Account}
+{ScopedCredentialParameters[]}
+{ScopedCredentialOptions}
+{Promise<ScopedCredentialInfo>}
+{{     prototype: WebAuthentication;     new(): WebAuthentication; }}
+{{     prototype: WebAuthnAssertion;     new(): WebAuthnAssertion; }}
+{{     prototype: WebGLActiveInfo;     new(): WebGLActiveInfo; }}
+{WebGLObject}
+{{     prototype: WebGLBuffer;     new(): WebGLBuffer; }}
+{{     prototype: WebGLContextEvent;     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent; }}
+{{     prototype: WebGLFramebuffer;     new(): WebGLFramebuffer; }}
+{{     prototype: WebGLObject;     new(): WebGLObject; }}
+{{     prototype: WebGLProgram;     new(): WebGLProgram; }}
+{{     prototype: WebGLRenderbuffer;     new(): WebGLRenderbuffer; }}
+{WebGLRenderingContextBase}
+{{     prototype: WebGLRenderingContext;     new(): WebGLRenderingContext;     readonly ACTIVE_ATTRIBUTES: GLenum;     readonly ACTIVE_TEXTURE: GLenum;     readonly ACTIVE_UNIFORMS: GLenum;     readonly ALIASED_LINE_WIDTH_RANGE: GLenum;     readonly ALIASED_POINT_SIZE_RANGE: GLenum;     readonly ALPHA: GLenum;     readonly ALPHA_BITS: GLenum;     readonly ALWAYS: GLenum;     readonly ARRAY_BUFFER: GLenum;     readonly ARRAY_BUFFER_BINDING: GLenum;     readonly ATTACHED_SHADERS: GLenum;     readonly BACK: GLenum;     readonly BLEND: GLenum;     readonly BLEND_COLOR: GLenum;     readonly BLEND_DST_ALPHA: GLenum;     readonly BLEND_DST_RGB: GLenum;     readonly BLEND_EQUATION: GLenum;     readonly BLEND_EQUATION_ALPHA: GLenum;     readonly BLEND_EQUATION_RGB: GLenum;     readonly BLEND_SRC_ALPHA: GLenum;     readonly BLEND_SRC_RGB: GLenum;     readonly BLUE_BITS: GLenum;     readonly BOOL: GLenum;     readonly BOOL_VEC2: GLenum;     readonly BOOL_VEC3: GLenum;     readonly BOOL_VEC4: GLenum;     readonly BROWSER_DEFAULT_WEBGL: GLenum;     readonly BUFFER_SIZE: GLenum;     readonly BUFFER_USAGE: GLenum;     readonly BYTE: GLenum;     readonly CCW: GLenum;     readonly CLAMP_TO_EDGE: GLenum;     readonly COLOR_ATTACHMENT0: GLenum;     readonly COLOR_BUFFER_BIT: GLenum;     readonly COLOR_CLEAR_VALUE: GLenum;     readonly COLOR_WRITEMASK: GLenum;     readonly COMPILE_STATUS: GLenum;     readonly COMPRESSED_TEXTURE_FORMATS: GLenum;     readonly CONSTANT_ALPHA: GLenum;     readonly CONSTANT_COLOR: GLenum;     readonly CONTEXT_LOST_WEBGL: GLenum;     readonly CULL_FACE: GLenum;     readonly CULL_FACE_MODE: GLenum;     readonly CURRENT_PROGRAM: GLenum;     readonly CURRENT_VERTEX_ATTRIB: GLenum;     readonly CW: GLenum;     readonly DECR: GLenum;     readonly DECR_WRAP: GLenum;     readonly DELETE_STATUS: GLenum;     readonly DEPTH_ATTACHMENT: GLenum;     readonly DEPTH_BITS: GLenum;     readonly DEPTH_BUFFER_BIT: GLenum;     readonly DEPTH_CLEAR_VALUE: GLenum;     readonly DEPTH_COMPONENT: GLenum;     readonly DEPTH_COMPONENT16: GLenum;     readonly DEPTH_FUNC: GLenum;     readonly DEPTH_RANGE: GLenum;     readonly DEPTH_STENCIL: GLenum;     readonly DEPTH_STENCIL_ATTACHMENT: GLenum;     readonly DEPTH_TEST: GLenum;     readonly DEPTH_WRITEMASK: GLenum;     readonly DITHER: GLenum;     readonly DONT_CARE: GLenum;     readonly DST_ALPHA: GLenum;     readonly DST_COLOR: GLenum;     readonly DYNAMIC_DRAW: GLenum;     readonly ELEMENT_ARRAY_BUFFER: GLenum;     readonly ELEMENT_ARRAY_BUFFER_BINDING: GLenum;     readonly EQUAL: GLenum;     readonly FASTEST: GLenum;     readonly FLOAT: GLenum;     readonly FLOAT_MAT2: GLenum;     readonly FLOAT_MAT3: GLenum;     readonly FLOAT_MAT4: GLenum;     readonly FLOAT_VEC2: GLenum;     readonly FLOAT_VEC3: GLenum;     readonly FLOAT_VEC4: GLenum;     readonly FRAGMENT_SHADER: GLenum;     readonly FRAMEBUFFER: GLenum;     readonly FRAMEBUFFER_ATTACHMENT_OBJECT_NAME: GLenum;     readonly FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: GLenum;     readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: GLenum;     readonly FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: GLenum;     readonly FRAMEBUFFER_BINDING: GLenum;     readonly FRAMEBUFFER_COMPLETE: GLenum;     readonly FRAMEBUFFER_INCOMPLETE_ATTACHMENT: GLenum;     readonly FRAMEBUFFER_INCOMPLETE_DIMENSIONS: GLenum;     readonly FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: GLenum;     readonly FRAMEBUFFER_UNSUPPORTED: GLenum;     readonly FRONT: GLenum;     readonly FRONT_AND_BACK: GLenum;     readonly FRONT_FACE: GLenum;     readonly FUNC_ADD: GLenum;     readonly FUNC_REVERSE_SUBTRACT: GLenum;     readonly FUNC_SUBTRACT: GLenum;     readonly GENERATE_MIPMAP_HINT: GLenum;     readonly GEQUAL: GLenum;     readonly GREATER: GLenum;     readonly GREEN_BITS: GLenum;     readonly HIGH_FLOAT: GLenum;     readonly HIGH_INT: GLenum;     readonly IMPLEMENTATION_COLOR_READ_FORMAT: GLenum;     readonly IMPLEMENTATION_COLOR_READ_TYPE: GLenum;     readonly INCR: GLenum;     readonly INCR_WRAP: GLenum;     readonly INT: GLenum;     readonly INT_VEC2: GLenum;     readonly INT_VEC3: GLenum;     readonly INT_VEC4: GLenum;     readonly INVALID_ENUM: GLenum;     readonly INVALID_FRAMEBUFFER_OPERATION: GLenum;     readonly INVALID_OPERATION: GLenum;     readonly INVALID_VALUE: GLenum;     readonly INVERT: GLenum;     readonly KEEP: GLenum;     readonly LEQUAL: GLenum;     readonly LESS: GLenum;     readonly LINEAR: GLenum;     readonly LINEAR_MIPMAP_LINEAR: GLenum;     readonly LINEAR_MIPMAP_NEAREST: GLenum;     readonly LINES: GLenum;     readonly LINE_LOOP: GLenum;     readonly LINE_STRIP: GLenum;     readonly LINE_WIDTH: GLenum;     readonly LINK_STATUS: GLenum;     readonly LOW_FLOAT: GLenum;     readonly LOW_INT: GLenum;     readonly LUMINANCE: GLenum;     readonly LUMINANCE_ALPHA: GLenum;     readonly MAX_COMBINED_TEXTURE_IMAGE_UNITS: GLenum;     readonly MAX_CUBE_MAP_TEXTURE_SIZE: GLenum;     readonly MAX_FRAGMENT_UNIFORM_VECTORS: GLenum;     readonly MAX_RENDERBUFFER_SIZE: GLenum;     readonly MAX_TEXTURE_IMAGE_UNITS: GLenum;     readonly MAX_TEXTURE_SIZE: GLenum;     readonly MAX_VARYING_VECTORS: GLenum;     readonly MAX_VERTEX_ATTRIBS: GLenum;     readonly MAX_VERTEX_TEXTURE_IMAGE_UNITS: GLenum;     readonly MAX_VERTEX_UNIFORM_VECTORS: GLenum;     readonly MAX_VIEWPORT_DIMS: GLenum;     readonly MEDIUM_FLOAT: GLenum;     readonly MEDIUM_INT: GLenum;     readonly MIRRORED_REPEAT: GLenum;     readonly NEAREST: GLenum;     readonly NEAREST_MIPMAP_LINEAR: GLenum;     readonly NEAREST_MIPMAP_NEAREST: GLenum;     readonly NEVER: GLenum;     readonly NICEST: GLenum;     readonly NONE: GLenum;     readonly NOTEQUAL: GLenum;     readonly NO_ERROR: GLenum;     readonly ONE: GLenum;     readonly ONE_MINUS_CONSTANT_ALPHA: GLenum;     readonly ONE_MINUS_CONSTANT_COLOR: GLenum;     readonly ONE_MINUS_DST_ALPHA: GLenum;     readonly ONE_MINUS_DST_COLOR: GLenum;     readonly ONE_MINUS_SRC_ALPHA: GLenum;     readonly ONE_MINUS_SRC_COLOR: GLenum;     readonly OUT_OF_MEMORY: GLenum;     readonly PACK_ALIGNMENT: GLenum;     readonly POINTS: GLenum;     readonly POLYGON_OFFSET_FACTOR: GLenum;     readonly POLYGON_OFFSET_FILL: GLenum;     readonly POLYGON_OFFSET_UNITS: GLenum;     readonly RED_BITS: GLenum;     readonly RENDERBUFFER: GLenum;     readonly RENDERBUFFER_ALPHA_SIZE: GLenum;     readonly RENDERBUFFER_BINDING: GLenum;     readonly RENDERBUFFER_BLUE_SIZE: GLenum;     readonly RENDERBUFFER_DEPTH_SIZE: GLenum;     readonly RENDERBUFFER_GREEN_SIZE: GLenum;     readonly RENDERBUFFER_HEIGHT: GLenum;     readonly RENDERBUFFER_INTERNAL_FORMAT: GLenum;     readonly RENDERBUFFER_RED_SIZE: GLenum;     readonly RENDERBUFFER_STENCIL_SIZE: GLenum;     readonly RENDERBUFFER_WIDTH: GLenum;     readonly RENDERER: GLenum;     readonly REPEAT: GLenum;     readonly REPLACE: GLenum;     readonly RGB: GLenum;     readonly RGB565: GLenum;     readonly RGB5_A1: GLenum;     readonly RGBA: GLenum;     readonly RGBA4: GLenum;     readonly SAMPLER_2D: GLenum;     readonly SAMPLER_CUBE: GLenum;     readonly SAMPLES: GLenum;     readonly SAMPLE_ALPHA_TO_COVERAGE: GLenum;     readonly SAMPLE_BUFFERS: GLenum;     readonly SAMPLE_COVERAGE: GLenum;     readonly SAMPLE_COVERAGE_INVERT: GLenum;     readonly SAMPLE_COVERAGE_VALUE: GLenum;     readonly SCISSOR_BOX: GLenum;     readonly SCISSOR_TEST: GLenum;     readonly SHADER_TYPE: GLenum;     readonly SHADING_LANGUAGE_VERSION: GLenum;     readonly SHORT: GLenum;     readonly SRC_ALPHA: GLenum;     readonly SRC_ALPHA_SATURATE: GLenum;     readonly SRC_COLOR: GLenum;     readonly STATIC_DRAW: GLenum;     readonly STENCIL_ATTACHMENT: GLenum;     readonly STENCIL_BACK_FAIL: GLenum;     readonly STENCIL_BACK_FUNC: GLenum;     readonly STENCIL_BACK_PASS_DEPTH_FAIL: GLenum;     readonly STENCIL_BACK_PASS_DEPTH_PASS: GLenum;     readonly STENCIL_BACK_REF: GLenum;     readonly STENCIL_BACK_VALUE_MASK: GLenum;     readonly STENCIL_BACK_WRITEMASK: GLenum;     readonly STENCIL_BITS: GLenum;     readonly STENCIL_BUFFER_BIT: GLenum;     readonly STENCIL_CLEAR_VALUE: GLenum;     readonly STENCIL_FAIL: GLenum;     readonly STENCIL_FUNC: GLenum;     readonly STENCIL_INDEX8: GLenum;     readonly STENCIL_PASS_DEPTH_FAIL: GLenum;     readonly STENCIL_PASS_DEPTH_PASS: GLenum;     readonly STENCIL_REF: GLenum;     readonly STENCIL_TEST: GLenum;     readonly STENCIL_VALUE_MASK: GLenum;     readonly STENCIL_WRITEMASK: GLenum;     readonly STREAM_DRAW: GLenum;     readonly SUBPIXEL_BITS: GLenum;     readonly TEXTURE: GLenum;     readonly TEXTURE0: GLenum;     readonly TEXTURE1: GLenum;     readonly TEXTURE10: GLenum;     readonly TEXTURE11: GLenum;     readonly TEXTURE12: GLenum;     readonly TEXTURE13: GLenum;     readonly TEXTURE14: GLenum;     readonly TEXTURE15: GLenum;     readonly TEXTURE16: GLenum;     readonly TEXTURE17: GLenum;     readonly TEXTURE18: GLenum;     readonly TEXTURE19: GLenum;     readonly TEXTURE2: GLenum;     readonly TEXTURE20: GLenum;     readonly TEXTURE21: GLenum;     readonly TEXTURE22: GLenum;     readonly TEXTURE23: GLenum;     readonly TEXTURE24: GLenum;     readonly TEXTURE25: GLenum;     readonly TEXTURE26: GLenum;     readonly TEXTURE27: GLenum;     readonly TEXTURE28: GLenum;     readonly TEXTURE29: GLenum;     readonly TEXTURE3: GLenum;     readonly TEXTURE30: GLenum;     readonly TEXTURE31: GLenum;     readonly TEXTURE4: GLenum;     readonly TEXTURE5: GLenum;     readonly TEXTURE6: GLenum;     readonly TEXTURE7: GLenum;     readonly TEXTURE8: GLenum;     readonly TEXTURE9: GLenum;     readonly TEXTURE_2D: GLenum;     readonly TEXTURE_BINDING_2D: GLenum;     readonly TEXTURE_BINDING_CUBE_MAP: GLenum;     readonly TEXTURE_CUBE_MAP: GLenum;     readonly TEXTURE_CUBE_MAP_NEGATIVE_X: GLenum;     readonly TEXTURE_CUBE_MAP_NEGATIVE_Y: GLenum;     readonly TEXTURE_CUBE_MAP_NEGATIVE_Z: GLenum;     readonly TEXTURE_CUBE_MAP_POSITIVE_X: GLenum;     readonly TEXTURE_CUBE_MAP_POSITIVE_Y: GLenum;     readonly TEXTURE_CUBE_MAP_POSITIVE_Z: GLenum;     readonly TEXTURE_MAG_FILTER: GLenum;     readonly TEXTURE_MIN_FILTER: GLenum;     readonly TEXTURE_WRAP_S: GLenum;     readonly TEXTURE_WRAP_T: GLenum;     readonly TRIANGLES: GLenum;     readonly TRIANGLE_FAN: GLenum;     readonly TRIANGLE_STRIP: GLenum;     readonly UNPACK_ALIGNMENT: GLenum;     readonly UNPACK_COLORSPACE_CONVERSION_WEBGL: GLenum;     readonly UNPACK_FLIP_Y_WEBGL: GLenum;     readonly UNPACK_PREMULTIPLY_ALPHA_WEBGL: GLenum;     readonly UNSIGNED_BYTE: GLenum;     readonly UNSIGNED_INT: GLenum;     readonly UNSIGNED_SHORT: GLenum;     readonly UNSIGNED_SHORT_4_4_4_4: GLenum;     readonly UNSIGNED_SHORT_5_5_5_1: GLenum;     readonly UNSIGNED_SHORT_5_6_5: GLenum;     readonly VALIDATE_STATUS: GLenum;     readonly VENDOR: GLenum;     readonly VERSION: GLenum;     readonly VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: GLenum;     readonly VERTEX_ATTRIB_ARRAY_ENABLED: GLenum;     readonly VERTEX_ATTRIB_ARRAY_NORMALIZED: GLenum;     readonly VERTEX_ATTRIB_ARRAY_POINTER: GLenum;     readonly VERTEX_ATTRIB_ARRAY_SIZE: GLenum;     readonly VERTEX_ATTRIB_ARRAY_STRIDE: GLenum;     readonly VERTEX_ATTRIB_ARRAY_TYPE: GLenum;     readonly VERTEX_SHADER: GLenum;     readonly VIEWPORT: GLenum;     readonly ZERO: GLenum; }}
+{WebGLProgram}
+{WebGLBuffer | null}
+{WebGLFramebuffer | null}
+{WebGLRenderbuffer | null}
+{WebGLTexture | null}
+{GLclampf}
+{GLsizeiptr}
+{BufferSource | null}
+{GLbitfield}
+{WebGLProgram | null}
+{WebGLShader | null}
+{WebGLActiveInfo | null}
+{WebGLShader[] | null}
+{WebGLContextAttributes | null}
+{"EXT_blend_minmax"}
+{EXT_blend_minmax | null}
+{"EXT_texture_filter_anisotropic"}
+{EXT_texture_filter_anisotropic | null}
+{"EXT_frag_depth"}
+{EXT_frag_depth | null}
+{"EXT_shader_texture_lod"}
+{EXT_shader_texture_lod | null}
+{"EXT_sRGB"}
+{EXT_sRGB | null}
+{"OES_vertex_array_object"}
+{OES_vertex_array_object | null}
+{"WEBGL_color_buffer_float"}
+{WEBGL_color_buffer_float | null}
+{"WEBGL_compressed_texture_astc"}
+{WEBGL_compressed_texture_astc | null}
+{"WEBGL_compressed_texture_s3tc_srgb"}
+{WEBGL_compressed_texture_s3tc_srgb | null}
+{"WEBGL_debug_shaders"}
+{WEBGL_debug_shaders | null}
+{"WEBGL_draw_buffers"}
+{WEBGL_draw_buffers | null}
+{"WEBGL_lose_context"}
+{WEBGL_lose_context | null}
+{"WEBGL_depth_texture"}
+{WEBGL_depth_texture | null}
+{"WEBGL_debug_renderer_info"}
+{WEBGL_debug_renderer_info | null}
+{"WEBGL_compressed_texture_s3tc"}
+{WEBGL_compressed_texture_s3tc | null}
+{"OES_texture_half_float_linear"}
+{OES_texture_half_float_linear | null}
+{"OES_texture_half_float"}
+{OES_texture_half_float | null}
+{"OES_texture_float_linear"}
+{OES_texture_float_linear | null}
+{"OES_texture_float"}
+{OES_texture_float | null}
+{"OES_standard_derivatives"}
+{OES_standard_derivatives | null}
+{"OES_element_index_uint"}
+{OES_element_index_uint | null}
+{"ANGLE_instanced_arrays"}
+{ANGLE_instanced_arrays | null}
+{WebGLShaderPrecisionFormat | null}
+{string[] | null}
+{WebGLUniformLocation}
+{WebGLUniformLocation | null}
+{GLfloat}
+{GLint | GLboolean}
+{ArrayBufferView | null}
+{TexImageSource}
+{Float32List}
+{Int32List}
+{{     prototype: WebGLShader;     new(): WebGLShader; }}
+{{     prototype: WebGLShaderPrecisionFormat;     new(): WebGLShaderPrecisionFormat; }}
+{{     prototype: WebGLTexture;     new(): WebGLTexture; }}
+{{     prototype: WebGLUniformLocation;     new(): WebGLUniformLocation; }}
+{{     prototype: WebKitPoint;     new(x?: number, y?: number): WebKitPoint; }}
+{BinaryType}
+{((this: WebSocket, ev: CloseEvent) => any) | null}
+{((this: WebSocket, ev: Event) => any) | null}
+{((this: WebSocket, ev: MessageEvent) => any) | null}
+{string | ArrayBufferLike | Blob | ArrayBufferView}
+{keyof WebSocketEventMap}
+{(this: WebSocket, ev: WebSocketEventMap[K]) => any}
+{{     prototype: WebSocket;     new(url: string, protocols?: string | string[]): WebSocket;     readonly CLOSED: number;     readonly CLOSING: number;     readonly CONNECTING: number;     readonly OPEN: number; }}
+{{     prototype: WheelEvent;     new(typeArg: string, eventInitDict?: WheelEventInit): WheelEvent;     readonly DOM_DELTA_LINE: number;     readonly DOM_DELTA_PAGE: number;     readonly DOM_DELTA_PIXEL: number; }}
+{WindowTimers}
+{WindowSessionStorage}
+{WindowLocalStorage}
+{WindowConsole}
+{IDBEnvironment}
+{WindowBase64}
+{GlobalFetch}
+{WindowOrWorkerGlobalScope}
+{typeof Blob}
+{typeof URLSearchParams}
+{ApplicationCache}
+{CacheStorage}
+{Navigator}
+{Crypto}
+{CustomElementRegistry}
+{Event | undefined}
+{External}
+{History}
+{BarProp}
+{ExtensionScriptApis}
+{string | boolean}
+{((this: Window, ev: Event) => any) | null}
+{((this: Window, ev: DeviceLightEvent) => any) | null}
+{((this: Window, ev: DeviceMotionEvent) => any) | null}
+{((this: Window, ev: DeviceOrientationEvent) => any) | null}
+{((this: Window, ev: ProgressEvent) => any) | null}
+{Performance}
+{Screen}
+{SpeechSynthesis}
+{StyleMedia}
+{FocusNavigationOrigin}
+{MediaQueryList}
+{WebKitPoint}
+{keyof WindowEventMap}
+{(this: Window, ev: WindowEventMap[K]) => any}
+{{     prototype: Window;     new(): Window; }}
+{Console}
+{((this: WindowEventHandlers, ev: Event) => any) | null}
+{((this: WindowEventHandlers, ev: BeforeUnloadEvent) => any) | null}
+{((this: WindowEventHandlers, ev: HashChangeEvent) => any) | null}
+{((this: WindowEventHandlers, ev: MessageEvent) => any) | null}
+{((this: WindowEventHandlers, ev: PageTransitionEvent) => any) | null}
+{((this: WindowEventHandlers, ev: PopStateEvent) => any) | null}
+{((this: WindowEventHandlers, ev: StorageEvent) => any) | null}
+{((this: WindowEventHandlers, ev: PromiseRejectionEvent) => any) | null}
+{keyof WindowEventHandlersEventMap}
+{(this: WindowEventHandlers, ev: WindowEventHandlersEventMap[K]) => any}
+{Storage}
+{ImageBitmapSource}
+{Promise<ImageBitmap>}
+{TimerHandler}
+{((this: Worker, ev: MessageEvent) => any) | null}
+{keyof WorkerEventMap}
+{(this: Worker, ev: WorkerEventMap[K]) => any}
+{{     prototype: Worker;     new(stringUrl: string | URL, options?: WorkerOptions): Worker; }}
+{WorkletOptions}
+{{     prototype: Worklet;     new(): Worklet; }}
+{WritableStreamDefaultWriter<W>}
+{{     prototype: WritableStream;     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>; }}
+{W}
+{(this: XMLDocument, ev: DocumentEventMap[K]) => any}
+{{     prototype: XMLDocument;     new(): XMLDocument; }}
+{XMLHttpRequestEventTargetEventMap}
+{XMLHttpRequestEventTarget}
+{((this: XMLHttpRequest, ev: Event) => any) | null}
+{XMLHttpRequestResponseType}
+{XMLHttpRequestUpload}
+{Document | BodyInit | null}
+{keyof XMLHttpRequestEventMap}
+{(this: XMLHttpRequest, ev: XMLHttpRequestEventMap[K]) => any}
+{{     prototype: XMLHttpRequest;     new(): XMLHttpRequest;     readonly DONE: number;     readonly HEADERS_RECEIVED: number;     readonly LOADING: number;     readonly OPENED: number;     readonly UNSENT: number; }}
+{((this: XMLHttpRequest, ev: ProgressEvent) => any) | null}
+{keyof XMLHttpRequestEventTargetEventMap}
+{(this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any}
+{{     prototype: XMLHttpRequestEventTarget;     new(): XMLHttpRequestEventTarget; }}
+{(this: XMLHttpRequestUpload, ev: XMLHttpRequestEventTargetEventMap[K]) => any}
+{{     prototype: XMLHttpRequestUpload;     new(): XMLHttpRequestUpload; }}
+{{     prototype: XMLSerializer;     new(): XMLSerializer; }}
+{XPathNSResolver}
+{XPathExpression}
+{{     prototype: XPathEvaluator;     new(): XPathEvaluator; }}
+{{     prototype: XPathExpression;     new(): XPathExpression; }}
+{{     prototype: XPathNSResolver;     new(): XPathNSResolver; }}
+{{     prototype: XPathResult;     new(): XPathResult;     readonly ANY_TYPE: number;     readonly ANY_UNORDERED_NODE_TYPE: number;     readonly BOOLEAN_TYPE: number;     readonly FIRST_ORDERED_NODE_TYPE: number;     readonly NUMBER_TYPE: number;     readonly ORDERED_NODE_ITERATOR_TYPE: number;     readonly ORDERED_NODE_SNAPSHOT_TYPE: number;     readonly STRING_TYPE: number;     readonly UNORDERED_NODE_ITERATOR_TYPE: number;     readonly UNORDERED_NODE_SNAPSHOT_TYPE: number; }}
+{{     prototype: XSLTProcessor;     new(): XSLTProcessor; }}
+{RTCPeerConnection}
+{(this: webkitRTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => any}
+{{     prototype: webkitRTCPeerConnection;     new(configuration: RTCConfiguration): webkitRTCPeerConnection; }}
+{EventListener | EventListenerObject}
+{Blob | null}
+{MediaKeyStatus}
+{IntersectionObserver}
+{MutationObserver}
+{MediaStreamError}
+{NotificationPermission}
+{Event | string}
+{PerformanceObserverEntryList}
+{PerformanceObserver}
+{Position}
+{PositionError}
+{ReadableByteStreamController}
+{void | PromiseLike<void>}
+{ReadableStreamDefaultController<R>}
+{TransformStreamDefaultController<O>}
+{I}
+{WritableStreamDefaultController}
+{HTMLAnchorElement}
+{HTMLAppletElement}
+{HTMLAreaElement}
+{HTMLAudioElement}
+{HTMLBaseElement}
+{HTMLBaseFontElement}
+{HTMLQuoteElement}
+{HTMLBodyElement}
+{HTMLBRElement}
+{HTMLButtonElement}
+{HTMLTableColElement}
+{HTMLDataElement}
+{HTMLDataListElement}
+{HTMLModElement}
+{HTMLDetailsElement}
+{HTMLDialogElement}
+{HTMLDirectoryElement}
+{HTMLDivElement}
+{HTMLDListElement}
+{HTMLEmbedElement}
+{HTMLFieldSetElement}
+{HTMLFontElement}
+{HTMLFormElement}
+{HTMLFrameElement}
+{HTMLFrameSetElement}
+{HTMLHeadingElement}
+{HTMLHRElement}
+{HTMLHtmlElement}
+{HTMLIFrameElement}
+{HTMLImageElement}
+{HTMLInputElement}
+{HTMLLabelElement}
+{HTMLLegendElement}
+{HTMLLIElement}
+{HTMLLinkElement}
+{HTMLMapElement}
+{HTMLMarqueeElement}
+{HTMLMenuElement}
+{HTMLMetaElement}
+{HTMLMeterElement}
+{HTMLObjectElement}
+{HTMLOListElement}
+{HTMLOptGroupElement}
+{HTMLOptionElement}
+{HTMLOutputElement}
+{HTMLParagraphElement}
+{HTMLParamElement}
+{HTMLPictureElement}
+{HTMLPreElement}
+{HTMLProgressElement}
+{HTMLScriptElement}
+{HTMLSelectElement}
+{HTMLSlotElement}
+{HTMLSourceElement}
+{HTMLSpanElement}
+{HTMLStyleElement}
+{HTMLTableElement}
+{HTMLTemplateElement}
+{HTMLTextAreaElement}
+{HTMLTableHeaderCellElement}
+{HTMLTimeElement}
+{HTMLTitleElement}
+{HTMLTrackElement}
+{HTMLUListElement}
+{HTMLVideoElement}
+{SVGCircleElement}
+{SVGClipPathElement}
+{SVGDefsElement}
+{SVGDescElement}
+{SVGEllipseElement}
+{SVGFEBlendElement}
+{SVGFEColorMatrixElement}
+{SVGFEComponentTransferElement}
+{SVGFECompositeElement}
+{SVGFEConvolveMatrixElement}
+{SVGFEDiffuseLightingElement}
+{SVGFEDisplacementMapElement}
+{SVGFEDistantLightElement}
+{SVGFEFloodElement}
+{SVGFEFuncAElement}
+{SVGFEFuncBElement}
+{SVGFEFuncGElement}
+{SVGFEFuncRElement}
+{SVGFEGaussianBlurElement}
+{SVGFEImageElement}
+{SVGFEMergeElement}
+{SVGFEMergeNodeElement}
+{SVGFEMorphologyElement}
+{SVGFEOffsetElement}
+{SVGFEPointLightElement}
+{SVGFESpecularLightingElement}
+{SVGFESpotLightElement}
+{SVGFETileElement}
+{SVGFETurbulenceElement}
+{SVGFilterElement}
+{SVGForeignObjectElement}
+{SVGGElement}
+{SVGImageElement}
+{SVGLineElement}
+{SVGLinearGradientElement}
+{SVGMarkerElement}
+{SVGMaskElement}
+{SVGMetadataElement}
+{SVGPathElement}
+{SVGPatternElement}
+{SVGPolygonElement}
+{SVGPolylineElement}
+{SVGRadialGradientElement}
+{SVGRectElement}
+{SVGStopElement}
+{SVGSVGElement}
+{SVGSwitchElement}
+{SVGSymbolElement}
+{SVGTextElement}
+{SVGTextPathElement}
+{SVGTSpanElement}
+{SVGViewElement}
+{HTMLElementTagNameMap}
+{SVGElementTagNameMap}
+{{     new(src?: string): HTMLAudioElement; }}
+{{     new(width?: number, height?: number): HTMLImageElement; }}
+{{     new(text?: string, value?: string, defaultSelected?: boolean, selected?: boolean): HTMLOptionElement; }}
+{((this: Window, ev: UIEvent) => any) | null}
+{((this: Window, ev: AnimationEvent) => any) | null}
+{((this: Window, ev: FocusEvent) => any) | null}
+{((this: Window, ev: MouseEvent) => any) | null}
+{((this: Window, ev: DragEvent) => any) | null}
+{((this: Window, ev: PointerEvent) => any) | null}
+{((this: Window, ev: KeyboardEvent) => any) | null}
+{((this: Window, ev: SecurityPolicyViolationEvent) => any) | null}
+{((this: Window, ev: TouchEvent) => any) | null}
+{((this: Window, ev: TransitionEvent) => any) | null}
+{((this: Window, ev: WheelEvent) => any) | null}
+{((this: Window, ev: BeforeUnloadEvent) => any) | null}
+{((this: Window, ev: HashChangeEvent) => any) | null}
+{((this: Window, ev: MessageEvent) => any) | null}
+{((this: Window, ev: PageTransitionEvent) => any) | null}
+{((this: Window, ev: PopStateEvent) => any) | null}
+{((this: Window, ev: StorageEvent) => any) | null}
+{((this: Window, ev: PromiseRejectionEvent) => any) | null}
+{BufferSource | Blob | string}
+{Headers | string[][] | Record<string, string>}
+{Blob | BufferSource | FormData | URLSearchParams | ReadableStream<Uint8Array> | string}
+{Request | string}
+{CanvasRenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext}
+{HTMLImageElement | SVGImageElement}
+{HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap}
+{WindowProxy | MessagePort | ServiceWorker}
+{HTMLScriptElement | SVGScriptElement}
+{CanvasImageSource | Blob | ImageData}
+{OnErrorEventHandlerNonNull | null}
+{OnBeforeUnloadEventHandlerNonNull | null}
+{string | Function}
+{PerformanceEntry[]}
+{AlgorithmIdentifier}
+{ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement}
+{Float32Array | GLfloat[]}
+{Int32Array | GLint[]}
+{ArrayBufferView | ArrayBuffer}
+{number | AutoKeyword}
+{File | string}
+{"beforebegin" | "afterbegin" | "beforeend" | "afterend"}
+{number | string | Date | BufferSource | IDBArrayKey}
+{"attributes" | "characterData" | "childList"}
+{ArrayBuffer | MessagePort | ImageBitmap}
+{RTCDtlsTransport | RTCSrtpSdesTransport}
+{"start" | "center" | "end" | "left" | "right"}
+{"idle" | "running" | "paused" | "finished"}
+{"segments" | "sequence"}
+{"balanced" | "interactive" | "playback"}
+{"suspended" | "running" | "closed"}
+{"auto"}
+{"a-rate" | "k-rate"}
+{"blob" | "arraybuffer"}
+{"lowpass" | "highpass" | "bandpass" | "lowshelf" | "highshelf" | "peaking" | "notch" | "allpass"}
+{"" | "maybe" | "probably"}
+{"ltr" | "rtl" | "inherit"}
+{"nonzero" | "evenodd"}
+{"butt" | "round" | "square"}
+{"round" | "bevel" | "miter"}
+{"start" | "end" | "left" | "right" | "center"}
+{"top" | "hanging" | "middle" | "alphabetic" | "ideographic" | "bottom"}
+{"max" | "clamped-max" | "explicit"}
+{"speakers" | "discrete"}
+{"window" | "worker" | "sharedworker" | "all"}
+{"replace" | "add" | "accumulate"}
+{"replace" | "add" | "accumulate" | "auto"}
+{"" | "rl" | "lr"}
+{"monitor" | "window" | "application" | "browser"}
+{"linear" | "inverse" | "exponential"}
+{"loading" | "interactive" | "complete"}
+{"network" | "decode"}
+{"transparent" | "native"}
+{"none" | "forwards" | "backwards" | "both" | "auto"}
+{"auto" | "show" | "hide"}
+{"" | "left" | "right"}
+{"vibration"}
+{"mouse" | "keyboard" | "gamepad"}
+{"" | "standard"}
+{"next" | "nextunique" | "prev" | "prevunique"}
+{"pending" | "done"}
+{"readonly" | "readwrite" | "versionchange"}
+{"low" | "medium" | "high"}
+{"replace" | "accumulate"}
+{"raw" | "spki" | "pkcs8" | "jwk"}
+{"public" | "private" | "secret"}
+{"encrypt" | "decrypt" | "sign" | "verify" | "deriveKey" | "deriveBits" | "wrapKey" | "unwrapKey"}
+{"start" | "center" | "end"}
+{"inactive" | "active" | "disambiguation"}
+{"FIDO_2_0"}
+{"Embedded" | "USB" | "NFC" | "BT"}
+{"unknown" | "defer" | "allow" | "deny"}
+{"geolocation" | "unlimitedIndexedDBQuota" | "media" | "pointerlock" | "webnotifications"}
+{"audioinput" | "audiooutput" | "videoinput"}
+{"license-request" | "license-renewal" | "license-release" | "individualization-request"}
+{"temporary" | "persistent-license"}
+{"usable" | "expired" | "released" | "output-restricted" | "output-downscaled" | "status-pending" | "internal-error"}
+{"required" | "optional" | "not-allowed"}
+{"live" | "ended"}
+{"up" | "down" | "left" | "right"}
+{"navigate" | "reload" | "back_forward" | "prerender"}
+{"auto" | "ltr" | "rtl"}
+{"default" | "denied" | "granted"}
+{"any" | "natural" | "landscape" | "portrait" | "portrait-primary" | "portrait-secondary" | "landscape-primary" | "landscape-secondary"}
+{"portrait-primary" | "portrait-secondary" | "landscape-primary" | "landscape-secondary"}
+{"sine" | "square" | "sawtooth" | "triangle" | "custom"}
+{"none" | "2x" | "4x"}
+{"equalpower" | "HRTF"}
+{"success" | "fail" | "unknown"}
+{"shipping" | "delivery" | "pickup"}
+{"normal" | "reverse" | "alternate" | "alternate-reverse"}
+{"line-left" | "center" | "line-right" | "auto"}
+{"p256dh" | "auth"}
+{"denied" | "granted" | "prompt"}
+{"balanced" | "max-compat" | "max-bundle"}
+{"connecting" | "open" | "closing" | "closed"}
+{"maintain-framerate" | "maintain-resolution" | "balanced"}
+{"auto" | "client" | "server"}
+{"new" | "connecting" | "connected" | "closed" | "failed"}
+{"disabled" | "enabled"}
+{"data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "idp-bad-script-failure" | "idp-execution-failure" | "idp-load-failure" | "idp-need-login" | "idp-timeout" | "idp-tls-failure" | "idp-token-expired" | "idp-token-invalid" | "sctp-failure" | "sdp-syntax-error" | "hardware-encoder-not-available" | "hardware-encoder-error"}
+{"host" | "srflx" | "prflx" | "relay"}
+{"rtp" | "rtcp"}
+{"new" | "checking" | "connected" | "completed" | "disconnected" | "failed" | "closed"}
+{"password" | "oauth"}
+{"all" | "nohost" | "relay"}
+{"new" | "gathering" | "complete"}
+{"udp" | "tcp"}
+{"controlling" | "controlled"}
+{"active" | "passive" | "so"}
+{"relay" | "all"}
+{"new" | "connecting" | "connected" | "disconnected" | "failed" | "closed"}
+{"very-low" | "low" | "medium" | "high"}
+{"negotiate" | "require"}
+{"sendrecv" | "sendonly" | "recvonly" | "inactive"}
+{"connecting" | "connected" | "closed"}
+{"offer" | "pranswer" | "answer" | "rollback"}
+{"stable" | "have-local-offer" | "have-remote-offer" | "have-local-pranswer" | "have-remote-pranswer" | "closed"}
+{"frozen" | "waiting" | "inprogress" | "failed" | "succeeded" | "cancelled"}
+{"host" | "serverreflexive" | "peerreflexive" | "relayed"}
+{"inboundrtp" | "outboundrtp" | "session" | "datachannel" | "track" | "transport" | "candidatepair" | "localcandidate" | "remotecandidate"}
+{"closed" | "open" | "ended"}
+{"" | "no-referrer" | "no-referrer-when-downgrade" | "same-origin" | "origin" | "strict-origin" | "origin-when-cross-origin" | "strict-origin-when-cross-origin" | "unsafe-url"}
+{"default" | "no-store" | "reload" | "no-cache" | "force-cache" | "only-if-cached"}
+{"omit" | "same-origin" | "include"}
+{"" | "audio" | "audioworklet" | "document" | "embed" | "font" | "image" | "manifest" | "object" | "paintworklet" | "report" | "script" | "sharedworker" | "style" | "track" | "video" | "worker" | "xslt"}
+{"navigate" | "same-origin" | "no-cors" | "cors"}
+{"follow" | "error" | "manual"}
+{"basic" | "cors" | "default" | "error" | "opaque" | "opaqueredirect"}
+{"ScopedCred"}
+{"auto" | "smooth"}
+{"start" | "center" | "end" | "nearest"}
+{"auto" | "manual"}
+{"" | "up"}
+{"select" | "start" | "end" | "preserve"}
+{"installing" | "installed" | "activating" | "activated" | "redundant"}
+{"imports" | "all" | "none"}
+{"open" | "closed"}
+{"no-speech" | "aborted" | "audio-capture" | "network" | "not-allowed" | "service-not-allowed" | "bad-grammar" | "language-not-supported"}
+{"canceled" | "interrupted" | "audio-busy" | "audio-hardware" | "network" | "synthesis-unavailable" | "synthesis-failed" | "language-unavailable" | "voice-unavailable" | "text-too-long" | "invalid-argument"}
+{"text/html" | "text/xml" | "application/xml" | "application/xhtml+xml" | "image/svg+xml"}
+{"subtitles" | "captions" | "descriptions" | "chapters" | "metadata"}
+{"disabled" | "hidden" | "showing"}
+{"direct" | "stylus"}
+{"usb" | "nfc" | "ble"}
+{"mounted" | "navigation" | "requested" | "unmounted"}
+{"user" | "environment" | "left" | "right"}
+{"hidden" | "visible" | "prerender"}
+{"default" | "low-power" | "high-performance"}
+{"classic" | "module"}
+{"" | "arraybuffer" | "blob" | "document" | "json" | "text"}
+{ActiveXObject}
+{TextStreamBase}
+{{     /**      * Outputs text to either a message box (under WScript.exe) or the command console window followed by      * a newline (under CScript.exe).      */     Echo(s: any): void;      /**      * Exposes the write-only error output stream for the current script.      * Can be accessed only while using CScript.exe.      */     StdErr: TextStreamWriter;      /**      * Exposes the write-only output stream for the current script.      * Can be accessed only while using CScript.exe.      */     StdOut: TextStreamWriter;     Arguments: { length: number; Item(n: number): string; };      /**      *  The full path of the currently running script.      */     ScriptFullName: string;      /**      * Forces the script to stop immediately, with an optional exit code.      */     Quit(exitCode?: number): number;      /**      * The Windows Script Host build version number.      */     BuildVersion: number;      /**      * Fully qualified path of the host executable.      */     FullName: string;      /**      * Gets/sets the script mode - interactive(true) or batch(false).      */     Interactive: boolean;      /**      * The name of the host executable (WScript.exe or CScript.exe).      */     Name: string;      /**      * Path of the directory containing the host executable.      */     Path: string;      /**      * The filename of the currently running script.      */     ScriptName: string;      /**      * Exposes the read-only input stream for the current script.      * Can be accessed only while using CScript.exe.      */     StdIn: TextStreamReader;      /**      * Windows Script Host version      */     Version: string;      /**      * Connects a COM object's event sources to functions named with a given prefix, in the form prefix_event.      */     ConnectObject(objEventSource: any, strPrefix: string): void;      /**      * Creates a COM object.      * @param strProgiID      * @param strPrefix Function names in the form prefix_event will be bound to this object's COM events.      */     CreateObject(strProgID: string, strPrefix?: string): any;      /**      * Disconnects a COM object from its event sources.      */     DisconnectObject(obj: any): void;      /**      * Retrieves an existing object with the specified ProgID from memory, or creates a new one from a file.      * @param strPathname Fully qualified path to the file containing the object persisted to disk.      *                       For objects in memory, pass a zero-length string.      * @param strProgID      * @param strPrefix Function names in the form prefix_event will be bound to this object's COM events.      */     GetObject(strPathname: string, strProgID?: string, strPrefix?: string): any;      /**      * Suspends script execution for a specified length of time, then continues execution.      * @param intTime Interval (in milliseconds) to suspend script execution.      */     Sleep(intTime: number): void; }}
+{typeof WScript}
+{SafeArray<T>}
+{Enumerator<T>}
+{{ Item(index: any): T }}
+{EnumeratorConstructor}
+{VBArray<T>}
+{VBArrayConstructor}
+{VarDate}
+{() => VarDate}
+{(...args: any[]) => void}
+{EventEmitter}
+{Listener}
+{Listener[]}
+{Schema.Domain[]}
+{Runtime.UnserializableValue}
+{Runtime.RemoteObjectId}
+{Runtime.ObjectPreview}
+{Runtime.CustomPreview}
+{Runtime.PropertyPreview[]}
+{Runtime.EntryPreview[]}
+{Runtime.RemoteObject}
+{Runtime.ExecutionContextId}
+{Runtime.ScriptId}
+{Runtime.StackTrace}
+{Runtime.CallFrame[]}
+{Runtime.CallFrame}
+{Runtime.CallArgument[]}
+{Runtime.ExceptionDetails}
+{Runtime.PropertyDescriptor[]}
+{Runtime.InternalPropertyDescriptor[]}
+{Runtime.ExecutionContextDescription}
+{Runtime.Timestamp}
+{Runtime.RemoteObject[]}
+{Debugger.CallFrameId}
+{Debugger.Location}
+{Debugger.Scope[]}
+{Debugger.BreakpointId}
+{Runtime.CallArgument}
+{Debugger.ScriptPosition[]}
+{Debugger.Location[]}
+{Debugger.BreakLocation[]}
+{Debugger.SearchMatch[]}
+{Debugger.CallFrame[]}
+{Console.ConsoleMessage}
+{Profiler.PositionTickInfo[]}
+{Profiler.ProfileNode[]}
+{Profiler.CoverageRange[]}
+{Profiler.FunctionCoverage[]}
+{Profiler.Profile}
+{Profiler.ScriptCoverage[]}
+{HeapProfiler.SamplingHeapProfileNode[]}
+{HeapProfiler.SamplingHeapProfileNode}
+{HeapProfiler.HeapSnapshotObjectId}
+{HeapProfiler.SamplingHeapProfile}
+{(err: Error | null, params?: {}) => void}
+{"Schema.getDomains"}
+{(err: Error | null, params: Schema.GetDomainsReturnType) => void}
+{"Runtime.evaluate"}
+{Runtime.EvaluateParameterType}
+{(err: Error | null, params: Runtime.EvaluateReturnType) => void}
+{"Runtime.awaitPromise"}
+{Runtime.AwaitPromiseParameterType}
+{(err: Error | null, params: Runtime.AwaitPromiseReturnType) => void}
+{"Runtime.callFunctionOn"}
+{Runtime.CallFunctionOnParameterType}
+{(err: Error | null, params: Runtime.CallFunctionOnReturnType) => void}
+{"Runtime.getProperties"}
+{Runtime.GetPropertiesParameterType}
+{(err: Error | null, params: Runtime.GetPropertiesReturnType) => void}
+{"Runtime.releaseObject"}
+{Runtime.ReleaseObjectParameterType}
+{(err: Error | null) => void}
+{"Runtime.releaseObjectGroup"}
+{Runtime.ReleaseObjectGroupParameterType}
+{"Runtime.runIfWaitingForDebugger"}
+{"Runtime.enable"}
+{"Runtime.disable"}
+{"Runtime.discardConsoleEntries"}
+{"Runtime.setCustomObjectFormatterEnabled"}
+{Runtime.SetCustomObjectFormatterEnabledParameterType}
+{"Runtime.compileScript"}
+{Runtime.CompileScriptParameterType}
+{(err: Error | null, params: Runtime.CompileScriptReturnType) => void}
+{"Runtime.runScript"}
+{Runtime.RunScriptParameterType}
+{(err: Error | null, params: Runtime.RunScriptReturnType) => void}
+{"Debugger.enable"}
+{"Debugger.disable"}
+{"Debugger.setBreakpointsActive"}
+{Debugger.SetBreakpointsActiveParameterType}
+{"Debugger.setSkipAllPauses"}
+{Debugger.SetSkipAllPausesParameterType}
+{"Debugger.setBreakpointByUrl"}
+{Debugger.SetBreakpointByUrlParameterType}
+{(err: Error | null, params: Debugger.SetBreakpointByUrlReturnType) => void}
+{"Debugger.setBreakpoint"}
+{Debugger.SetBreakpointParameterType}
+{(err: Error | null, params: Debugger.SetBreakpointReturnType) => void}
+{"Debugger.removeBreakpoint"}
+{Debugger.RemoveBreakpointParameterType}
+{"Debugger.getPossibleBreakpoints"}
+{Debugger.GetPossibleBreakpointsParameterType}
+{(err: Error | null, params: Debugger.GetPossibleBreakpointsReturnType) => void}
+{"Debugger.continueToLocation"}
+{Debugger.ContinueToLocationParameterType}
+{"Debugger.stepOver"}
+{"Debugger.stepInto"}
+{"Debugger.stepOut"}
+{"Debugger.pause"}
+{"Debugger.scheduleStepIntoAsync"}
+{"Debugger.resume"}
+{"Debugger.searchInContent"}
+{Debugger.SearchInContentParameterType}
+{(err: Error | null, params: Debugger.SearchInContentReturnType) => void}
+{"Debugger.setScriptSource"}
+{Debugger.SetScriptSourceParameterType}
+{(err: Error | null, params: Debugger.SetScriptSourceReturnType) => void}
+{"Debugger.restartFrame"}
+{Debugger.RestartFrameParameterType}
+{(err: Error | null, params: Debugger.RestartFrameReturnType) => void}
+{"Debugger.getScriptSource"}
+{Debugger.GetScriptSourceParameterType}
+{(err: Error | null, params: Debugger.GetScriptSourceReturnType) => void}
+{"Debugger.setPauseOnExceptions"}
+{Debugger.SetPauseOnExceptionsParameterType}
+{"Debugger.evaluateOnCallFrame"}
+{Debugger.EvaluateOnCallFrameParameterType}
+{(err: Error | null, params: Debugger.EvaluateOnCallFrameReturnType) => void}
+{"Debugger.setVariableValue"}
+{Debugger.SetVariableValueParameterType}
+{"Debugger.setAsyncCallStackDepth"}
+{Debugger.SetAsyncCallStackDepthParameterType}
+{"Debugger.setBlackboxPatterns"}
+{Debugger.SetBlackboxPatternsParameterType}
+{"Debugger.setBlackboxedRanges"}
+{Debugger.SetBlackboxedRangesParameterType}
+{"Console.enable"}
+{"Console.disable"}
+{"Console.clearMessages"}
+{"Profiler.enable"}
+{"Profiler.disable"}
+{"Profiler.setSamplingInterval"}
+{Profiler.SetSamplingIntervalParameterType}
+{"Profiler.start"}
+{"Profiler.stop"}
+{(err: Error | null, params: Profiler.StopReturnType) => void}
+{"Profiler.startPreciseCoverage"}
+{Profiler.StartPreciseCoverageParameterType}
+{"Profiler.stopPreciseCoverage"}
+{"Profiler.takePreciseCoverage"}
+{(err: Error | null, params: Profiler.TakePreciseCoverageReturnType) => void}
+{"Profiler.getBestEffortCoverage"}
+{(err: Error | null, params: Profiler.GetBestEffortCoverageReturnType) => void}
+{"HeapProfiler.enable"}
+{"HeapProfiler.disable"}
+{"HeapProfiler.startTrackingHeapObjects"}
+{HeapProfiler.StartTrackingHeapObjectsParameterType}
+{"HeapProfiler.stopTrackingHeapObjects"}
+{HeapProfiler.StopTrackingHeapObjectsParameterType}
+{"HeapProfiler.takeHeapSnapshot"}
+{HeapProfiler.TakeHeapSnapshotParameterType}
+{"HeapProfiler.collectGarbage"}
+{"HeapProfiler.getObjectByHeapObjectId"}
+{HeapProfiler.GetObjectByHeapObjectIdParameterType}
+{(err: Error | null, params: HeapProfiler.GetObjectByHeapObjectIdReturnType) => void}
+{"HeapProfiler.addInspectedHeapObject"}
+{HeapProfiler.AddInspectedHeapObjectParameterType}
+{"HeapProfiler.getHeapObjectId"}
+{HeapProfiler.GetHeapObjectIdParameterType}
+{(err: Error | null, params: HeapProfiler.GetHeapObjectIdReturnType) => void}
+{"HeapProfiler.startSampling"}
+{HeapProfiler.StartSamplingParameterType}
+{"HeapProfiler.stopSampling"}
+{(err: Error | null, params: HeapProfiler.StopSamplingReturnType) => void}
+{"inspectorNotification"}
+{(message: InspectorNotification<{}>) => void}
+{"Runtime.executionContextCreated"}
+{(message: InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>) => void}
+{"Runtime.executionContextDestroyed"}
+{(message: InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>) => void}
+{"Runtime.executionContextsCleared"}
+{() => void}
+{"Runtime.exceptionThrown"}
+{(message: InspectorNotification<Runtime.ExceptionThrownEventDataType>) => void}
+{"Runtime.exceptionRevoked"}
+{(message: InspectorNotification<Runtime.ExceptionRevokedEventDataType>) => void}
+{"Runtime.consoleAPICalled"}
+{(message: InspectorNotification<Runtime.ConsoleAPICalledEventDataType>) => void}
+{"Runtime.inspectRequested"}
+{(message: InspectorNotification<Runtime.InspectRequestedEventDataType>) => void}
+{"Debugger.scriptParsed"}
+{(message: InspectorNotification<Debugger.ScriptParsedEventDataType>) => void}
+{"Debugger.scriptFailedToParse"}
+{(message: InspectorNotification<Debugger.ScriptFailedToParseEventDataType>) => void}
+{"Debugger.breakpointResolved"}
+{(message: InspectorNotification<Debugger.BreakpointResolvedEventDataType>) => void}
+{"Debugger.paused"}
+{(message: InspectorNotification<Debugger.PausedEventDataType>) => void}
+{"Debugger.resumed"}
+{"Console.messageAdded"}
+{(message: InspectorNotification<Console.MessageAddedEventDataType>) => void}
+{"Profiler.consoleProfileStarted"}
+{(message: InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>) => void}
+{"Profiler.consoleProfileFinished"}
+{(message: InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>) => void}
+{"HeapProfiler.addHeapSnapshotChunk"}
+{(message: InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>) => void}
+{"HeapProfiler.resetProfiles"}
+{"HeapProfiler.reportHeapSnapshotProgress"}
+{(message: InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>) => void}
+{"HeapProfiler.lastSeenObjectId"}
+{(message: InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>) => void}
+{"HeapProfiler.heapStatsUpdate"}
+{(message: InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>) => void}
+{string | symbol}
+{InspectorNotification<{}>}
+{InspectorNotification<Runtime.ExecutionContextCreatedEventDataType>}
+{InspectorNotification<Runtime.ExecutionContextDestroyedEventDataType>}
+{InspectorNotification<Runtime.ExceptionThrownEventDataType>}
+{InspectorNotification<Runtime.ExceptionRevokedEventDataType>}
+{InspectorNotification<Runtime.ConsoleAPICalledEventDataType>}
+{InspectorNotification<Runtime.InspectRequestedEventDataType>}
+{InspectorNotification<Debugger.ScriptParsedEventDataType>}
+{InspectorNotification<Debugger.ScriptFailedToParseEventDataType>}
+{InspectorNotification<Debugger.BreakpointResolvedEventDataType>}
+{InspectorNotification<Debugger.PausedEventDataType>}
+{InspectorNotification<Console.MessageAddedEventDataType>}
+{InspectorNotification<Profiler.ConsoleProfileStartedEventDataType>}
+{InspectorNotification<Profiler.ConsoleProfileFinishedEventDataType>}
+{InspectorNotification<HeapProfiler.AddHeapSnapshotChunkEventDataType>}
+{InspectorNotification<HeapProfiler.ReportHeapSnapshotProgressEventDataType>}
+{InspectorNotification<HeapProfiler.LastSeenObjectIdEventDataType>}
+{InspectorNotification<HeapProfiler.HeapStatsUpdateEventDataType>}
+{NodeJS.ConsoleConstructor}
+{NodeJS.InspectOptions}
+{(err: Error, stackTraces: NodeJS.CallSite[]) => any}
+{IteratorResult<T>}
+{SymbolConstructor}
+{NodeJS.Process}
+{NodeJS.Global}
+{NodeJS.Timer}
+{Promise<T>}
+{NodeRequireFunction}
+{RequireResolve}
+{NodeExtensions}
+{NodeModule | undefined}
+{{ paths?: string[]; }}
+{(m: NodeModule, filename: string) => any}
+{NodeRequire}
+{NodeModule | null}
+{NodeModule[]}
+{NodeModule}
+{{     new(str: string, encoding?: string): Buffer;     new(size: number): Buffer;     new(size: Uint8Array): Buffer;     new(array: any[]): Buffer;     prototype: Buffer;     isBuffer(obj: any): boolean;     byteLength(string: string, encoding?: string): number;     concat(list: Buffer[], totalLength?: number): Buffer; }}
+{"ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex"}
+{NodeBuffer}
+{{     /**      * Allocates a new buffer containing the given {str}.      *      * @param str String to store in buffer.      * @param encoding encoding to use, optional.  Default is 'utf8'      */     new(str: string, encoding?: string): Buffer;     /**      * Allocates a new buffer of {size} octets.      *      * @param size count of octets to allocate.      */     new(size: number): Buffer;     /**      * Allocates a new buffer containing the given {array} of octets.      *      * @param array The octets to store.      */     new(array: Uint8Array): Buffer;     /**      * Produces a Buffer backed by the same allocated memory as      * the given {ArrayBuffer}.      *      *      * @param arrayBuffer The ArrayBuffer with which to share memory.      */     new(arrayBuffer: ArrayBuffer): Buffer;     /**      * Allocates a new buffer containing the given {array} of octets.      *      * @param array The octets to store.      */     new(array: any[]): Buffer;     /**      * Copies the passed {buffer} data onto a new {Buffer} instance.      *      * @param buffer The buffer to copy.      */     new(buffer: Buffer): Buffer;     prototype: Buffer;     /**      * Allocates a new Buffer using an {array} of octets.      */     from(array: any[]): Buffer;     /**      * When passed a reference to the .buffer property of a TypedArray instance,      * the newly created Buffer will share the same allocated memory as the TypedArray.      * The optional {byteOffset} and {length} arguments specify a memory range      * within the {arrayBuffer} that will be shared by the Buffer.      *      * @param arrayBuffer The .buffer property of a TypedArray or a new ArrayBuffer()      */     from(arrayBuffer: ArrayBuffer, byteOffset?: number, length?: number): Buffer;     /**      * Copies the passed {buffer} data onto a new Buffer instance.      */     from(buffer: Buffer): Buffer;     /**      * Creates a new Buffer containing the given JavaScript string {str}.      * If provided, the {encoding} parameter identifies the character encoding.      * If not provided, {encoding} defaults to 'utf8'.      */     from(str: string, encoding?: string): Buffer;     /**      * Returns true if {obj} is a Buffer      *      * @param obj object to test.      */     isBuffer(obj: any): obj is Buffer;     /**      * Returns true if {encoding} is a valid encoding argument.      * Valid string encodings in Node 0.12: 'ascii'|'utf8'|'utf16le'|'ucs2'(alias of 'utf16le')|'base64'|'binary'(deprecated)|'hex'      *      * @param encoding string to test.      */     isEncoding(encoding: string): boolean;     /**      * Gives the actual byte length of a string. encoding defaults to 'utf8'.      * This is not the same as String.prototype.length since that returns the number of characters in a string.      *      * @param string string to test. (TypedArray is also allowed, but it is only available starting ES2017)      * @param encoding encoding used to evaluate (defaults to 'utf8')      */     byteLength(string: string | Buffer | DataView | ArrayBuffer, encoding?: string): number;     /**      * Returns a buffer which is the result of concatenating all the buffers in the list together.      *      * If the list has no items, or if the totalLength is 0, then it returns a zero-length buffer.      * If the list has exactly one item, then the first item of the list is returned.      * If the list has more than one item, then a new Buffer is created.      *      * @param list An array of Buffer objects to concatenate      * @param totalLength Total length of the buffers when concatenated.      *   If totalLength is not provided, it is read from the buffers in the list. However, this adds an additional loop to the function, so it is faster to provide the length explicitly.      */     concat(list: Buffer[], totalLength?: number): Buffer;     /**      * The same as buf1.compare(buf2).      */     compare(buf1: Buffer, buf2: Buffer): number;     /**      * Allocates a new buffer of {size} octets.      *      * @param size count of octets to allocate.      * @param fill if specified, buffer will be initialized by calling buf.fill(fill).      *    If parameter is omitted, buffer will be filled with zeros.      * @param encoding encoding used for call to buf.fill while initalizing      */     alloc(size: number, fill?: string | Buffer | number, encoding?: string): Buffer;     /**      * Allocates a new buffer of {size} octets, leaving memory not initialized, so the contents      * of the newly created Buffer are unknown and may contain sensitive data.      *      * @param size count of octets to allocate      */     allocUnsafe(size: number): Buffer;     /**      * Allocates a new non-pooled buffer of {size} octets, leaving memory not initialized, so the contents      * of the newly created Buffer are unknown and may contain sensitive data.      *      * @param size count of octets to allocate      */     allocUnsafeSlow(size: number): Buffer;     /**      * This is the number of bytes used to determine the size of pre-allocated, internal Buffer instances used for pooling. This value may be modified.      */     poolSize: number; }}
+{WritableStream}
+{Function | undefined}
+{Function[]}
+{Array<string | symbol>}
+{string | Buffer}
+{{ end?: boolean; }}
+{Buffer}
+{ReadableStream}
+{Buffer | string}
+{Events}
+{(err: Error, data: any) => any}
+{(data: any) => any}
+{'aix'         | 'android'         | 'darwin'         | 'freebsd'         | 'linux'         | 'openbsd'         | 'sunos'         | 'win32'         | 'cygwin'}
+{"SIGABRT" | "SIGALRM" | "SIGBUS" | "SIGCHLD" | "SIGCONT" | "SIGFPE" | "SIGHUP" | "SIGILL" | "SIGINT" | "SIGIO" |         "SIGIOT" | "SIGKILL" | "SIGPIPE" | "SIGPOLL" | "SIGPROF" | "SIGPWR" | "SIGQUIT" | "SIGSEGV" | "SIGSTKFLT" |         "SIGSTOP" | "SIGSYS" | "SIGTERM" | "SIGTRAP" | "SIGTSTP" | "SIGTTIN" | "SIGTTOU" | "SIGUNUSED" | "SIGURG" |         "SIGUSR1" | "SIGUSR2" | "SIGVTALRM" | "SIGWINCH" | "SIGXCPU" | "SIGXFSZ" | "SIGBREAK" | "SIGLOST" | "SIGINFO"}
+{(code: number) => void}
+{(promise: Promise<any>) => void}
+{(error: Error) => void}
+{(reason: any, promise: Promise<any>) => void}
+{(warning: Error) => void}
+{(message: any, sendHandle: any) => void}
+{(signal: Signals) => void}
+{(type: string | symbol, listener: (...args: any[]) => void) => void}
+{ReadWriteStream}
+{Socket}
+{WriteStream}
+{ReadStream}
+{string | Error}
+{ProcessEnv}
+{Array<string | number>}
+{((err: Error) => void) | null}
+{ProcessVersions}
+{{             target_defaults: {                 cflags: any[];                 default_configuration: string;                 defines: string[];                 include_dirs: string[];                 libraries: string[];             };             variables: {                 clang: number;                 host_arch: string;                 node_install_npm: boolean;                 node_install_waf: boolean;                 node_prefix: string;                 node_shared_openssl: boolean;                 node_shared_v8: boolean;                 node_shared_zlib: boolean;                 node_use_dtrace: boolean;                 node_use_etw: boolean;                 node_use_openssl: boolean;                 target_arch: string;                 v8_no_strict_aliasing: number;                 v8_use_snapshot: boolean;                 visibility: string;             };         }}
+{Platform}
+{MemoryUsage}
+{CpuUsage}
+{[number, number]}
+{Domain}
+{"beforeExit"}
+{BeforeExitListener}
+{"disconnect"}
+{DisconnectListener}
+{"exit"}
+{ExitListener}
+{"rejectionHandled"}
+{RejectionHandledListener}
+{"uncaughtException"}
+{UncaughtExceptionListener}
+{"unhandledRejection"}
+{UnhandledRejectionListener}
+{"warning"}
+{WarningListener}
+{"message"}
+{MessageListener}
+{Signals}
+{SignalsListener}
+{"newListener"}
+{NewListenerListener}
+{"removeListener"}
+{RemoveListenerListener}
+{BeforeExitListener[]}
+{DisconnectListener[]}
+{ExitListener[]}
+{RejectionHandledListener[]}
+{UncaughtExceptionListener[]}
+{UnhandledRejectionListener[]}
+{WarningListener[]}
+{MessageListener[]}
+{SignalsListener[]}
+{NewListenerListener[]}
+{RemoveListenerListener[]}
+{typeof Array}
+{typeof ArrayBuffer}
+{typeof Boolean}
+{typeof Buffer}
+{typeof DataView}
+{typeof Date}
+{typeof Error}
+{typeof EvalError}
+{typeof Float32Array}
+{typeof Float64Array}
+{typeof Function}
+{Global}
+{typeof Infinity}
+{typeof Int16Array}
+{typeof Int32Array}
+{typeof Int8Array}
+{typeof Intl}
+{typeof JSON}
+{MapConstructor}
+{typeof Math}
+{typeof NaN}
+{typeof Number}
+{typeof Object}
+{typeof RangeError}
+{typeof ReferenceError}
+{typeof RegExp}
+{SetConstructor}
+{typeof String}
+{typeof SyntaxError}
+{typeof TypeError}
+{typeof URIError}
+{typeof Uint16Array}
+{typeof Uint32Array}
+{typeof Uint8Array}
+{WeakMapConstructor}
+{WeakSetConstructor}
+{(immediateId: any) => void}
+{(intervalId: NodeJS.Timer) => void}
+{(timeoutId: NodeJS.Timer) => void}
+{typeof console}
+{typeof decodeURI}
+{typeof decodeURIComponent}
+{typeof encodeURI}
+{typeof encodeURIComponent}
+{(str: string) => string}
+{typeof eval}
+{typeof isFinite}
+{typeof isNaN}
+{typeof parseFloat}
+{typeof parseInt}
+{Process}
+{(callback: (...args: any[]) => void, ...args: any[]) => any}
+{(callback: (...args: any[]) => void, ms: number, ...args: any[]) => NodeJS.Timer}
+{typeof undefined}
+{typeof Module}
+{Module | null}
+{Module[]}
+{Module}
+{{ type: 'Buffer', data: any[] }}
+{string | number | Buffer}
+{IterableIterator<[number, number]>}
+{IterableIterator<number>}
+{typeof SlowBuffer}
+{StringifyOptions}
+{ParseOptions}
+{ParsedUrlQuery}
+{NodeJS.EventEmitter}
+{internal}
+{string | string[] | undefined}
+{number | string | string[] | undefined}
+{OutgoingHttpHeaders}
+{Agent | boolean}
+{Agent}
+{(options: ClientRequestArgs, oncreate: (err: Error, socket: net.Socket) => void) => net.Socket}
+{net.Server}
+{(req: IncomingMessage, res: ServerResponse) => void}
+{IncomingMessage}
+{net.Socket}
+{stream.Writable}
+{number | string | string[]}
+{OutgoingHttpHeaders | Array<[string, string]>}
+{OutgoingMessage}
+{string | URL | ClientRequestArgs}
+{(res: IncomingMessage) => void}
+{stream.Readable}
+{IncomingHttpHeaders}
+{{ [key: string]: string | undefined }}
+{AgentOptions}
+{{         [errorCode: number]: string | undefined;         [errorCode: string]: string | undefined;     }}
+{(request: IncomingMessage, response: ServerResponse) => void}
+{Server}
+{ClientRequestArgs}
+{RequestOptions | string | URL}
+{ClientRequest}
+{number | (() => number)}
+{number | "udp4" | "udp6"}
+{events.EventEmitter}
+{child.ChildProcess}
+{"error"}
+{(code: number, signal: string) => void}
+{"listening"}
+{(address: Address) => void}
+{(message: any, handle: net.Socket | net.Server) => void}
+{"online"}
+{Address}
+{net.Socket | net.Server}
+{Worker}
+{ClusterSettings}
+{{             [index: string]: Worker | undefined         }}
+{(worker: Worker) => void}
+{(worker: Worker, code: number, signal: string) => void}
+{"fork"}
+{(worker: Worker, address: Address) => void}
+{(worker: Worker, message: any, handle: net.Socket | net.Server) => void}
+{"setup"}
+{(settings: any) => void}
+{{         [index: string]: Worker | undefined     }}
+{Cluster}
+{number | (() => void)}
+{stream.Transform}
+{Zlib}
+{ZlibReset}
+{ZlibParams}
+{ZlibOptions}
+{Gzip}
+{Gunzip}
+{Deflate}
+{Inflate}
+{DeflateRaw}
+{InflateRaw}
+{Unzip}
+{string | Buffer | DataView | ArrayBuffer}
+{InputType}
+{(error: Error | null, result: Buffer) => void}
+{{             user: number;             nice: number;             sys: number;             idle: number;             irq: number;         }}
+{NetworkInterfaceBase}
+{"IPv4"}
+{"IPv6"}
+{NetworkInterfaceInfoIPv4 | NetworkInterfaceInfoIPv6}
+{CpuInfo[]}
+{{ [index: string]: NetworkInterfaceInfo[] }}
+{{ encoding: string }}
+{{ username: string, uid: number, gid: number, shell: any, homedir: string }}
+{{         UV_UDP_REUSEADDR: number,         signals: {             SIGHUP: number;             SIGINT: number;             SIGQUIT: number;             SIGILL: number;             SIGTRAP: number;             SIGABRT: number;             SIGIOT: number;             SIGBUS: number;             SIGFPE: number;             SIGKILL: number;             SIGUSR1: number;             SIGSEGV: number;             SIGUSR2: number;             SIGPIPE: number;             SIGALRM: number;             SIGTERM: number;             SIGCHLD: number;             SIGSTKFLT: number;             SIGCONT: number;             SIGSTOP: number;             SIGTSTP: number;             SIGTTIN: number;             SIGTTOU: number;             SIGURG: number;             SIGXCPU: number;             SIGXFSZ: number;             SIGVTALRM: number;             SIGPROF: number;             SIGWINCH: number;             SIGIO: number;             SIGPOLL: number;             SIGPWR: number;             SIGSYS: number;             SIGUNUSED: number;         },         errno: {             E2BIG: number;             EACCES: number;             EADDRINUSE: number;             EADDRNOTAVAIL: number;             EAFNOSUPPORT: number;             EAGAIN: number;             EALREADY: number;             EBADF: number;             EBADMSG: number;             EBUSY: number;             ECANCELED: number;             ECHILD: number;             ECONNABORTED: number;             ECONNREFUSED: number;             ECONNRESET: number;             EDEADLK: number;             EDESTADDRREQ: number;             EDOM: number;             EDQUOT: number;             EEXIST: number;             EFAULT: number;             EFBIG: number;             EHOSTUNREACH: number;             EIDRM: number;             EILSEQ: number;             EINPROGRESS: number;             EINTR: number;             EINVAL: number;             EIO: number;             EISCONN: number;             EISDIR: number;             ELOOP: number;             EMFILE: number;             EMLINK: number;             EMSGSIZE: number;             EMULTIHOP: number;             ENAMETOOLONG: number;             ENETDOWN: number;             ENETRESET: number;             ENETUNREACH: number;             ENFILE: number;             ENOBUFS: number;             ENODATA: number;             ENODEV: number;             ENOENT: number;             ENOEXEC: number;             ENOLCK: number;             ENOLINK: number;             ENOMEM: number;             ENOMSG: number;             ENOPROTOOPT: number;             ENOSPC: number;             ENOSR: number;             ENOSTR: number;             ENOSYS: number;             ENOTCONN: number;             ENOTDIR: number;             ENOTEMPTY: number;             ENOTSOCK: number;             ENOTSUP: number;             ENOTTY: number;             ENXIO: number;             EOPNOTSUPP: number;             EOVERFLOW: number;             EPERM: number;             EPIPE: number;             EPROTO: number;             EPROTONOSUPPORT: number;             EPROTOTYPE: number;             ERANGE: number;             EROFS: number;             ESPIPE: number;             ESRCH: number;             ESTALE: number;             ETIME: number;             ETIMEDOUT: number;             ETXTBSY: number;             EWOULDBLOCK: number;             EXDEV: number;         },     }}
+{NodeJS.Platform}
+{"BE" | "LE"}
+{tls.SecureContextOptions & tls.TlsOptions}
+{http.RequestOptions & tls.SecureContextOptions & {         rejectUnauthorized?: boolean; // Defaults to true         servername?: string; // SNI TLS Extension     }}
+{http.AgentOptions}
+{tls.ConnectionOptions}
+{http.Agent}
+{tls.Server}
+{ServerOptions}
+{(req: http.IncomingMessage, res: http.ServerResponse) => void}
+{(res: http.IncomingMessage) => void}
+{http.ClientRequest}
+{ucs2}
+{NodeJS.ReadableStream}
+{NodeJS.WritableStream}
+{readline.ReadLine}
+{Function | { help: string, action: Function }}
+{"reset"}
+{string | ReplOptions}
+{REPLServer}
+{(answer: string) => void}
+{ReadLine}
+{Key}
+{"close"}
+{"line"}
+{(input: any) => void}
+{"pause"}
+{"resume"}
+{"SIGCONT"}
+{"SIGINT"}
+{"SIGTSTP"}
+{(line: string) => CompleterResult}
+{(line: string, callback: (err: any, result: CompleterResult) => void) => any}
+{[string[], string]}
+{Completer | AsyncCompleter}
+{ReadLineOptions}
+{ScriptOptions}
+{Context}
+{RunningScriptOptions}
+{RunningScriptOptions | string}
+{[stream.Writable, stream.Readable, stream.Readable]}
+{MessageOptions}
+{(err: Error) => void}
+{(message: any, sendHandle: net.Socket | net.Server) => void}
+{boolean | string}
+{SpawnOptions}
+{ChildProcess}
+{ExecOptions}
+{BufferEncoding}
+{(error: Error | null, stdout: string, stderr: string) => void}
+{{ encoding: "buffer" | null } & ExecOptions}
+{(error: Error | null, stdout: Buffer, stderr: Buffer) => void}
+{{ encoding: BufferEncoding } & ExecOptions}
+{{ encoding: string } & ExecOptions}
+{(error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void}
+{({ encoding?: string | null } & ExecOptions) | undefined | null}
+{Promise<{ stdout: string, stderr: string }>}
+{Promise<{ stdout: Buffer, stderr: Buffer }>}
+{({ encoding?: string | null } & ExecOptions) | null}
+{Promise<{ stdout: string | Buffer, stderr: string | Buffer }>}
+{ExecFileOptions}
+{'buffer' | null}
+{({ encoding?: string | null } & ExecFileOptions) | undefined | null}
+{string[] | undefined | null}
+{ExecFileOptionsWithBufferEncoding}
+{ExecFileOptionsWithStringEncoding}
+{ExecFileOptionsWithOtherEncoding}
+{((error: Error | null, stdout: string | Buffer, stderr: string | Buffer) => void) | undefined | null}
+{ForkOptions}
+{SpawnSyncOptions}
+{SpawnSyncReturns<Buffer>}
+{SpawnSyncOptionsWithStringEncoding}
+{SpawnSyncReturns<string>}
+{SpawnSyncOptionsWithBufferEncoding}
+{ExecSyncOptions}
+{ExecSyncOptionsWithStringEncoding}
+{ExecSyncOptionsWithBufferEncoding}
+{ExecFileSyncOptions}
+{ExecFileSyncOptionsWithStringEncoding}
+{ExecFileSyncOptionsWithBufferEncoding}
+{UrlObjectCommon}
+{string | null | { [key: string]: any }}
+{string | null | ParsedUrlQuery}
+{Url}
+{UrlWithStringQuery}
+{false | undefined}
+{UrlWithParsedQuery}
+{URLFormatOptions}
+{UrlObject | string}
+{Iterable<[string, string]>}
+{URLSearchParams | string | { [key: string]: string | string[] | undefined } | Iterable<[string, string]> | Array<[string, string]>}
+{IterableIterator<[string, string]>}
+{(value: string, name: string) => void}
+{IterableIterator<string>}
+{string | URL}
+{LookupOptions}
+{false}
+{(err: NodeJS.ErrnoException, address: string, family: number) => void}
+{LookupOneOptions}
+{LookupAllOptions}
+{(err: NodeJS.ErrnoException, addresses: LookupAddress[]) => void}
+{(err: NodeJS.ErrnoException, address: string | LookupAddress[], family: number) => void}
+{Promise<{ address: LookupAddress[] }>}
+{LookupOneOptions | number}
+{Promise<{ address: string, family: number }>}
+{LookupOptions | number}
+{Promise<{ address: string | LookupAddress[], family?: number }>}
+{ResolveOptions}
+{(err: NodeJS.ErrnoException, addresses: string[]) => void}
+{"A"}
+{"AAAA"}
+{"CNAME"}
+{"MX"}
+{(err: NodeJS.ErrnoException, addresses: MxRecord[]) => void}
+{"NAPTR"}
+{(err: NodeJS.ErrnoException, addresses: NaptrRecord[]) => void}
+{"NS"}
+{"PTR"}
+{"SOA"}
+{(err: NodeJS.ErrnoException, addresses: SoaRecord) => void}
+{"SRV"}
+{(err: NodeJS.ErrnoException, addresses: SrvRecord[]) => void}
+{"TXT"}
+{(err: NodeJS.ErrnoException, addresses: string[][]) => void}
+{(err: NodeJS.ErrnoException, addresses: string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][]) => void}
+{"A" | "AAAA" | "CNAME" | "NS" | "PTR"}
+{Promise<MxRecord[]>}
+{Promise<NaptrRecord[]>}
+{Promise<SoaRecord>}
+{Promise<SrvRecord[]>}
+{Promise<string[][]>}
+{Promise<string[] | MxRecord[] | NaptrRecord[] | SoaRecord | SrvRecord[] | string[][]>}
+{ResolveWithTtlOptions}
+{(err: NodeJS.ErrnoException, addresses: RecordWithTtl[]) => void}
+{(err: NodeJS.ErrnoException, addresses: string[] | RecordWithTtl[]) => void}
+{Promise<RecordWithTtl[]>}
+{Promise<string[] | RecordWithTtl[]>}
+{(err: NodeJS.ErrnoException, address: SoaRecord) => void}
+{(err: NodeJS.ErrnoException, hostnames: string[]) => void}
+{(hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException | null, address: string, family: number) => void) => void}
+{LookupFunction}
+{TcpSocketConnectOpts | IpcSocketConnectOpts}
+{stream.Duplex}
+{SocketConstructorOpts}
+{SocketConnectOpts}
+{{ port: number; family: string; address: string; }}
+{(had_error: boolean) => void}
+{"connect"}
+{"data"}
+{(data: Buffer) => void}
+{"drain"}
+{"end"}
+{"lookup"}
+{(err: Error, address: string, family: string | number, host: string) => void}
+{"timeout"}
+{(socket: Socket) => void}
+{{ allowHalfOpen?: boolean, pauseOnConnect?: boolean }}
+{ListenOptions}
+{(error: Error | null, count: number) => void}
+{"connection"}
+{TcpSocketConnectOpts}
+{IpcSocketConnectOpts}
+{TcpNetConnectOpts | IpcNetConnectOpts}
+{NetConnectOpts}
+{"udp4" | "udp6"}
+{SocketType}
+{(hostname: string, options: dns.LookupOneOptions, callback: (err: NodeJS.ErrnoException, address: string, family: number) => void) => void}
+{(msg: Buffer, rinfo: RemoteInfo) => void}
+{SocketOptions}
+{Buffer | String | any[]}
+{(error: Error | null, bytes: number) => void}
+{BindOptions}
+{AddressInfo}
+{(msg: Buffer, rinfo: AddressInfo) => void}
+{string | Buffer | URL}
+{"change"}
+{(eventType: string, filename: string | Buffer) => void}
+{"open"}
+{(fd: number) => void}
+{PathLike}
+{(err: NodeJS.ErrnoException) => void}
+{number | undefined | null}
+{(err: NodeJS.ErrnoException, stats: Stats) => void}
+{Promise<Stats>}
+{Stats}
+{string | undefined | null}
+{{ encoding?: BufferEncoding | null } | BufferEncoding | undefined | null}
+{(err: NodeJS.ErrnoException, linkString: string) => void}
+{{ encoding: "buffer" } | "buffer"}
+{(err: NodeJS.ErrnoException, linkString: Buffer) => void}
+{{ encoding?: string | null } | string | undefined | null}
+{(err: NodeJS.ErrnoException, linkString: string | Buffer) => void}
+{{ encoding?: BufferEncoding | null } | BufferEncoding | null}
+{Promise<Buffer>}
+{{ encoding?: string | null } | string | null}
+{Promise<string | Buffer>}
+{(err: NodeJS.ErrnoException, resolvedPath: string) => void}
+{(err: NodeJS.ErrnoException, resolvedPath: Buffer) => void}
+{(err: NodeJS.ErrnoException, resolvedPath: string | Buffer) => void}
+{number | string | undefined | null}
+{number | string | null}
+{(err: NodeJS.ErrnoException, folder: string) => void}
+{"buffer" | { encoding: "buffer" }}
+{(err: NodeJS.ErrnoException, folder: Buffer) => void}
+{(err: NodeJS.ErrnoException, folder: string | Buffer) => void}
+{{ encoding: BufferEncoding | null } | BufferEncoding | undefined | null}
+{(err: NodeJS.ErrnoException, files: string[]) => void}
+{(err: NodeJS.ErrnoException, files: Buffer[]) => void}
+{(err: NodeJS.ErrnoException, files: string[] | Buffer[]) => void}
+{{ encoding: BufferEncoding | null } | BufferEncoding | null}
+{Promise<Buffer[]>}
+{Promise<string[] | Buffer[]>}
+{Buffer[]}
+{string[] | Buffer[]}
+{string | number | undefined | null}
+{(err: NodeJS.ErrnoException, fd: number) => void}
+{string | number | null}
+{Promise<number>}
+{string | number | Date}
+{Buffer | Uint8Array}
+{TBuffer}
+{(err: NodeJS.ErrnoException, written: number, buffer: TBuffer) => void}
+{(err: NodeJS.ErrnoException, written: number, str: string) => void}
+{Promise<{ bytesWritten: number, buffer: TBuffer }>}
+{Promise<{ bytesWritten: number, buffer: string }>}
+{(err: NodeJS.ErrnoException, bytesRead: number, buffer: TBuffer) => void}
+{Promise<{ bytesRead: number, buffer: TBuffer }>}
+{PathLike | number}
+{{ encoding?: null; flag?: string; } | undefined | null}
+{(err: NodeJS.ErrnoException, data: Buffer) => void}
+{{ encoding: string; flag?: string; } | string}
+{(err: NodeJS.ErrnoException, data: string) => void}
+{{ encoding?: string | null; flag?: string; } | string | undefined | null}
+{(err: NodeJS.ErrnoException, data: string | Buffer) => void}
+{{ encoding?: null; flag?: string; } | null}
+{{ encoding?: string | null; flag?: string; } | string | null}
+{{ encoding?: string | null; mode?: number | string; flag?: string; } | string | undefined | null}
+{{ encoding?: string | null; mode?: number | string; flag?: string; } | string | null}
+{{ encoding?: string | null, mode?: string | number, flag?: string } | string | undefined | null}
+{{ encoding?: string | null, mode?: string | number, flag?: string } | string | null}
+{{ persistent?: boolean; interval?: number; } | undefined}
+{(curr: Stats, prev: Stats) => void}
+{{ encoding?: BufferEncoding | null, persistent?: boolean, recursive?: boolean } | BufferEncoding | undefined | null}
+{(event: string, filename: string) => void}
+{FSWatcher}
+{{ encoding: "buffer", persistent?: boolean, recursive?: boolean } | "buffer"}
+{(event: string, filename: Buffer) => void}
+{{ encoding?: string | null, persistent?: boolean, recursive?: boolean } | string | null}
+{(event: string, filename: string | Buffer) => void}
+{(event: string, filename: string) => any}
+{(exists: boolean) => void}
+{string | {         flags?: string;         encoding?: string;         fd?: number;         mode?: number;         autoClose?: boolean;         start?: number;         end?: number;         highWaterMark?: number;     }}
+{string | {         flags?: string;         encoding?: string;         fd?: number;         mode?: number;         autoClose?: boolean;         start?: number;     }}
+{'\\' | '/'}
+{';' | ':'}
+{ParsedPath}
+{FormatInputPathObject}
+{{         new(encoding?: string): NodeStringDecoder;     }}
+{Certificate}
+{{ [index: string]: string[] | undefined }}
+{PeerCertificate}
+{DetailedPeerCertificate}
+{{             /**              * An optional TLS context object from tls.createSecureContext()              */             secureContext?: SecureContext,             /**              * If true the TLS socket will be instantiated in server-mode.              * Defaults to false.              */             isServer?: boolean,             /**              * An optional net.Server instance.              */             server?: net.Server,             /**              * If true the server will request a certificate from clients that              * connect and attempt to verify that certificate. Defaults to              * false.              */             requestCert?: boolean,             /**              * If true the server will reject any connection which is not              * authorized with the list of supplied CAs. This option only has an              * effect if requestCert is true. Defaults to false.              */             rejectUnauthorized?: boolean,             /**              * An array of strings or a Buffer naming possible NPN protocols.              * (Protocols should be ordered by their priority.)              */             NPNProtocols?: string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array,             /**              * An array of strings or a Buffer naming possible ALPN protocols.              * (Protocols should be ordered by their priority.) When the server              * receives both NPN and ALPN extensions from the client, ALPN takes              * precedence over NPN and the server does not send an NPN extension              * to the client.              */             ALPNProtocols?: string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array,             /**              * SNICallback(servername, cb) <Function> A function that will be              * called if the client supports SNI TLS extension. Two arguments              * will be passed when called: servername and cb. SNICallback should              * invoke cb(null, ctx), where ctx is a SecureContext instance.              * (tls.createSecureContext(...) can be used to get a proper              * SecureContext.) If SNICallback wasn't provided the default callback              * with high-level API will be used (see below).              */             SNICallback?: (servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void,             /**              * An optional Buffer instance containing a TLS session.              */             session?: Buffer,             /**              * If true, specifies that the OCSP status request extension will be              * added to the client hello and an 'OCSPResponse' event will be              * emitted on the socket before establishing a secure communication              */             requestOCSP?: boolean         }}
+{CipherNameAndProtocol}
+{PeerCertificate | DetailedPeerCertificate}
+{{ rejectUnauthorized?: boolean, requestCert?: boolean }}
+{"OCSPResponse"}
+{(response: Buffer) => void}
+{"secureConnect"}
+{SecureContextOptions}
+{string[] | Buffer[] | Uint8Array[] | Buffer | Uint8Array}
+{(servername: string, cb: (err: Error | null, ctx: SecureContext) => void) => void}
+{typeof checkServerIdentity}
+{SecureContext}
+{net.LookupFunction}
+{{             key: string;             cert: string;             ca: string;         }}
+{"tlsClientError"}
+{(err: Error, tlsSocket: TLSSocket) => void}
+{"newSession"}
+{(sessionId: any, sessionData: any, callback: (err: Error, resp: Buffer) => void) => void}
+{"OCSPRequest"}
+{(certificate: Buffer, issuer: Buffer, callback: Function) => void}
+{"resumeSession"}
+{(sessionId: any, callback: (err: Error, sessionData: any) => void) => void}
+{"secureConnection"}
+{(tlsSocket: TLSSocket) => void}
+{TLSSocket}
+{(err: Error, resp: Buffer) => void}
+{(err: Error, sessionData: any) => void}
+{{             name: string;             version: string;         }}
+{{             port: number;             family: string;             address: string;         }}
+{string | Buffer | Array<string | Buffer | Object>}
+{string | Buffer | Array<Buffer | Object>}
+{string | Buffer | Array<string | Buffer>}
+{Error | undefined}
+{TlsOptions}
+{(socket: TLSSocket) => void}
+{ConnectionOptions}
+{crypto.Credentials}
+{SecurePair}
+{{         new(): Certificate;         (): Certificate;     }}
+{CredentialDetails}
+{Credentials}
+{Hash}
+{Hmac}
+{"utf8" | "ascii" | "latin1"}
+{"latin1" | "hex" | "base64"}
+{"utf8" | "ascii" | "binary"}
+{"binary" | "base64" | "hex"}
+{"compressed" | "uncompressed" | "hybrid"}
+{NodeJS.ReadWriteStream}
+{string | Buffer | DataView}
+{Utf8AsciiLatin1Encoding}
+{HexBase64Latin1Encoding}
+{Cipher}
+{Buffer | DataView}
+{Utf8AsciiBinaryEncoding}
+{HexBase64BinaryEncoding}
+{Decipher}
+{Signer}
+{string | { key: string; passphrase: string }}
+{Verify}
+{string | Object}
+{DiffieHellman}
+{number | Buffer}
+{(err: Error, derivedKey: Buffer) => any}
+{(err: Error, buf: Buffer) => void}
+{(err: Error, buf: Uint8Array) => void}
+{string | RsaPublicKey}
+{string | RsaPrivateKey}
+{ECDHKeyFormat}
+{ECDH}
+{(this: Readable, size?: number) => any}
+{(error?: Error) => any}
+{Stream}
+{ReadableOptions}
+{(chunk: Buffer | string) => void}
+{"readable"}
+{(chunk: string | Buffer, encoding: string, callback: Function) => any}
+{(chunks: Array<{ chunk: string | Buffer, encoding: string }>, callback: Function) => any}
+{(callback: (error?: Error) => void) => void}
+{WritableOptions}
+{(err?: Error) => void}
+{Array<{ chunk: any, encoding: string }>}
+{"finish"}
+{"pipe"}
+{(src: Readable) => void}
+{"unpipe"}
+{Readable}
+{Writable}
+{DuplexOptions}
+{(callback: Function) => any}
+{Duplex}
+{TransformOptions}
+{Transform}
+{{         (object: any, showHidden?: boolean, depth?: number | null, color?: boolean): string;         (object: any, options: InspectOptions): string;         colors: {             [color: string]: [number, number] | undefined         }         styles: {             [style: string]: string | undefined         }         defaultOptions: InspectOptions;         custom: symbol;     }}
+{object is any[]}
+{object is RegExp}
+{object is Date}
+{object is Error}
+{(msg: string, ...param: any[]) => void}
+{object is boolean}
+{object is Buffer}
+{object is null}
+{object is null | undefined}
+{object is number}
+{object is string}
+{object is symbol}
+{object is undefined}
+{TCustom}
+{() => Promise<void>}
+{(callback: (err: NodeJS.ErrnoException) => void) => void}
+{() => Promise<TResult>}
+{(callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1) => Promise<void>}
+{(arg1: T1, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1) => Promise<TResult>}
+{(arg1: T1, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2) => Promise<void>}
+{(arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1, arg2: T2) => Promise<TResult>}
+{(arg1: T1, arg2: T2, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3) => Promise<void>}
+{(arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3) => Promise<TResult>}
+{(arg1: T1, arg2: T2, arg3: T3, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<void>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4) => Promise<TResult>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<void>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5) => Promise<TResult>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<void>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6) => Promise<TResult>}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, callback: (err: NodeJS.ErrnoException, result: TResult) => void) => void}
+{CustomPromisify<TCustom>}
+{(callback: (err: Error | null, result: TResult) => void) => void}
+{(callback: (err: Error | null) => void) => void}
+{(arg1: T1, callback: (err: Error | null, result: TResult) => void) => void}
+{(arg1: T1, callback: (err: Error | null) => void) => void}
+{(arg1: T1, arg2: T2, callback: (err: Error | null, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, callback: (err: Error | null) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, callback: (err: Error | null) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, callback: (err: Error | null) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null, result: TResult) => void) => void}
+{(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, callback: (err: Error | null) => void) => void}
+{{                 message?: string; actual?: any; expected?: any;                 operator?: string; stackStartFunction?: Function             }}
+{(err: any) => boolean}
+{NodeJS.Domain}
+{0 | 1}
+{DoesZapCodeSpaceFlag}
+{HeapInfo}
+{HeapSpaceInfo[]}
+{HookCallbacks}
+{AsyncHook}
+{number|AsyncResourceOptions}
+{(this: This, ...args: any[]) => Result}
+{This}
+{Result}
+{(trailers: OutgoingHttpHeaders) => void}
+{(stats: fs.Stats, headers: OutgoingHttpHeaders, statOptions: StatOptions) => void | boolean}
+{ServerStreamFileResponseOptions}
+{StreamPriorityOptions}
+{Http2Session}
+{StreamState}
+{"aborted"}
+{"frameError"}
+{(frameType: number, errorCode: number) => void}
+{(src: stream.Readable) => void}
+{"streamClosed"}
+{"trailers"}
+{(trailers: IncomingHttpHeaders, flags: number) => void}
+{Http2Stream}
+{"headers"}
+{(headers: IncomingHttpHeaders, flags: number) => void}
+{"push"}
+{"response"}
+{(err: Error | null, pushStream: ServerHttp2Stream, headers: OutgoingHttpHeaders) => void}
+{ServerStreamResponseOptions}
+{ServerStreamFileResponseOptionsWithError}
+{(trailers: OutgoingHttpHeaders, flags: number) => void}
+{Settings}
+{net.Socket | tls.TLSSocket}
+{SessionState}
+{(frameType: number, errorCode: number, streamID: number) => void}
+{"goaway"}
+{(errorCode: number, lastStreamID: number, opaqueData: Buffer) => void}
+{"localSettings"}
+{(settings: Settings) => void}
+{"remoteSettings"}
+{ClientSessionRequestOptions}
+{ClientHttp2Stream}
+{"altsvc"}
+{(alt: string, origin: string, stream: number) => void}
+{(session: ClientHttp2Session, socket: net.Socket | tls.TLSSocket) => void}
+{"stream"}
+{(stream: ClientHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void}
+{ClientHttp2Session}
+{number | string | url.URL}
+{number | string | url.URL | AlternativeServiceOptions}
+{Http2Server | Http2SecureServer}
+{(session: ServerHttp2Session, socket: net.Socket | tls.TLSSocket) => void}
+{(stream: ServerHttp2Stream, headers: IncomingHttpHeaders, flags: number) => void}
+{ServerHttp2Session}
+{ServerHttp2Stream}
+{(frameLen: number, maxFrameLen: number) => number}
+{SessionOptions}
+{ClientSessionOptions}
+{ServerSessionOptions}
+{tls.TlsOptions}
+{SecureServerSessionOptions}
+{"checkContinue"}
+{(request: Http2ServerRequest, response: Http2ServerResponse) => void}
+{"request"}
+{"sessionError"}
+{Http2ServerRequest}
+{Http2ServerResponse}
+{"unknownProtocol"}
+{(socket: tls.TLSSocket) => void}
+{tls.TLSSocket}
+{(hadError: boolean, code: number) => void}
+{''}
+{(err: Error | null, res: Http2ServerResponse) => void}
+{Http2Server}
+{Http2SecureServer}
+{SecureServerOptions}
+{string | url.URL}
+{ClientSessionOptions | SecureClientSessionOptions}
+{PerformanceNodeTiming}
+{(...optionalParams: any[]) => any}
+{(list: PerformanceObserverEntryList, observer: PerformanceObserver) => void}
+{PerformanceObserverCallback}
+{{ entryTypes: string[], buffered?: boolean }}
+{M.IOptions}
+{IOptions}
+{(element: string, indexed: number, array: ReadonlyArray<string>) => boolean}
+{IMinimatchStatic}
+{IMinimatch}
+{any[][]}
+{(err: Error | null, matches: string[]) => void}
+{G.IOptions}
+{IGlobStatic}
+{IGlobSyncStatic}
+{minimatch.IOptions}
+{{ [path: string]: any /* boolean | string | string[] */ }}
+{{ [path: string]: fs.Stats }}
+{IGlob}
+{IGlobBase}
+{minimatch.IMinimatch}
+{{ [path: string]: boolean }}
+{{ [path: string]: string }}
+{ShellString}
+{Array<string | string[]>}
+{ShellArray}
+{TestOptions}
+{"-b" | "-c" | "-d" | "-e" | "-f" | "-L" | "-p" | "-S"}
+{"+N"}
+{"-N"}
+{"-c"}
+{{ [key: string]: string }}
+{ExecOutputReturnValue}
+{ExecOutputReturnValue | child.ChildProcess}
+{ExecCallback}
+{(code: number, stdout: string, stderr: string) => any}
+{child.ExecOptions}
+{string & ShellReturnValue}
+{string[] & ShellReturnValue}
+{"-a" | "-c" | "-m" | "-d" | "-r"}
+{TouchOptionsLiteral}
+{TouchOptionsArray}
+{glob.IOptions}
+{ShellConfig}

--- a/tests/test_no_hang.js
+++ b/tests/test_no_hang.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var util = require('util');
+var Parser = require('../lib/parsing.js');
+var Fs = require('fs');
+var Path = require('path');
+
+
+var Fixtures = {
+  DEFINITELY_TYPED: readFixtureSync('definitely-typed-types'),
+};
+
+
+describe('Parser', function() {
+  it('should not hang when parsing tests/fixtures/*', function() {
+    Object.keys(Fixtures).forEach(function(fixtureName) {
+      Fixtures[fixtureName].forEach(function(fixture) {
+        if (fixture.skip) return;
+
+        try {
+          Parser.parse(fixture.typeExprStr);
+        }
+        catch (e) {
+          if (e.name !== 'SyntaxError') {
+            throw e;
+          }
+        }
+      });
+    });
+  });
+});
+
+
+function readFixtureSync(fileName) {
+  var filePath = Path.resolve(__dirname, 'fixtures', fileName);
+
+  return Fs.readFileSync(filePath, 'utf8')
+    .trim()
+    .split(/\n/)
+    .map(function(line, lineIdx) {
+      return {
+        // When the line starts with "//", we should skip it.
+        skip: /^\/\//.test(line),
+
+        typeExprStr: line.trim().replace(/^\{(.*)\}$/, '$1'),
+        position: {
+          filePath: filePath,
+          lineno: lineIdx + 1,
+        },
+      };
+    });
+}

--- a/tests/test_no_hang.js
+++ b/tests/test_no_hang.js
@@ -13,6 +13,7 @@ var Fixtures = {
 
 describe('Parser', function() {
   it('should not hang when parsing tests/fixtures/*', function() {
+    this.timeout(50 * 1000);
     Object.keys(Fixtures).forEach(function(fixtureName) {
       Fixtures[fixtureName].forEach(function(fixture) {
         if (fixture.skip) return;


### PR DESCRIPTION
I want to make sure that the parser doesn't hang on complex typescript types.

Gathered by walking the syntax tree for all the typescript files in Definitely Typed and printing the type nodes. 3700 unique types seems low for Definitely Typed, with 5800 packages, so it's likely that I missed some. I'll expand this list later.
