### PR TITLE
fix(eslint): Ignore `peg_lib` directory

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,3 @@
 lib/legacy
 node_modules
-peg_lib/jsdoctype.js
+peg_lib

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,5 @@
 {
-  "excludeFiles": ["node_modules/**", "lib/legacy/**"],
+  "excludeFiles": ["node_modules/**", "lib/legacy/**", "peg_lib/**"],
 
   "disallowEmptyBlocks": true,
   "disallowImplicitTypeConversion": ["numeric", "boolean", "binary", "string"],


### PR DESCRIPTION
This makes linters ignore the `peg_lib` directory.