### PR TITLE
chore: Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
This adds an [EditorConfig] file, so that the project’s indentation style is maintained without needing to reconfigure the editor.

[EditorConfig]: https://editorconfig.org