### PR TITLE
Migration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 lib/legacy
 node_modules
+peg_lib/jsdoctype.js

--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,7 @@
+Copyright © 2019 Kuniwak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 jsdoctypeparser
 ===============
 
-[![Build Status](https://travis-ci.org/Kuniwak/jsdoctypeparser.svg?branch=master)](https://travis-ci.org/Kuniwak/jsdoctypeparser)
+[![Build Status](https://travis-ci.org/jsdoctypeparser/jsdoctypeparser.svg?branch=master)](https://travis-ci.org/jsdoctypeparser/jsdoctypeparser)
 [![NPM version](https://badge.fury.io/js/jsdoctypeparser.svg)](http://badge.fury.io/js/jsdoctypeparser)
 
 The parser can parse:
@@ -19,7 +19,7 @@ The parser can parse:
 Live demo
 ---------
 
-The [live demo](http://kuniwak.github.io/jsdoctypeparser/) is available.
+The [live demo](https://jsdoctypeparser.github.io/jsdoctypeparser/) is available.
 
 
 Usage
@@ -105,7 +105,7 @@ const ast = {
 };
 
 const customPublisher = createDefaultPublisher();
-customPublisher.NAME = (node, pub) => 
+customPublisher.NAME = (node, pub) =>
   `<a href="./types/${node.name}.html">${node.name}</a>`;
 
 const string = publish(ast, customPublisher);

--- a/README.md
+++ b/README.md
@@ -645,4 +645,4 @@ We can use a parenthesis to change operator orders.
 License
 -------
 
-[This script licensed under the MIT](http://kuniwak.mit-license.org).
+[This script is licensed under the MIT](./LICENSE-MIT.txt).

--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/Kuniwak/jsdoctypeparser.git"
+    "url": "git://github.com/jsdoctypeparser/jsdoctypeparser.git"
   },
   "engines": {
     "node": ">=6"
   },
-  "homepage": "http://kuniwak.github.io/jsdoctypeparser/",
+  "homepage": "https://jsdoctypeparser.github.io/jsdoctypeparser/",
   "bugs": {
     "mail": "orga.chem.job@gmail.com",
-    "url": "https://github.com/Kuniwak/jsdoctypeparser/issues"
+    "url": "https://github.com/jsdoctypeparser/jsdoctypeparser/issues"
   },
   "directories": {
     "test": "test"

--- a/peg_lib/jsdoctype.js
+++ b/peg_lib/jsdoctype.js
@@ -250,7 +250,7 @@ function peg$parse(input, options) {
                        return memberPartWithOperators.reduce(function(owner, tokens) {
                          var operatorType = tokens[1];
                          var memberName = tokens[3];
-        
+
                          switch (operatorType) {
                            case NamepathOperatorType.MEMBER:
                              return {
@@ -486,7 +486,7 @@ function peg$parse(input, options) {
       peg$c127 = "...",
       peg$c128 = peg$literalExpectation("...", false),
       peg$c129 = function(spread, id, type) {
-        var operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type }; 
+        var operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         if (spread) {
         return {
           type: NodeType.VARIADIC,

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -138,7 +138,7 @@ TypeNameExprStrict = name:JsIdentifier {
 
 
 // JSDoc allow to use hyphens in identifier contexts.
-// See https://github.com/Kuniwak/jsdoctypeparser/issues/15
+// See https://github.com/jsdoctypeparser/jsdoctypeparser/issues/15
 TypeNameExprJsDocFlavored = name:$([a-zA-Z_$][a-zA-Z0-9_$-]*) {
                             return {
                               type: NodeType.NAME,
@@ -160,7 +160,7 @@ MemberName = "'" name:$([^']*) "'" {
 InfixNamepathOperator = MemberTypeOperator
                       / InstanceMemberTypeOperator
                       / InnerMemberTypeOperator
-                      
+
 QualifiedMemberName = rootOwner:TypeNameExpr memberPart:(_ "." _ TypeNameExpr)* {
                       return memberPart.reduce(function(owner, tokens) {
                         return {
@@ -256,7 +256,7 @@ ModulePathExpr = rootOwner:(FilePathExpr) memberPartWithOperators:(_ InfixNamepa
                  return memberPartWithOperators.reduce(function(owner, tokens) {
                    var operatorType = tokens[1];
                    var memberName = tokens[3];
-  
+
                    switch (operatorType) {
                      case NamepathOperatorType.MEMBER:
                        return {
@@ -715,7 +715,7 @@ ArrowTypeExprParams = paramsWithComma:(JsIdentifier _ ":" _ FunctionTypeExprPara
 }
 
 VariadicNameExpr = spread:"..."? _ id:JsIdentifier _ ":" _ type:FunctionTypeExprParamOperand? _ ","? {
-  var operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type }; 
+  var operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
   if (spread) {
   return {
     type: NodeType.VARIADIC,


### PR DESCRIPTION
- Update references from Kuniwak to jsdoctypeparser (repo URL, github.io site, and Travis URLs)
- `.eslintignore` - Add PEG output
- Replace license reference (to http://kuniwak.mit-license.org/ ) to a new local copy (the license itself insists it be stored with any copies of the software).

There is one reference to a Kuniwak URL that I didn't update because I think it either needs to be removed or replaced with something else as the files are not present at the given location:

> See the [AST specifications](https://github.com/Kuniwak/jsdoctypeparser/blob/update-readme/README.md#ast-specifications).