### PR TITLE
feat(traversal): pass on immediate parent property name and type

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ traverse(ast, onEnter, onLeave);
 The output will be:
 
 ```
-enter GENERIC undefined undefined
+enter GENERIC null null
 enter NAME subject GENERIC
 leave NAME subject GENERIC
 enter RECORD objects GENERIC
@@ -152,7 +152,7 @@ leave MEMBER owner MEMBER
 leave MEMBER value RECORD_ENTRY
 leave RECORD_ENTRY entries RECORD
 leave RECORD objects GENERIC
-leave GENERIC undefined undefined
+leave GENERIC null null
 ```
 
 ## AST Specifications

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The parser can parse:
 * Complex type expressions
   * `Array<Array<string>>`, `function(function(Function))`
 
-
 ## Live demo
 
 The [live demo](https://jsdoctypeparser.github.io/jsdoctypeparser/) is available.
@@ -54,7 +53,6 @@ The `ast` becomes:
 
 See the [AST specifications](https://github.com/Kuniwak/jsdoctypeparser/blob/update-readme/README.md#ast-specifications).
 
-
 ### Publishing
 
 We can stringify the AST nodes by using `publish`.
@@ -85,14 +83,12 @@ The `string` becomes:
 "Array<MyClass>"
 ```
 
-
 #### Custom publishing
 
 We can change the stringification strategy by using the 2nd parameter of `publish(node, publisher)`.
 The `publisher` MUST have handlers for all node types (see `lib/NodeType.js`).
 
 And we can override default behavior by using `createDefaultPublisher`.
-
 
 ```javascript
 const {publish, createDefaultPublisher} = require('jsdoctypeparser');
@@ -115,7 +111,6 @@ The `string` becomes:
 <a href="./types/MyClass.html">MyClass</a>
 ```
 
-
 ### Traversing
 
 We can traverse the AST by using `traverse`.
@@ -126,12 +121,12 @@ The handlers take a visiting node.
 const {parse, traverse} = require('jsdoctypeparser');
 const ast = parse('Array<{ key1: function(), key2: A.B.C }>');
 
-funciton onEnter(node) {
-  console.log('enter', node.type);
+function onEnter(node, parentName, parentType) {
+  console.log('enter', node.type, parentName, parentType);
 }
 
-funciton onLeave(node) {
-  console.log('leave', node.type);
+function onLeave(node, parentName, parentType) {
+  console.log('leave', node.type, parentName, parentType);
 }
 
 traverse(ast, onEnter, onLeave);
@@ -140,24 +135,25 @@ traverse(ast, onEnter, onLeave);
 The output will be:
 
 ```
-enter GENERIC
-enter RECORD
-enter RECORD_ENTRY
-enter FUNCTION
-leave FUNCTION
-leave RECORD_ENTRY
-enter RECORD_ENTRY
-enter MEMBER
-enter MEMBER
-enter NAME
-leave NAME
-leave MEMBER
-leave MEMBER
-leave RECORD_ENTRY
-leave RECORD
-leave GENERIC
+enter GENERIC undefined undefined
+enter NAME subject GENERIC
+leave NAME subject GENERIC
+enter RECORD objects GENERIC
+enter RECORD_ENTRY entries RECORD
+enter FUNCTION value RECORD_ENTRY
+leave FUNCTION value RECORD_ENTRY
+leave RECORD_ENTRY entries RECORD
+enter RECORD_ENTRY entries RECORD
+enter MEMBER value RECORD_ENTRY
+enter MEMBER owner MEMBER
+enter NAME owner MEMBER
+leave NAME owner MEMBER
+leave MEMBER owner MEMBER
+leave MEMBER value RECORD_ENTRY
+leave RECORD_ENTRY entries RECORD
+leave RECORD objects GENERIC
+leave GENERIC undefined undefined
 ```
-
 
 ## AST Specifications
 
@@ -179,7 +175,6 @@ Structure:
   "name": string
 }
 ```
-
 
 ### `MEMBER`
 
@@ -203,7 +198,6 @@ Structure:
 }
 ```
 
-
 ### `INNER_MEMBER`
 
 Example:
@@ -225,8 +219,6 @@ Structure:
 }
 ```
 
-
-
 ### `INSTANCE_MEMBER`
 
 Example:
@@ -247,7 +239,6 @@ Structure:
   "hasEventPrefix": boolean
 }
 ```
-
 
 ### `UNION`
 
@@ -274,7 +265,6 @@ Structure:
 }
 ```
 
-
 ### `RECORD`
 
 Example:
@@ -300,7 +290,6 @@ Structure:
 }
 ```
 
-
 ### `RECORD_ENTRY`
 
 Structure:
@@ -312,7 +301,6 @@ Structure:
   "value": node (or null)
 }
 ```
-
 
 ### `GENERIC`
 
@@ -341,7 +329,6 @@ Structure:
   }
 }
 ```
-
 
 ### `FUNCTION`
 
@@ -372,7 +359,6 @@ Structure:
 }
 ```
 
-
 ### `OPTIONAL`
 
 Example:
@@ -394,7 +380,6 @@ Structure:
   }
 }
 ```
-
 
 ### `NULLABLE`
 
@@ -418,7 +403,6 @@ Structure:
 }
 ```
 
-
 ### `NOT_NULLABLE`
 
 Example:
@@ -440,7 +424,6 @@ Structure:
   }
 }
 ```
-
 
 ### `VARIADIC`
 
@@ -466,7 +449,6 @@ Structure:
 }
 ```
 
-
 ### `MODULE`
 
 Example:
@@ -485,7 +467,6 @@ Structure:
   "value": node
 }
 ```
-
 
 ### `FILE_PATH`
 
@@ -507,7 +488,6 @@ Structure:
 }
 ```
 
-
 ### `EXTERNAL`
 
 Example:
@@ -526,7 +506,6 @@ Structure:
   "value": node
 }
 ```
-
 
 ### `STRING_VALUE`
 
@@ -547,7 +526,6 @@ Structure:
   "string": string
 }
 ```
-
 
 ### `NUMBER_VALUE`
 
@@ -571,7 +549,6 @@ Structure:
 }
 ```
 
-
 ### `ANY`
 
 Example:
@@ -590,7 +567,6 @@ Structure:
 }
 ```
 
-
 ### `UNKNOWN`
 
 Example:
@@ -608,7 +584,6 @@ Structure:
   "type": "UNKNOWN"
 }
 ```
-
 
 ### `PARENTHESIS`
 
@@ -629,8 +604,6 @@ Structure:
 }
 ```
 
-
-
 ### Others
 
 We can use a parenthesis to change operator orders.
@@ -640,7 +613,6 @@ We can use a parenthesis to change operator orders.
  * @type {(module:path/to/file.js).foo}
  */
 ```
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ The handlers take a visiting node.
 const {parse, traverse} = require('jsdoctypeparser');
 const ast = parse('Array<{ key1: function(), key2: A.B.C }>');
 
-function onEnter(node, parentName, parentType) {
-  console.log('enter', node.type, parentName, parentType);
+function onEnter(node, parentName, parentNode) {
+  console.log('enter', node.type, parentName, parentNode.type);
 }
 
-function onLeave(node, parentName, parentType) {
-  console.log('leave', node.type, parentName, parentType);
+function onLeave(node, parentName, parentNode) {
+  console.log('leave', node.type, parentName, parentNode.type);
 }
 
 traverse(ast, onEnter, onLeave);

--- a/lib/traversing.js
+++ b/lib/traversing.js
@@ -9,9 +9,13 @@
 function traverse(node, opt_onEnter, opt_onLeave) {
   if (opt_onEnter) opt_onEnter(node);
 
-  const childNodes = _collectChildNodes(node);
-  childNodes.forEach(function(childNode) {
-    traverse(childNode, opt_onEnter, opt_onLeave);
+  const childNodeInfo = _collectChildNodeInfo(node);
+  childNodeInfo.forEach(function([childNode, parentPropName, parentType]) {
+    traverse(childNode, opt_onEnter ? (node, pn, pt) => {
+      opt_onEnter(node, pn || parentPropName, pt || parentType);
+    } : null, opt_onLeave ? (node, pn, pt) => {
+      opt_onLeave(node, pn || parentPropName, pt || parentType);
+    } : null);
   });
 
   if (opt_onLeave) opt_onLeave(node);
@@ -19,20 +23,19 @@ function traverse(node, opt_onEnter, opt_onLeave) {
 
 
 /**
- * @enum {number}
  * @private
  */
 const _PropertyAccessor = {
-  NODE (fn, node) {
-    fn(node);
+  NODE (fn, node, parentPropName, parentNodeType) {
+    fn(node, parentPropName, parentNodeType);
   },
-  NODE_LIST (fn, nodes) {
+  NODE_LIST (fn, nodes, parentPropName, parentNodeType) {
     nodes.forEach(function(node) {
-      fn(node);
+      fn(node, parentPropName, parentNodeType);
     });
   },
-  NULLABLE_NODE (fn, opt_node) {
-    if (opt_node) fn(opt_node);
+  NULLABLE_NODE (fn, opt_node, parentPropName, parentNodeType) {
+    if (opt_node) fn(opt_node, parentPropName, parentNodeType);
   },
 };
 
@@ -113,16 +116,18 @@ const _childNodesMap = {
 
 
 /** @private */
-function _collectChildNodes(node) {
-  const childNodes = [];
+function _collectChildNodeInfo(node) {
+  const childNodeInfo = [];
   const propAccessorMap = _childNodesMap[node.type];
 
   Object.keys(propAccessorMap).forEach(function(propName) {
     const propAccessor = propAccessorMap[propName];
-    propAccessor(childNodes.push.bind(childNodes), node[propName]);
+    propAccessor((node, propName, parentType) => {
+      childNodeInfo.push([node, propName, parentType]);
+    }, node[propName], propName, node.type);
   });
 
-  return childNodes;
+  return childNodeInfo;
 }
 
 module.exports = {

--- a/lib/traversing.js
+++ b/lib/traversing.js
@@ -10,11 +10,11 @@ function traverse(node, opt_onEnter, opt_onLeave) {
   if (opt_onEnter) opt_onEnter(node, null, null);
 
   const childNodeInfo = _collectChildNodeInfo(node);
-  childNodeInfo.forEach(function([childNode, parentPropName, parentType]) {
-    traverse(childNode, opt_onEnter ? (node, pn, pt) => {
-      opt_onEnter(node, pn || parentPropName, pt || parentType);
-    } : null, opt_onLeave ? (node, pn, pt) => {
-      opt_onLeave(node, pn || parentPropName, pt || parentType);
+  childNodeInfo.forEach(function([childNode, parentPropName, parentNode]) {
+    traverse(childNode, opt_onEnter ? (node, pn, pNode) => {
+      opt_onEnter(node, pn || parentPropName, pNode || parentNode);
+    } : null, opt_onLeave ? (node, pn, pNode) => {
+      opt_onLeave(node, pn || parentPropName, pNode || parentNode);
     } : null);
   });
 
@@ -26,16 +26,16 @@ function traverse(node, opt_onEnter, opt_onLeave) {
  * @private
  */
 const _PropertyAccessor = {
-  NODE (fn, node, parentPropName, parentNodeType) {
-    fn(node, parentPropName, parentNodeType);
+  NODE (fn, node, parentPropName, parentNode) {
+    fn(node, parentPropName, parentNode);
   },
-  NODE_LIST (fn, nodes, parentPropName, parentNodeType) {
+  NODE_LIST (fn, nodes, parentPropName, parentNode) {
     nodes.forEach(function(node) {
-      fn(node, parentPropName, parentNodeType);
+      fn(node, parentPropName, parentNode);
     });
   },
-  NULLABLE_NODE (fn, opt_node, parentPropName, parentNodeType) {
-    if (opt_node) fn(opt_node, parentPropName, parentNodeType);
+  NULLABLE_NODE (fn, opt_node, parentPropName, parentNode) {
+    if (opt_node) fn(opt_node, parentPropName, parentNode);
   },
 };
 
@@ -122,9 +122,9 @@ function _collectChildNodeInfo(node) {
 
   Object.keys(propAccessorMap).forEach(function(propName) {
     const propAccessor = propAccessorMap[propName];
-    propAccessor((node, propName, parentType) => {
-      childNodeInfo.push([node, propName, parentType]);
-    }, node[propName], propName, node.type);
+    propAccessor((node, propName, parentNode) => {
+      childNodeInfo.push([node, propName, parentNode]);
+    }, node[propName], propName, node);
   });
 
   return childNodeInfo;

--- a/lib/traversing.js
+++ b/lib/traversing.js
@@ -7,7 +7,7 @@
  * @param {function({ type: NodeType })?} opt_onLeave Callback for onLeave.
  */
 function traverse(node, opt_onEnter, opt_onLeave) {
-  if (opt_onEnter) opt_onEnter(node);
+  if (opt_onEnter) opt_onEnter(node, null, null);
 
   const childNodeInfo = _collectChildNodeInfo(node);
   childNodeInfo.forEach(function([childNode, parentPropName, parentType]) {
@@ -18,7 +18,7 @@ function traverse(node, opt_onEnter, opt_onLeave) {
     } : null);
   });
 
-  if (opt_onLeave) opt_onLeave(node);
+  if (opt_onLeave) opt_onLeave(node, null, null);
 }
 
 

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -9,62 +9,62 @@ describe('traversing', function() {
     'should visit a name node': {
       given: createNameNode('name'),
       then: [
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
+        ['enter', NodeType.NAME, undefined, undefined],
+        ['leave', NodeType.NAME, undefined, undefined],
       ],
     },
 
     'should visit a member node': {
       given: createMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.MEMBER],
+        ['enter', NodeType.MEMBER, undefined, undefined],
+        ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
+        ['leave', NodeType.MEMBER, undefined, undefined],
       ],
     },
 
     'should visit a nested member node': {
       given: createMemberNode('superchild', createMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.MEMBER],
-        ['enter', NodeType.MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER],
+        ['enter', NodeType.MEMBER, undefined, undefined],
+        ['enter', NodeType.MEMBER, 'owner', NodeType.MEMBER],
+        ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
+        ['leave', NodeType.MEMBER, 'owner', NodeType.MEMBER],
+        ['leave', NodeType.MEMBER, undefined, undefined],
       ],
     },
 
     'should visit an union node': {
       given: createUnionNode(createNameNode('left'), createNameNode('right')),
       then: [
-        ['enter', NodeType.UNION],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.UNION],
+        ['enter', NodeType.UNION, undefined, undefined],
+        ['enter', NodeType.NAME, 'left', NodeType.UNION],
+        ['leave', NodeType.NAME, 'left', NodeType.UNION],
+        ['enter', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.UNION, undefined, undefined],
       ],
     },
 
     'should visit a type query node': {
       given: createTypeQueryNode(createNameNode('t')),
       then: [
-        ['enter', NodeType.TYPE_QUERY],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.TYPE_QUERY],
+        ['enter', NodeType.TYPE_QUERY, undefined, undefined],
+        ['enter', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
+        ['leave', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
+        ['leave', NodeType.TYPE_QUERY, undefined, undefined],
       ],
     },
 
     'should visit an import type node': {
       given: createImportNode(createStringLiteral('jquery')),
       then: [
-        ['enter', NodeType.IMPORT],
-        ['enter', NodeType.STRING_VALUE],
-        ['leave', NodeType.STRING_VALUE],
-        ['leave', NodeType.IMPORT],
+        ['enter', NodeType.IMPORT, undefined, undefined],
+        ['enter', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
+        ['leave', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
+        ['leave', NodeType.IMPORT, undefined, undefined],
       ],
     },
 
@@ -77,26 +77,26 @@ describe('traversing', function() {
         createNameNode('right')
       ),
       then: [
-        ['enter', NodeType.UNION],
-        ['enter', NodeType.UNION],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.UNION],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.UNION],
+        ['enter', NodeType.UNION, undefined, undefined],
+        ['enter', NodeType.UNION, 'left', NodeType.UNION],
+        ['enter', NodeType.NAME, 'left', NodeType.UNION],
+        ['leave', NodeType.NAME, 'left', NodeType.UNION],
+        ['enter', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.UNION, 'left', NodeType.UNION],
+        ['enter', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.NAME, 'right', NodeType.UNION],
+        ['leave', NodeType.UNION, undefined, undefined],
       ],
     },
 
     'should visit a variadic node': {
       given: { type: NodeType.VARIADIC, value: createNameNode('variadic') },
       then: [
-        ['enter', NodeType.VARIADIC],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.VARIADIC],
+        ['enter', NodeType.VARIADIC, undefined, undefined],
+        ['enter', NodeType.NAME, 'value', NodeType.VARIADIC],
+        ['leave', NodeType.NAME, 'value', NodeType.VARIADIC],
+        ['leave', NodeType.VARIADIC, undefined, undefined],
       ],
     },
 
@@ -106,8 +106,8 @@ describe('traversing', function() {
         entries: [],
       },
       then: [
-        ['enter', NodeType.RECORD],
-        ['leave', NodeType.RECORD],
+        ['enter', NodeType.RECORD, undefined, undefined],
+        ['leave', NodeType.RECORD, undefined, undefined],
       ],
     },
 
@@ -120,16 +120,16 @@ describe('traversing', function() {
         ],
       },
       then: [
-        ['enter', NodeType.RECORD],
-        ['enter', NodeType.RECORD_ENTRY],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.RECORD_ENTRY],
-        ['enter', NodeType.RECORD_ENTRY],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.RECORD_ENTRY],
-        ['leave', NodeType.RECORD],
+        ['enter', NodeType.RECORD, undefined, undefined],
+        ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+        ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+        ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+        ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+        ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+        ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+        ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+        ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+        ['leave', NodeType.RECORD, undefined, undefined],
       ],
     },
 
@@ -140,10 +140,10 @@ describe('traversing', function() {
         objects: [],
       },
       then: [
-        ['enter', NodeType.GENERIC],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.GENERIC],
+        ['enter', NodeType.GENERIC, undefined, undefined],
+        ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
+        ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
+        ['leave', NodeType.GENERIC, undefined, undefined],
       ],
     },
 
@@ -157,14 +157,14 @@ describe('traversing', function() {
         ],
       },
       then: [
-        ['enter', NodeType.GENERIC],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.GENERIC],
+        ['enter', NodeType.GENERIC, undefined, undefined],
+        ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
+        ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
+        ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
+        ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
+        ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
+        ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
+        ['leave', NodeType.GENERIC, undefined, undefined],
       ],
     },
 
@@ -174,10 +174,10 @@ describe('traversing', function() {
         value: createFilePathNode('module'),
       },
       then: [
-        ['enter', NodeType.MODULE],
-        ['enter', NodeType.FILE_PATH],
-        ['leave', NodeType.FILE_PATH],
-        ['leave', NodeType.MODULE],
+        ['enter', NodeType.MODULE, undefined, undefined],
+        ['enter', NodeType.FILE_PATH, 'value', NodeType.MODULE],
+        ['leave', NodeType.FILE_PATH, 'value', NodeType.MODULE],
+        ['leave', NodeType.MODULE, undefined, undefined],
       ],
     },
 
@@ -187,10 +187,10 @@ describe('traversing', function() {
         value: createNameNode('optional'),
       },
       then: [
-        ['enter', NodeType.OPTIONAL],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.OPTIONAL],
+        ['enter', NodeType.OPTIONAL, undefined, undefined],
+        ['enter', NodeType.NAME, 'value', NodeType.OPTIONAL],
+        ['leave', NodeType.NAME, 'value', NodeType.OPTIONAL],
+        ['leave', NodeType.OPTIONAL, undefined, undefined],
       ],
     },
 
@@ -200,10 +200,10 @@ describe('traversing', function() {
         value: createNameNode('nullable'),
       },
       then: [
-        ['enter', NodeType.NULLABLE],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.NULLABLE],
+        ['enter', NodeType.NULLABLE, undefined, undefined],
+        ['enter', NodeType.NAME, 'value', NodeType.NULLABLE],
+        ['leave', NodeType.NAME, 'value', NodeType.NULLABLE],
+        ['leave', NodeType.NULLABLE, undefined, undefined],
       ],
     },
 
@@ -213,10 +213,10 @@ describe('traversing', function() {
         value: createNameNode('not_nullable'),
       },
       then: [
-        ['enter', NodeType.NOT_NULLABLE],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.NOT_NULLABLE],
+        ['enter', NodeType.NOT_NULLABLE, undefined, undefined],
+        ['enter', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
+        ['leave', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
+        ['leave', NodeType.NOT_NULLABLE, undefined, undefined],
       ],
     },
 
@@ -229,8 +229,8 @@ describe('traversing', function() {
         new: null,
       },
       then: [
-        ['enter', NodeType.FUNCTION],
-        ['leave', NodeType.FUNCTION],
+        ['enter', NodeType.FUNCTION, undefined, undefined],
+        ['leave', NodeType.FUNCTION, undefined, undefined],
       ],
     },
 
@@ -246,18 +246,18 @@ describe('traversing', function() {
         new: createNameNode('new'),
       },
       then: [
-        ['enter', NodeType.FUNCTION],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.FUNCTION],
+        ['enter', NodeType.FUNCTION, undefined, undefined],
+        ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
+        ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
+        ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
+        ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
+        ['enter', NodeType.NAME, 'returns', NodeType.FUNCTION],
+        ['leave', NodeType.NAME, 'returns', NodeType.FUNCTION],
+        ['enter', NodeType.NAME, 'this', NodeType.FUNCTION],
+        ['leave', NodeType.NAME, 'this', NodeType.FUNCTION],
+        ['enter', NodeType.NAME, 'new', NodeType.FUNCTION],
+        ['leave', NodeType.NAME, 'new', NodeType.FUNCTION],
+        ['leave', NodeType.FUNCTION, undefined, undefined],
       ],
     },
 
@@ -271,18 +271,18 @@ describe('traversing', function() {
         returns: createNameNode('return'),
       },
       then: [
-        ['enter', NodeType.ARROW],
-        ['enter', NodeType.NAMED_PARAMETER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.NAMED_PARAMETER],
-        ['enter', NodeType.NAMED_PARAMETER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.NAMED_PARAMETER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.ARROW],
+        ['enter', NodeType.ARROW, undefined, undefined],
+        ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
+        ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
+        ['leave', NodeType.ARROW, undefined, undefined],
       ],
     },
 
@@ -302,16 +302,16 @@ describe('traversing', function() {
         returns: createNameNode('return'),
       },
       then: [
-        ['enter', NodeType.ARROW],
-        ['enter', NodeType.VARIADIC],
-        ['enter', NodeType.NAMED_PARAMETER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.VARIADIC],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.ARROW],
+        ['enter', NodeType.ARROW, undefined, undefined],
+        ['enter', NodeType.VARIADIC, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
+        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+        ['leave', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
+        ['leave', NodeType.VARIADIC, 'params', NodeType.ARROW],
+        ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
+        ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
+        ['leave', NodeType.ARROW, undefined, undefined],
       ],
     },
 
@@ -320,8 +320,8 @@ describe('traversing', function() {
         type: NodeType.ANY,
       },
       then: [
-        ['enter', NodeType.ANY],
-        ['leave', NodeType.ANY],
+        ['enter', NodeType.ANY, undefined, undefined],
+        ['leave', NodeType.ANY, undefined, undefined],
       ],
     },
 
@@ -330,18 +330,18 @@ describe('traversing', function() {
         type: NodeType.UNKNOWN,
       },
       then: [
-        ['enter', NodeType.UNKNOWN],
-        ['leave', NodeType.UNKNOWN],
+        ['enter', NodeType.UNKNOWN, undefined, undefined],
+        ['leave', NodeType.UNKNOWN, undefined, undefined],
       ],
     },
 
     'should visit an inner member node': {
       given: createInnerMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.INNER_MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.INNER_MEMBER],
+        ['enter', NodeType.INNER_MEMBER, undefined, undefined],
+        ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+        ['leave', NodeType.INNER_MEMBER, undefined, undefined],
       ],
     },
 
@@ -349,22 +349,22 @@ describe('traversing', function() {
       given: createInnerMemberNode('superchild',
         createInnerMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.INNER_MEMBER],
-        ['enter', NodeType.INNER_MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER],
+        ['enter', NodeType.INNER_MEMBER, undefined, undefined],
+        ['enter', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
+        ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+        ['leave', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
+        ['leave', NodeType.INNER_MEMBER, undefined, undefined],
       ],
     },
 
     'should visit an instance member node': {
       given: createInstanceMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.INSTANCE_MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.INSTANCE_MEMBER],
+        ['enter', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+        ['leave', NodeType.INSTANCE_MEMBER, undefined, undefined],
       ],
     },
 
@@ -372,38 +372,38 @@ describe('traversing', function() {
       given: createInstanceMemberNode('superchild',
         createInstanceMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.INSTANCE_MEMBER],
-        ['enter', NodeType.INSTANCE_MEMBER],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER],
+        ['enter', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['enter', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
+        ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+        ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+        ['leave', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
+        ['leave', NodeType.INSTANCE_MEMBER, undefined, undefined],
       ],
     },
 
     'should visit a string value node': {
       given: { type: NodeType.STRING_VALUE, value: 'stringValue' },
       then: [
-        ['enter', NodeType.STRING_VALUE],
-        ['leave', NodeType.STRING_VALUE],
+        ['enter', NodeType.STRING_VALUE, undefined, undefined],
+        ['leave', NodeType.STRING_VALUE, undefined, undefined],
       ],
     },
 
     'should visit a number value node': {
       given: { type: NodeType.NUMBER_VALUE, value: 'numberValue' },
       then: [
-        ['enter', NodeType.NUMBER_VALUE],
-        ['leave', NodeType.NUMBER_VALUE],
+        ['enter', NodeType.NUMBER_VALUE, undefined, undefined],
+        ['leave', NodeType.NUMBER_VALUE, undefined, undefined],
       ],
     },
 
     'should visit an external node': {
       given: { type: NodeType.EXTERNAL, value: createNameNode('external') },
       then: [
-        ['enter', NodeType.EXTERNAL],
-        ['enter', NodeType.NAME],
-        ['leave', NodeType.NAME],
-        ['leave', NodeType.EXTERNAL],
+        ['enter', NodeType.EXTERNAL, undefined, undefined],
+        ['enter', NodeType.NAME, 'value', NodeType.EXTERNAL],
+        ['leave', NodeType.NAME, 'value', NodeType.EXTERNAL],
+        ['leave', NodeType.EXTERNAL, undefined, undefined],
       ],
     },
   };
@@ -493,8 +493,8 @@ function createInstanceMemberNode(name, owner) {
 }
 
 function createEventSpy(eventName, result) {
-  return function(node) {
-    result.push([eventName, node.type]);
+  return function(node, propName, parentType) {
+    result.push([eventName, node.type, propName, parentType]);
   };
 }
 

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -493,8 +493,8 @@ function createInstanceMemberNode(name, owner) {
 }
 
 function createEventSpy(eventName, result) {
-  return function(node, propName, parentType) {
-    result.push([eventName, node.type, propName, parentType]);
+  return function(node, propName, parentNode) {
+    result.push([eventName, node.type, propName, parentNode && parentNode.type]);
   };
 }
 

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -9,62 +9,62 @@ describe('traversing', function() {
     'should visit a name node': {
       given: createNameNode('name'),
       then: [
-        ['enter', NodeType.NAME, undefined, undefined],
-        ['leave', NodeType.NAME, undefined, undefined],
+        ['enter', NodeType.NAME, null, null],
+        ['leave', NodeType.NAME, null, null],
       ],
     },
 
     'should visit a member node': {
       given: createMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.MEMBER, undefined, undefined],
+        ['enter', NodeType.MEMBER, null, null],
         ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER, undefined, undefined],
+        ['leave', NodeType.MEMBER, null, null],
       ],
     },
 
     'should visit a nested member node': {
       given: createMemberNode('superchild', createMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.MEMBER, undefined, undefined],
+        ['enter', NodeType.MEMBER, null, null],
         ['enter', NodeType.MEMBER, 'owner', NodeType.MEMBER],
         ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
         ['leave', NodeType.MEMBER, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER, undefined, undefined],
+        ['leave', NodeType.MEMBER, null, null],
       ],
     },
 
     'should visit an union node': {
       given: createUnionNode(createNameNode('left'), createNameNode('right')),
       then: [
-        ['enter', NodeType.UNION, undefined, undefined],
+        ['enter', NodeType.UNION, null, null],
         ['enter', NodeType.NAME, 'left', NodeType.UNION],
         ['leave', NodeType.NAME, 'left', NodeType.UNION],
         ['enter', NodeType.NAME, 'right', NodeType.UNION],
         ['leave', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.UNION, undefined, undefined],
+        ['leave', NodeType.UNION, null, null],
       ],
     },
 
     'should visit a type query node': {
       given: createTypeQueryNode(createNameNode('t')),
       then: [
-        ['enter', NodeType.TYPE_QUERY, undefined, undefined],
+        ['enter', NodeType.TYPE_QUERY, null, null],
         ['enter', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
         ['leave', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
-        ['leave', NodeType.TYPE_QUERY, undefined, undefined],
+        ['leave', NodeType.TYPE_QUERY, null, null],
       ],
     },
 
     'should visit an import type node': {
       given: createImportNode(createStringLiteral('jquery')),
       then: [
-        ['enter', NodeType.IMPORT, undefined, undefined],
+        ['enter', NodeType.IMPORT, null, null],
         ['enter', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
         ['leave', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
-        ['leave', NodeType.IMPORT, undefined, undefined],
+        ['leave', NodeType.IMPORT, null, null],
       ],
     },
 
@@ -77,7 +77,7 @@ describe('traversing', function() {
         createNameNode('right')
       ),
       then: [
-        ['enter', NodeType.UNION, undefined, undefined],
+        ['enter', NodeType.UNION, null, null],
         ['enter', NodeType.UNION, 'left', NodeType.UNION],
         ['enter', NodeType.NAME, 'left', NodeType.UNION],
         ['leave', NodeType.NAME, 'left', NodeType.UNION],
@@ -86,17 +86,17 @@ describe('traversing', function() {
         ['leave', NodeType.UNION, 'left', NodeType.UNION],
         ['enter', NodeType.NAME, 'right', NodeType.UNION],
         ['leave', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.UNION, undefined, undefined],
+        ['leave', NodeType.UNION, null, null],
       ],
     },
 
     'should visit a variadic node': {
       given: { type: NodeType.VARIADIC, value: createNameNode('variadic') },
       then: [
-        ['enter', NodeType.VARIADIC, undefined, undefined],
+        ['enter', NodeType.VARIADIC, null, null],
         ['enter', NodeType.NAME, 'value', NodeType.VARIADIC],
         ['leave', NodeType.NAME, 'value', NodeType.VARIADIC],
-        ['leave', NodeType.VARIADIC, undefined, undefined],
+        ['leave', NodeType.VARIADIC, null, null],
       ],
     },
 
@@ -106,8 +106,8 @@ describe('traversing', function() {
         entries: [],
       },
       then: [
-        ['enter', NodeType.RECORD, undefined, undefined],
-        ['leave', NodeType.RECORD, undefined, undefined],
+        ['enter', NodeType.RECORD, null, null],
+        ['leave', NodeType.RECORD, null, null],
       ],
     },
 
@@ -120,7 +120,7 @@ describe('traversing', function() {
         ],
       },
       then: [
-        ['enter', NodeType.RECORD, undefined, undefined],
+        ['enter', NodeType.RECORD, null, null],
         ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
         ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
         ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
@@ -129,7 +129,7 @@ describe('traversing', function() {
         ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
         ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
         ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
-        ['leave', NodeType.RECORD, undefined, undefined],
+        ['leave', NodeType.RECORD, null, null],
       ],
     },
 
@@ -140,10 +140,10 @@ describe('traversing', function() {
         objects: [],
       },
       then: [
-        ['enter', NodeType.GENERIC, undefined, undefined],
+        ['enter', NodeType.GENERIC, null, null],
         ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
         ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
-        ['leave', NodeType.GENERIC, undefined, undefined],
+        ['leave', NodeType.GENERIC, null, null],
       ],
     },
 
@@ -157,14 +157,14 @@ describe('traversing', function() {
         ],
       },
       then: [
-        ['enter', NodeType.GENERIC, undefined, undefined],
+        ['enter', NodeType.GENERIC, null, null],
         ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
         ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
         ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
         ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
         ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
         ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
-        ['leave', NodeType.GENERIC, undefined, undefined],
+        ['leave', NodeType.GENERIC, null, null],
       ],
     },
 
@@ -174,10 +174,10 @@ describe('traversing', function() {
         value: createFilePathNode('module'),
       },
       then: [
-        ['enter', NodeType.MODULE, undefined, undefined],
+        ['enter', NodeType.MODULE, null, null],
         ['enter', NodeType.FILE_PATH, 'value', NodeType.MODULE],
         ['leave', NodeType.FILE_PATH, 'value', NodeType.MODULE],
-        ['leave', NodeType.MODULE, undefined, undefined],
+        ['leave', NodeType.MODULE, null, null],
       ],
     },
 
@@ -187,10 +187,10 @@ describe('traversing', function() {
         value: createNameNode('optional'),
       },
       then: [
-        ['enter', NodeType.OPTIONAL, undefined, undefined],
+        ['enter', NodeType.OPTIONAL, null, null],
         ['enter', NodeType.NAME, 'value', NodeType.OPTIONAL],
         ['leave', NodeType.NAME, 'value', NodeType.OPTIONAL],
-        ['leave', NodeType.OPTIONAL, undefined, undefined],
+        ['leave', NodeType.OPTIONAL, null, null],
       ],
     },
 
@@ -200,10 +200,10 @@ describe('traversing', function() {
         value: createNameNode('nullable'),
       },
       then: [
-        ['enter', NodeType.NULLABLE, undefined, undefined],
+        ['enter', NodeType.NULLABLE, null, null],
         ['enter', NodeType.NAME, 'value', NodeType.NULLABLE],
         ['leave', NodeType.NAME, 'value', NodeType.NULLABLE],
-        ['leave', NodeType.NULLABLE, undefined, undefined],
+        ['leave', NodeType.NULLABLE, null, null],
       ],
     },
 
@@ -213,10 +213,10 @@ describe('traversing', function() {
         value: createNameNode('not_nullable'),
       },
       then: [
-        ['enter', NodeType.NOT_NULLABLE, undefined, undefined],
+        ['enter', NodeType.NOT_NULLABLE, null, null],
         ['enter', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
         ['leave', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
-        ['leave', NodeType.NOT_NULLABLE, undefined, undefined],
+        ['leave', NodeType.NOT_NULLABLE, null, null],
       ],
     },
 
@@ -229,8 +229,8 @@ describe('traversing', function() {
         new: null,
       },
       then: [
-        ['enter', NodeType.FUNCTION, undefined, undefined],
-        ['leave', NodeType.FUNCTION, undefined, undefined],
+        ['enter', NodeType.FUNCTION, null, null],
+        ['leave', NodeType.FUNCTION, null, null],
       ],
     },
 
@@ -246,7 +246,7 @@ describe('traversing', function() {
         new: createNameNode('new'),
       },
       then: [
-        ['enter', NodeType.FUNCTION, undefined, undefined],
+        ['enter', NodeType.FUNCTION, null, null],
         ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
         ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
         ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
@@ -257,7 +257,7 @@ describe('traversing', function() {
         ['leave', NodeType.NAME, 'this', NodeType.FUNCTION],
         ['enter', NodeType.NAME, 'new', NodeType.FUNCTION],
         ['leave', NodeType.NAME, 'new', NodeType.FUNCTION],
-        ['leave', NodeType.FUNCTION, undefined, undefined],
+        ['leave', NodeType.FUNCTION, null, null],
       ],
     },
 
@@ -271,7 +271,7 @@ describe('traversing', function() {
         returns: createNameNode('return'),
       },
       then: [
-        ['enter', NodeType.ARROW, undefined, undefined],
+        ['enter', NodeType.ARROW, null, null],
         ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
         ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
         ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
@@ -282,7 +282,7 @@ describe('traversing', function() {
         ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
         ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
         ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.ARROW, undefined, undefined],
+        ['leave', NodeType.ARROW, null, null],
       ],
     },
 
@@ -302,7 +302,7 @@ describe('traversing', function() {
         returns: createNameNode('return'),
       },
       then: [
-        ['enter', NodeType.ARROW, undefined, undefined],
+        ['enter', NodeType.ARROW, null, null],
         ['enter', NodeType.VARIADIC, 'params', NodeType.ARROW],
         ['enter', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
         ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
@@ -311,7 +311,7 @@ describe('traversing', function() {
         ['leave', NodeType.VARIADIC, 'params', NodeType.ARROW],
         ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
         ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.ARROW, undefined, undefined],
+        ['leave', NodeType.ARROW, null, null],
       ],
     },
 
@@ -320,8 +320,8 @@ describe('traversing', function() {
         type: NodeType.ANY,
       },
       then: [
-        ['enter', NodeType.ANY, undefined, undefined],
-        ['leave', NodeType.ANY, undefined, undefined],
+        ['enter', NodeType.ANY, null, null],
+        ['leave', NodeType.ANY, null, null],
       ],
     },
 
@@ -330,18 +330,18 @@ describe('traversing', function() {
         type: NodeType.UNKNOWN,
       },
       then: [
-        ['enter', NodeType.UNKNOWN, undefined, undefined],
-        ['leave', NodeType.UNKNOWN, undefined, undefined],
+        ['enter', NodeType.UNKNOWN, null, null],
+        ['leave', NodeType.UNKNOWN, null, null],
       ],
     },
 
     'should visit an inner member node': {
       given: createInnerMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.INNER_MEMBER, undefined, undefined],
+        ['enter', NodeType.INNER_MEMBER, null, null],
         ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER, undefined, undefined],
+        ['leave', NodeType.INNER_MEMBER, null, null],
       ],
     },
 
@@ -349,22 +349,22 @@ describe('traversing', function() {
       given: createInnerMemberNode('superchild',
         createInnerMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.INNER_MEMBER, undefined, undefined],
+        ['enter', NodeType.INNER_MEMBER, null, null],
         ['enter', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
         ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
         ['leave', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER, undefined, undefined],
+        ['leave', NodeType.INNER_MEMBER, null, null],
       ],
     },
 
     'should visit an instance member node': {
       given: createInstanceMemberNode('child', createNameNode('owner')),
       then: [
-        ['enter', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['enter', NodeType.INSTANCE_MEMBER, null, null],
         ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['leave', NodeType.INSTANCE_MEMBER, null, null],
       ],
     },
 
@@ -372,38 +372,38 @@ describe('traversing', function() {
       given: createInstanceMemberNode('superchild',
         createInstanceMemberNode('child', createNameNode('owner'))),
       then: [
-        ['enter', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['enter', NodeType.INSTANCE_MEMBER, null, null],
         ['enter', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
         ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
         ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
         ['leave', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER, undefined, undefined],
+        ['leave', NodeType.INSTANCE_MEMBER, null, null],
       ],
     },
 
     'should visit a string value node': {
       given: { type: NodeType.STRING_VALUE, value: 'stringValue' },
       then: [
-        ['enter', NodeType.STRING_VALUE, undefined, undefined],
-        ['leave', NodeType.STRING_VALUE, undefined, undefined],
+        ['enter', NodeType.STRING_VALUE, null, null],
+        ['leave', NodeType.STRING_VALUE, null, null],
       ],
     },
 
     'should visit a number value node': {
       given: { type: NodeType.NUMBER_VALUE, value: 'numberValue' },
       then: [
-        ['enter', NodeType.NUMBER_VALUE, undefined, undefined],
-        ['leave', NodeType.NUMBER_VALUE, undefined, undefined],
+        ['enter', NodeType.NUMBER_VALUE, null, null],
+        ['leave', NodeType.NUMBER_VALUE, null, null],
       ],
     },
 
     'should visit an external node': {
       given: { type: NodeType.EXTERNAL, value: createNameNode('external') },
       then: [
-        ['enter', NodeType.EXTERNAL, undefined, undefined],
+        ['enter', NodeType.EXTERNAL, null, null],
         ['enter', NodeType.NAME, 'value', NodeType.EXTERNAL],
         ['leave', NodeType.NAME, 'value', NodeType.EXTERNAL],
-        ['leave', NodeType.EXTERNAL, undefined, undefined],
+        ['leave', NodeType.EXTERNAL, null, null],
       ],
     },
   };


### PR DESCRIPTION
Ok, here's that other PR I wanted to get in...

For `check-types` in `eslint-plugin-jsdoc`, we're now allowing replacement or error reporting for types based on whether they are parents are children (e.g., one might accept `Array.<string>` but not just `Array` (or vice versa).

We need something like this PR to do that properly.

This PR will:
1. Pass ~`undefined`~ (*now `null`*) for parent name and type if there is no parent (at root).
2. Pass the most immediate available parent name and ~type~ (*now the parent node*).

`eslint-plugin-jsdoc` can thus do such as ignore `Array` if it has the parent name `subject` (and thus has children), and report it otherwise.

~To be more sure this will fully work, I should really fully implement my `eslint-plugin-jsdoc` fixes against this branch, but wanted to get this in for you to take a look. It is probably if you still hold off on publishing though until I may have a chance to test its use in `eslint-plugin-jsdoc`.~ (*Now tested against my PR in eslint-plugin-jsdoc and passing*)