### PR TITLE
Allow preserve of string quote style; fixes for quotes and backslashes in strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Structure:
 ```javascript
 {
   "type": "STRING_VALUE",
+  "quoteStyle": "double",
   "string": string
 }
 ```

--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -121,9 +121,17 @@ function createDefaultPublisher() {
         (memberNode.hasEventPrefix ? 'event:' : '') + memberNode.name;
     },
     STRING_VALUE (stringValueNode) {
+      const singleQuoteStyle = stringValueNode.quoteStyle === 'single';
       return format(
-        '"%s"',
-        stringValueNode.string.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+        singleQuoteStyle
+          ? "'%s'"
+          : '"%s"',
+        stringValueNode.string
+          .replace(/\\/g, '\\\\')
+          .replace(
+            singleQuoteStyle ? /'/gu : /"/gu,
+            '\\' + (singleQuoteStyle ? "'" : '"')
+          )
       );
     },
     NUMBER_VALUE (numberValueNode) {

--- a/peg_lib/jsdoctype.js
+++ b/peg_lib/jsdoctype.js
@@ -311,7 +311,9 @@ function peg$parse(input, options) {
       peg$c56 = function(value) {
                             return {
                               type: NodeType.STRING_VALUE,
-                              string: value.replace(/\\"/g, '"')
+                              quoteStyle: 'double',
+                              string: value.replace(/\\"/gu, '"')
+                                  .replace(/\\\\/gu, '\\')
                             };
                           },
       peg$c57 = /^[^\\']/,
@@ -319,7 +321,9 @@ function peg$parse(input, options) {
       peg$c59 = function(value) {
                             return {
                               type: NodeType.STRING_VALUE,
+                              quoteStyle: 'single',
                               string: value.replace(/\\'/g, "'")
+                                  .replace(/\\\\/gu, '\\')
                             };
                           },
       peg$c60 = function(value) {

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -356,13 +356,17 @@ ValueExpr = StringLiteralExpr / NumberLiteralExpr
 StringLiteralExpr = '"' value:$([^\\"] / "\\".)* '"' {
                       return {
                         type: NodeType.STRING_VALUE,
-                        string: value.replace(/\\"/g, '"')
+                        quoteStyle: 'double',
+                        string: value.replace(/\\"/gu, '"')
+                            .replace(/\\\\/gu, '\\')
                       };
                     }
                   / "'" value:$([^\\'] / "\\".)* "'" {
                       return {
                         type: NodeType.STRING_VALUE,
+                        quoteStyle: 'single',
                         string: value.replace(/\\'/g, "'")
+                            .replace(/\\\\/gu, '\\')
                       };
                     }
 

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -1373,6 +1373,28 @@ describe('Parser', function() {
     expect(node).to.deep.equal(expectedNode);
   });
 
+  it('should return a string value type node when \'"\\string with\\ \\"escapes\\\\"\' arrived', function() {
+    const typeExprStr = '"\\string with\\ \\"escapes\\\\"';
+    const node = Parser.parse(typeExprStr);
+
+    const expectedNode = createStringValueNode('\\string with\\ "escapes\\');
+    expect(node).to.deep.equal(expectedNode);
+  });
+
+  it('should throw for string value type node with unescaped quotes', function() {
+    const typeExprStr = '"string with "unescaped quote"';
+    expect(function () {
+      Parser.parse(typeExprStr);
+    }).to.throw('or end of input but "u" found.');
+  });
+
+  it('should throw for string value type node with unescaped quotes (preceded by escaped backslash)', function() {
+    const typeExprStr = '"string with \\\\"unescaped quote"';
+    expect(function () {
+      Parser.parse(typeExprStr);
+    }).to.throw('or end of input but "u" found.');
+  });
+
 
   it('should throw a syntax error when "" arrived', function() {
     const typeExprStr = '';
@@ -1635,9 +1657,10 @@ function createNumberValueNode(numberLiteral) {
   };
 }
 
-function createStringValueNode(stringLiteral) {
+function createStringValueNode(stringLiteral, quoteStyle = 'double') {
   return {
     type: NodeType.STRING_VALUE,
+    quoteStyle,
     string: stringLiteral,
   };
 }

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -304,14 +304,19 @@ describe('publish', function() {
     expect(publish(node)).to.equal('"stringValue"');
   });
 
-  it('should return a string value with escaped quote type', function() {
+  it('should return a string value type with escaped quote', function() {
     const node = parse('"string \\"Value"');
     expect(publish(node)).to.equal('"string \\"Value"');
   });
 
-  it('should return an escaped string value type', function() {
-    const node = parse('"\\str\\ing\\\\Value and end backslash: \\\\"');
-    expect(publish(node)).to.equal('"\\\\str\\\\ing\\\\\\\\Value and end backslash: \\\\\\\\"');
+  it('should return a string value type with single extra backslash for odd count backslash series not before a quote', function() {
+    const node = parse('"\\Odd count backslash sequence not before a quote\\add\\\\\\one backslash\\."');
+    expect(publish(node)).to.equal('"\\\\Odd count backslash sequence not before a quote\\\\add\\\\\\\\one backslash\\\\."');
+  });
+
+  it('should return a string value type without adding backslashes for escaped backslash sequences (i.e., even count)', function() {
+    const node = parse('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
+    expect(publish(node)).to.equal('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
   });
 
 

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -515,6 +515,7 @@ function createImportNode(path) {
 function createStringLiteral(string) {
   return {
     type: NodeType.STRING_VALUE,
+    quoteStyle: 'double',
     string: string,
   }
 }


### PR DESCRIPTION
- Fix/Enhancement: Preserve quote style information (single or double) for strings from parsing to publishing
- Fix: In parsing/grammar, strip extra backslashes in strings for results; these serve as backslash escapes within a string  (had already added them for publishing)
- Testing: Add parsing tests that throw for unescaped quotes in strings; add publishing tests for odd/even backslashes in strings
- Testing: Add tests for single quote string

(Builds on 1a7dbc7c5373dc31b3d24afd8bd684e5b9902573 and e31fea3f2db0c77a05ca68c61cc063eea798865d which I added to `master` as small fixes before realizing I needed some additional work as presented in this PR.)

~I hope to also add similar fixes to allow similar fixes related to quotes and backslashes within `MemberName`.~ *(Now in PR #71)*