### PR TITLE
Publishing change for angle bracket with dot

### DIFF
--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -37,6 +37,18 @@ function createDefaultPublisher() {
     },
     GENERIC (genericNode, concretePublish) {
       const concretePublishedObjects = genericNode.objects.map(concretePublish);
+      if (genericNode.meta) {
+        switch (genericNode.meta.syntax) {
+        case 'SQUARE_BRACKET':
+          if (genericNode.subject && genericNode.subject.name === 'Array') {
+            return format('%s[]', concretePublishedObjects.join(', '));
+          }
+          break;
+        case 'ANGLE_BRACKET_WITH_DOT':
+          return format('%s.<%s>', concretePublish(genericNode.subject),
+                        concretePublishedObjects.join(', '));
+        }
+      }
       return format('%s<%s>', concretePublish(genericNode.subject),
                     concretePublishedObjects.join(', '));
     },

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -28,19 +28,19 @@ describe('publish', function() {
 
   it('should return a generic type has a parameter', function() {
     const node = parse('Array.<string>');
-    expect(publish(node)).to.equal('Array<string>');
+    expect(publish(node)).to.equal('Array.<string>');
   });
 
 
   it('should return a generic type has 2 parameters', function() {
     const node = parse('Object.<string, number>');
-    expect(publish(node)).to.equal('Object<string, number>');
+    expect(publish(node)).to.equal('Object.<string, number>');
   });
 
 
   it('should return a JsDoc-formal generic type', function() {
     const node = parse('String[]');
-    expect(publish(node)).to.equal('Array<String>');
+    expect(publish(node)).to.equal('String[]');
   });
 
 
@@ -177,7 +177,7 @@ describe('publish', function() {
 
   it('should return an arrow type with one variadic parameter', function() {
     const node = parse('(...x: any[]) => string');
-    expect(publish(node)).to.equal('(...x: Array<any>) => string');
+    expect(publish(node)).to.equal('(...x: any[]) => string');
   });
 
   it('should return a construct signature with one parameter', function() {


### PR DESCRIPTION
- Breaking change: Have GENERIC publisher publish with a dot when `ANGLE_BRACKET_WITH_DOT` is present (not only legacy Closure but also used in jsdoc)

The main syntax specified at https://jsdoc.app/tags-type.html for bracketed types appears to be with a dot, so this PR changes the publishing behavior to express it. While we could use a custom publisher over at eslint-plugin-jsdoc (which is impacted in its `check-types` fixer which does not preserve the user's dot notation), I figured this made sense as a default, but thought I'd check with anyone else who might have an opinion (e.g., @Kuniwak, @sandersn , @gajus ).

FWIW, I also pushed some non-breaking refactoring changes (mostly using ES6 as supported by our targeted Node `engines` (>= 6)).