### PR TITLE
Syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {parse, SyntaxError} = require('./lib/parsing.js');
+const {parse, JSDocTypeSyntaxError} = require('./lib/parsing.js');
 const {publish, createDefaultPublisher} = require('./lib/publishing.js');
 const {traverse} = require('./lib/traversing.js');
 const NodeType = require('./lib/NodeType.js');
@@ -14,7 +14,7 @@ const SyntaxType = require('./lib/SyntaxType.js');
  */
 module.exports = {
   parse,
-  SyntaxError,
+  JSDocTypeSyntaxError,
   publish,
   createDefaultPublisher,
   traverse,

--- a/lib/parsing.js
+++ b/lib/parsing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {SyntaxError, parse} = require('../peg_lib/jsdoctype.js');
+const {SyntaxError: JSDocTypeSyntaxError, parse} = require('../peg_lib/jsdoctype.js');
 
 module.exports = {
 
@@ -8,7 +8,7 @@ module.exports = {
    * @constructor
    * @extends {Error}
    */
-  SyntaxError,
+  JSDocTypeSyntaxError,
 
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,6 +1154,12 @@
         "object-keys": "^1.0.11"
       }
     },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
+    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
+    "object.entries-ponyfill": "^1.0.1",
     "pegjs": "^0.10.0",
     "rimraf": "^2.6.3"
   },

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -72,7 +72,7 @@ _  = [ \t\r\n ]*
 /*
  * JavaScript identifier names.
  *
- * NOTE: We does not support UnicodeIDStart and \UnicodeEscapeSequence yet.
+ * NOTE: We do not support UnicodeIDStart and \UnicodeEscapeSequence yet.
  *
  * Spec:
  *   - http://www.ecma-international.org/ecma-262/6.0/index.html#sec-names-and-keywords
@@ -719,7 +719,7 @@ GenericTypeEndToken = ">"
 
 
 /*
- * JSDoc style array of a generic type expressions.
+ * JSDoc style array of generic type expressions.
  *
  * Examples:
  *   - string[]

--- a/tests/test_index.js
+++ b/tests/test_index.js
@@ -6,7 +6,7 @@ const jsdoctypeparser = require('../index.js');
 describe('jsdoctypeparser', function() {
   const expectedTypeMap = {
     parse: 'function',
-    SyntaxError: 'function',
+    JSDocTypeSyntaxError: 'function',
     publish: 'function',
     createDefaultPublisher: 'function',
     traverse: 'function',

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -14,1438 +14,1492 @@ const {
 } = SyntaxType;
 
 describe('Parser', function() {
-  it('should return a type name node when "TypeName" arrived', function() {
-    const typeExprStr = 'TypeName';
-    const node = Parser.parse(typeExprStr);
+  describe('Primitive types', function () {
+    it('should return a number value type node when "0123456789" arrived', function() {
+      const typeExprStr = '0123456789';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createTypeNameNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a number value type node when "0.0" arrived', function() {
+      const typeExprStr = '0.0';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a number value type node when "-0" arrived', function() {
+      const typeExprStr = '-0';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a number value type node when "0b01" arrived', function() {
+      const typeExprStr = '0b01';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a number value type node when "0o01234567" arrived', function() {
+      const typeExprStr = '0o01234567';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a number value type node when "0x0123456789abcdef" arrived', function() {
+      const typeExprStr = '0x0123456789abcdef';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a string value type node when \'""\' arrived', function() {
+      const typeExprStr = '""';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a string value type node when "\'\'" arrived', function() {
+      const typeExprStr = "''";
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('', 'single');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a string value type node when \'"string"\' arrived', function() {
+      const typeExprStr = '"string"';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('string');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a string value type node when \'"マルチバイト"\' arrived', function() {
+      const typeExprStr = '"マルチバイト"';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('マルチバイト');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a string value type node when \'"\\n\\"\\t"\' arrived', function() {
+      const typeExprStr = '"\\n\\"\\t"';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('\\n"\\t');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a string value type node when \'"\\string with\\ \\"escapes\\\\"\' arrived', function() {
+      const typeExprStr = '"\\string with\\ \\"escapes\\\\"';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('\\string with\\ "escapes\\');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should throw for string value type node with unescaped quotes', function() {
+      const typeExprStr = '"string with "unescaped quote"';
+      expect(function () {
+        Parser.parse(typeExprStr);
+      }).to.throw('or end of input but "u" found.');
+    });
+
+    it('should throw for string value type node with unescaped quotes (preceded by escaped backslash)', function() {
+      const typeExprStr = '"string with \\\\"unescaped quote"';
+      expect(function () {
+        Parser.parse(typeExprStr);
+      }).to.throw('or end of input but "u" found.');
+    });
+
+
+    it('should throw a syntax error when "" arrived', function() {
+      const typeExprStr = '';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+    it('should throw a syntax error when "Invalid type" arrived', function() {
+      const typeExprStr = 'Invalid type';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
   });
 
+  describe('Wildcard types', function () {
+    it('should return an any type node when "*" arrived', function() {
+      const typeExprStr = '*';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return a type name node when "my-type" arrived', function() {
-    const typeExprStr = 'my-type';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createAnyTypeNode();
+      expect(node).to.deep.equal(expectedNode);
+    });
 
-    const expectedNode = createTypeNameNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
+
+    it('should return an unknown type node when "?" arrived', function() {
+      const typeExprStr = '?';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createUnknownTypeNode();
+      expect(node).to.deep.equal(expectedNode);
+    });
   });
 
+  describe('Generic types', function () {
+    it('should return a generic type node when "[][]" arrived', function() {
+      const typeExprStr = '[][]';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return a type name node when "$" arrived', function() {
-    const typeExprStr = '$';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'),
+        [
+          createTupleTypeNode([]),
+        ],
+        GenericTypeSyntax.SQUARE_BRACKET);
 
-    const expectedNode = createTypeNameNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a generic type node when "[TupleType][]" arrived', function() {
+      const typeExprStr = '[TupleType][]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'),
+        [
+          createTupleTypeNode([
+            createTypeNameNode('TupleType'),
+          ]),
+        ],
+        GenericTypeSyntax.SQUARE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a generic type node when "[TupleType1, TupleType2][]" arrived', function() {
+      const typeExprStr = '[TupleType1, TupleType2][]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'),
+        [
+          createTupleTypeNode([
+            createTypeNameNode('TupleType1'),
+            createTypeNameNode('TupleType2'),
+          ]),
+        ],
+        GenericTypeSyntax.SQUARE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic<ParamType>" arrived', function() {
+      const typeExprStr = 'Generic<ParamType>';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType'),
+      ], GenericTypeSyntax.ANGLE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic<Inner<ParamType>>" arrived', function() {
+      const typeExprStr = 'Generic<Inner<ParamType>>';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createGenericTypeNode(
+            createTypeNameNode('Inner'), [ createTypeNameNode('ParamType') ]
+          ),
+      ], GenericTypeSyntax.ANGLE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic<ParamType1,ParamType2>"' +
+       ' arrived', function() {
+      const typeExprStr = 'Generic<ParamType1,ParamType2>';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType1'),
+          createTypeNameNode('ParamType2'),
+        ], GenericTypeSyntax.ANGLE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic < ParamType1 , ParamType2 >"' +
+       ' arrived', function() {
+      const typeExprStr = 'Generic < ParamType1, ParamType2 >';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType1'),
+          createTypeNameNode('ParamType2'),
+        ], GenericTypeSyntax.ANGLE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic.<ParamType>" arrived', function() {
+      const typeExprStr = 'Generic.<ParamType>';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType'),
+      ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic.<ParamType1,ParamType2>"' +
+       ' arrived', function() {
+      const typeExprStr = 'Generic.<ParamType1,ParamType2>';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType1'),
+          createTypeNameNode('ParamType2'),
+        ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "Generic .< ParamType1 , ParamType2 >"' +
+       ' arrived', function() {
+      const typeExprStr = 'Generic .< ParamType1 , ParamType2 >';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Generic'), [
+          createTypeNameNode('ParamType1'),
+          createTypeNameNode('ParamType2'),
+        ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "ParamType[]" arrived', function() {
+      const typeExprStr = 'ParamType[]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'), [
+          createTypeNameNode('ParamType'),
+        ], GenericTypeSyntax.SQUARE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "ParamType[][]" arrived', function() {
+      const typeExprStr = 'ParamType[][]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'), [
+          createGenericTypeNode(
+            createTypeNameNode('Array'), [
+              createTypeNameNode('ParamType'),
+          ], GenericTypeSyntax.SQUARE_BRACKET),
+        ], GenericTypeSyntax.SQUARE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a generic type node when "ParamType [ ] [ ]" arrived', function() {
+      const typeExprStr = 'ParamType [ ] [ ]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createGenericTypeNode(
+        createTypeNameNode('Array'), [
+          createGenericTypeNode(
+            createTypeNameNode('Array'), [
+              createTypeNameNode('ParamType'),
+          ], GenericTypeSyntax.SQUARE_BRACKET),
+        ], GenericTypeSyntax.SQUARE_BRACKET);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should throw a syntax error when "Promise*Error" arrived', function() {
+      const typeExprStr = 'Promise*Error';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
   });
 
+  describe('Record types', function () {
+    it('should return a record type node when "{}" arrived', function() {
+      const typeExprStr = '{}';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return a type name node when "_" arrived', function() {
-    const typeExprStr = '_';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createRecordTypeNode([]);
 
-    const expectedNode = createTypeNameNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{key:ValueType}" arrived', function() {
+      const typeExprStr = '{key:ValueType}';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key', createTypeNameNode('ValueType')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{keyOnly}" arrived', function() {
+      const typeExprStr = '{keyOnly}';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('keyOnly', null),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{key1:ValueType1,key2:ValueType2}"' +
+       ' arrived', function() {
+      const typeExprStr = '{key1:ValueType1,key2:ValueType2}';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
+        createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{key:ValueType1,keyOnly}"' +
+       ' arrived', function() {
+      const typeExprStr = '{key:ValueType1,keyOnly}';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key', createTypeNameNode('ValueType1')),
+        createRecordEntryNode('keyOnly', null),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{ key1 : ValueType1 , key2 : ValueType2 }"' +
+       ' arrived', function() {
+      const typeExprStr = '{ key1 : ValueType1 , key2 : ValueType2 }';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
+        createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a record type node when "{\'quoted-key\':ValueType}"' +
+       ' arrived', function() {
+      const typeExprStr = '{\'quoted-key\':ValueType}';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('quoted-key', createTypeNameNode('ValueType')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
   });
 
+  describe('Tuple types', function () {
+    it('should return a tuple type node when "[]" arrived', function() {
+      const typeExprStr = '[]';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return an any type node when "*" arrived', function() {
-    const typeExprStr = '*';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createTupleTypeNode([]);
 
-    const expectedNode = createAnyTypeNode();
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
+    it('should return a tuple type node when "[TupleType]" arrived', function() {
+      const typeExprStr = '[TupleType]';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return an unknown type node when "?" arrived', function() {
-    const typeExprStr = '?';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createTupleTypeNode([
+        createTypeNameNode('TupleType'),
+      ]);
 
-    const expectedNode = createUnknownTypeNode();
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
+    it('should return a tuple type node when "[TupleType1, TupleType2]" arrived', function() {
+      const typeExprStr = '[TupleType1, TupleType2]';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return an optional unknown type node when "?=" arrived', function() {
-    const typeExprStr = '?=';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createTupleTypeNode([
+        createTypeNameNode('TupleType1'),
+        createTypeNameNode('TupleType2'),
+      ]);
 
-    const expectedNode = createOptionalTypeNode(
-      createUnknownTypeNode(),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a module name node when "module:path/to/file" arrived', function() {
-    const typeExprStr = 'module:path/to/file';
-    const node = Parser.parse(typeExprStr);
+    it('should return a tuple type node when "[TupleConcreteType, ...TupleVarargsType]" arrived', function() {
+      const typeExprStr = '[TupleConcreteType, ...TupleVarargsType]';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createModuleNameNode(createFilePathNode('path/to/file'));
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a module name node when "module : path/to/file" arrived', function() {
-    const typeExprStr = 'module : path/to/file';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createModuleNameNode(createFilePathNode('path/to/file'));
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member node when "(module:path/to/file).member" arrived', function() {
-    const typeExprStr = '(module:path/to/file).member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createParenthesizedNode(
-        createModuleNameNode(createFilePathNode('path/to/file'))
-      ),
-      'member'
-    );
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member node when "module:path/to/file.member" arrived', function() {
-    const typeExprStr = 'module:path/to/file.member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createModuleNameNode(
-      createMemberTypeNode(createFilePathNode('path/to/file'), 'member')
-    );
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a member node when "module:path/to/file.event:member" arrived', function() {
-    const typeExprStr = 'module:path/to/file.event:member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createModuleNameNode(
-      createMemberTypeNode(createFilePathNode('path/to/file'), 'member', 'none', true)
-    );
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a module name node when "external:string" arrived', function() {
-    const typeExprStr = 'external:string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createExternalNameNode(createTypeNameNode('string'));
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a module name node when "external : String#rot13" arrived', function() {
-    const typeExprStr = 'external : String#rot13';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createExternalNameNode(
-      createInstanceMemberTypeNode(createTypeNameNode('String'), 'rot13'));
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when "owner.Member" arrived', function() {
-    const typeExprStr = 'owner.Member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Member');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when "owner . Member" arrived', function() {
-    const typeExprStr = 'owner . Member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Member');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when \'owner."Mem.ber"\' arrived', function() {
-    const typeExprStr = 'owner."Mem.ber"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Mem.ber',
-      'double');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a member type node when \'owner."Mem\\ber"\' arrived', function() {
-    const typeExprStr = 'owner."Mem\\ber"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Mem\\ber',
-      'double');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a member type node when \'owner."Mem.ber\\""\' arrived', function() {
-    const typeExprStr = 'owner."Mem.ber\\""';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Mem.ber"',
-      'double'
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a member type node when \'owner."Mem\\\\ber\\""\' arrived', function() {
-    const typeExprStr = 'owner."Mem\\\\ber\\""';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Mem\\ber"',
-      'double');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when "superOwner.owner.Member" arrived', function() {
-    const typeExprStr = 'superOwner.owner.Member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-        createMemberTypeNode(
-          createTypeNameNode('superOwner'), 'owner'),
-        'Member');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when "superOwner.owner.Member=" arrived', function() {
-    const typeExprStr = 'superOwner.owner.Member=';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createMemberTypeNode(
-        createMemberTypeNode(
-          createTypeNameNode('superOwner'),
-        'owner'),
-      'Member'),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an inner member type node when "owner~innerMember" arrived', function() {
-    const typeExprStr = 'owner~innerMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInnerMemberTypeNode(
-      createTypeNameNode('owner'),
-      'innerMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an inner member type node when "owner ~ innerMember" arrived', function() {
-    const typeExprStr = 'owner ~ innerMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInnerMemberTypeNode(
-      createTypeNameNode('owner'),
-      'innerMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an inner member type node when "superOwner~owner~innerMember" ' +
-     'arrived', function() {
-    const typeExprStr = 'superOwner~owner~innerMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInnerMemberTypeNode(
-        createInnerMemberTypeNode(
-          createTypeNameNode('superOwner'), 'owner'),
-        'innerMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an inner member type node when "superOwner~owner~innerMember=" ' +
-     'arrived', function() {
-    const typeExprStr = 'superOwner~owner~innerMember=';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createInnerMemberTypeNode(
-        createInnerMemberTypeNode(
-          createTypeNameNode('superOwner'),
-        'owner'),
-      'innerMember'),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an instance member type node when "owner#instanceMember" arrived', function() {
-    const typeExprStr = 'owner#instanceMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInstanceMemberTypeNode(
-      createTypeNameNode('owner'),
-      'instanceMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an instance member type node when "owner # instanceMember" ' +
-     'arrived', function() {
-    const typeExprStr = 'owner # instanceMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInstanceMemberTypeNode(
-      createTypeNameNode('owner'),
-      'instanceMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an instance member type node when "superOwner#owner#instanceMember" ' +
-     'arrived', function() {
-    const typeExprStr = 'superOwner#owner#instanceMember';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createInstanceMemberTypeNode(
-        createInstanceMemberTypeNode(
-          createTypeNameNode('superOwner'), 'owner'),
-        'instanceMember');
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an instance member type node when "superOwner#owner#instanceMember=" ' +
-     'arrived', function() {
-    const typeExprStr = 'superOwner#owner#instanceMember=';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createInstanceMemberTypeNode(
-        createInstanceMemberTypeNode(
-          createTypeNameNode('superOwner'),
-        'owner'),
-      'instanceMember'),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a member type node when "owner.event:Member" arrived', function() {
-    const typeExprStr = 'owner.event:Member';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createMemberTypeNode(
-      createTypeNameNode('owner'),
-      'Member',
-      'none',
-      true);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an union type when "LeftType|RightType" arrived', function() {
-    const typeExprStr = 'LeftType|RightType';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createUnionTypeNode(
-      createTypeNameNode('LeftType'),
-      createTypeNameNode('RightType'),
-      UnionTypeSyntax.PIPE
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an union type when "LeftType|MiddleType|RightType" arrived', function() {
-    const typeExprStr = 'LeftType|MiddleType|RightType';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createUnionTypeNode(
-      createTypeNameNode('LeftType'),
-      createUnionTypeNode(
-        createTypeNameNode('MiddleType'),
-        createTypeNameNode('RightType'),
-        UnionTypeSyntax.PIPE
-      ), UnionTypeSyntax.PIPE);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an union type when "(LeftType|RightType)" arrived', function() {
-    const typeExprStr = '(LeftType|RightType)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createParenthesizedNode(
-      createUnionTypeNode(
-        createTypeNameNode('LeftType'),
-        createTypeNameNode('RightType')
-      )
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an union type when "( LeftType | RightType )" arrived', function() {
-    const typeExprStr = '( LeftType | RightType )';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createParenthesizedNode(
-      createUnionTypeNode(
-        createTypeNameNode('LeftType'),
-        createTypeNameNode('RightType')
-      )
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an union type when "LeftType/RightType" arrived', function() {
-    const typeExprStr = 'LeftType/RightType';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createUnionTypeNode(
-      createTypeNameNode('LeftType'),
-      createTypeNameNode('RightType'),
-      UnionTypeSyntax.SLASH
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{}" arrived', function() {
-    const typeExprStr = '{}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{key:ValueType}" arrived', function() {
-    const typeExprStr = '{key:ValueType}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('key', createTypeNameNode('ValueType')),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{keyOnly}" arrived', function() {
-    const typeExprStr = '{keyOnly}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('keyOnly', null),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{key1:ValueType1,key2:ValueType2}"' +
-     ' arrived', function() {
-    const typeExprStr = '{key1:ValueType1,key2:ValueType2}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
-      createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{key:ValueType1,keyOnly}"' +
-     ' arrived', function() {
-    const typeExprStr = '{key:ValueType1,keyOnly}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('key', createTypeNameNode('ValueType1')),
-      createRecordEntryNode('keyOnly', null),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{ key1 : ValueType1 , key2 : ValueType2 }"' +
-     ' arrived', function() {
-    const typeExprStr = '{ key1 : ValueType1 , key2 : ValueType2 }';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
-      createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a record type node when "{\'quoted-key\':ValueType}"' +
-     ' arrived', function() {
-    const typeExprStr = '{\'quoted-key\':ValueType}';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createRecordTypeNode([
-      createRecordEntryNode('quoted-key', createTypeNameNode('ValueType')),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a tuple type node when "[]" arrived', function() {
-    const typeExprStr = '[]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a tuple type node when "[TupleType]" arrived', function() {
-    const typeExprStr = '[TupleType]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([
-      createTypeNameNode('TupleType'),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a tuple type node when "[TupleType1, TupleType2]" arrived', function() {
-    const typeExprStr = '[TupleType1, TupleType2]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([
-      createTypeNameNode('TupleType1'),
-      createTypeNameNode('TupleType2'),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a tuple type node when "[TupleConcreteType, ...TupleVarargsType]" arrived', function() {
-    const typeExprStr = '[TupleConcreteType, ...TupleVarargsType]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([
-      createTypeNameNode('TupleConcreteType'),
-      createVariadicTypeNode(
-        createTypeNameNode('TupleVarargsType'),
-        VariadicTypeSyntax.PREFIX_DOTS
-      ),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a tuple type node when "[TupleConcreteType, TupleBrokenVarargsType...]" arrived', function() {
-    const typeExprStr = '[TupleConcreteType, TupleBrokenVarargsType...]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([
-      createTypeNameNode('TupleConcreteType'),
-      createVariadicTypeNode(
-        // This is broken because the TypeScript JSDoc parser doesn't support
-        // the suffix dots variadic type syntax:
-        createTypeNameNode('TupleBrokenVarargsType'),
-        VariadicTypeSyntax.SUFFIX_DOTS
-      ),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a tuple type node when "[TupleAnyVarargs, ...]" arrived', function() {
-    const typeExprStr = '[TupleAnyVarargs, ...]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createTupleTypeNode([
-      createTypeNameNode('TupleAnyVarargs'),
-      createVariadicTypeNode(
-        null,
-        VariadicTypeSyntax.ONLY_DOTS
-      ),
-    ]);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a generic type node when "[][]" arrived', function() {
-    const typeExprStr = '[][]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'),
-      [
-        createTupleTypeNode([]),
-      ],
-      GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a generic type node when "[TupleType][]" arrived', function() {
-    const typeExprStr = '[TupleType][]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'),
-      [
-        createTupleTypeNode([
-          createTypeNameNode('TupleType'),
-        ]),
-      ],
-      GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a generic type node when "[TupleType1, TupleType2][]" arrived', function() {
-    const typeExprStr = '[TupleType1, TupleType2][]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'),
-      [
-        createTupleTypeNode([
-          createTypeNameNode('TupleType1'),
-          createTypeNameNode('TupleType2'),
-        ]),
-      ],
-      GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a generic type node when "Generic<ParamType>" arrived', function() {
-    const typeExprStr = 'Generic<ParamType>';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType'),
-    ], GenericTypeSyntax.ANGLE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a generic type node when "Generic<Inner<ParamType>>" arrived', function() {
-    const typeExprStr = 'Generic<Inner<ParamType>>';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createGenericTypeNode(
-          createTypeNameNode('Inner'), [ createTypeNameNode('ParamType') ]
+      const expectedNode = createTupleTypeNode([
+        createTypeNameNode('TupleConcreteType'),
+        createVariadicTypeNode(
+          createTypeNameNode('TupleVarargsType'),
+          VariadicTypeSyntax.PREFIX_DOTS
         ),
-    ], GenericTypeSyntax.ANGLE_BRACKET);
+      ]);
 
-    expect(node).to.deep.equal(expectedNode);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a tuple type node when "[TupleConcreteType, TupleBrokenVarargsType...]" arrived', function() {
+      const typeExprStr = '[TupleConcreteType, TupleBrokenVarargsType...]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createTupleTypeNode([
+        createTypeNameNode('TupleConcreteType'),
+        createVariadicTypeNode(
+          // This is broken because the TypeScript JSDoc parser doesn't support
+          // the suffix dots variadic type syntax:
+          createTypeNameNode('TupleBrokenVarargsType'),
+          VariadicTypeSyntax.SUFFIX_DOTS
+        ),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a tuple type node when "[TupleAnyVarargs, ...]" arrived', function() {
+      const typeExprStr = '[TupleAnyVarargs, ...]';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createTupleTypeNode([
+        createTypeNameNode('TupleAnyVarargs'),
+        createVariadicTypeNode(
+          null,
+          VariadicTypeSyntax.ONLY_DOTS
+        ),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
   });
 
+  describe('Function/Constructor/Arrow types', function () {
+    it('should return a function type node when "function()" arrived', function() {
+      const typeExprStr = 'function()';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return a generic type node when "Generic<ParamType1,ParamType2>"' +
-     ' arrived', function() {
-    const typeExprStr = 'Generic<ParamType1,ParamType2>';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createFunctionTypeNode(
+        [], null,
+        { 'this': null, 'new': null }
+      );
 
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType1'),
-        createTypeNameNode('ParamType2'),
-      ], GenericTypeSyntax.ANGLE_BRACKET);
+      expect(node).to.deep.equal(expectedNode);
+    });
 
-    expect(node).to.deep.equal(expectedNode);
+
+    it('should return a function type node with a param when "function(Param)" arrived', function() {
+      const typeExprStr = 'function(Param)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [ createTypeNameNode('Param') ], null,
+        { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node with several params when "function(Param1,Param2)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(Param1,Param2)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [ createTypeNameNode('Param1'), createTypeNameNode('Param2') ], null,
+        { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node with variadic params when "function(...VariadicParam)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(...VariadicParam)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [
+          createVariadicTypeNode(
+            createTypeNameNode('VariadicParam'),
+            VariadicTypeSyntax.PREFIX_DOTS
+          ),
+        ],
+        null, { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node with variadic params when "function(Param,...VariadicParam)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(Param,...VariadicParam)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [
+          createTypeNameNode('Param'),
+          createVariadicTypeNode(
+            createTypeNameNode('VariadicParam'),
+            VariadicTypeSyntax.PREFIX_DOTS
+          ),
+        ],
+        null, { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should throw an error when "function(...VariadicParam, UnexpectedLastParam)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(...VariadicParam, UnexpectedLastParam)';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+
+    it('should return a function type node with returns when "function():Returned"' +
+       ' arrived', function() {
+      const typeExprStr = 'function():Returned';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [], createTypeNameNode('Returned'),
+        { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node with a context type when "function(this:ThisObject)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(this:ThisObject)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [], null,
+        { 'this': createTypeNameNode('ThisObject'), 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node with a context type when ' +
+       '"function(this:ThisObject, param1)" arrived', function() {
+      const typeExprStr = 'function(this:ThisObject, param1)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [createTypeNameNode('param1')],
+        null,
+        { 'this': createTypeNameNode('ThisObject'), 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node as a constructor when "function(new:NewObject)"' +
+       ' arrived', function() {
+      const typeExprStr = 'function(new:NewObject)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [], null,
+        { 'this': null, 'new': createTypeNameNode('NewObject') }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a function type node as a constructor when ' +
+       '"function(new:NewObject, param1)" arrived', function() {
+      const typeExprStr = 'function(new:NewObject, param1)';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [createTypeNameNode('param1')],
+        null,
+        { 'this': null, 'new': createTypeNameNode('NewObject') }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should throw an error when "function(new:NewObject, this:ThisObject)" ' +
+       'arrived', function() {
+      const typeExprStr = 'function(new:NewObject, this:ThisObject)';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+
+    it('should throw an error when "function(this:ThisObject, new:NewObject)" ' +
+       'arrived', function() {
+      const typeExprStr = 'function(this:ThisObject, new:NewObject)';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+
+    it('should return a function type node when "function( Param1 , Param2 ) : Returned"' +
+       ' arrived', function() {
+      const typeExprStr = 'function( Param1 , Param2 ) : Returned';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createFunctionTypeNode(
+        [ createTypeNameNode('Param1'), createTypeNameNode('Param2') ],
+        createTypeNameNode('Returned'),
+        { 'this': null, 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return an arrow function type node when "() => string" arrived', function() {
+      const typeExprStr = '() => string';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createArrowFunctionTypeNode(
+        [], createTypeNameNode('string'),
+        { 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
   });
 
+  describe('BroadNamepathExpr types', function () {
+    describe('Single component', function () {
+      it('should return a type name node when "TypeName" arrived', function() {
+        const typeExprStr = 'TypeName';
+        const node = Parser.parse(typeExprStr);
 
-  it('should return a generic type node when "Generic < ParamType1 , ParamType2 >"' +
-     ' arrived', function() {
-    const typeExprStr = 'Generic < ParamType1, ParamType2 >';
-    const node = Parser.parse(typeExprStr);
+        const expectedNode = createTypeNameNode(typeExprStr);
+        expect(node).to.deep.equal(expectedNode);
+      });
 
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType1'),
-        createTypeNameNode('ParamType2'),
-      ], GenericTypeSyntax.ANGLE_BRACKET);
 
-    expect(node).to.deep.equal(expectedNode);
+      it('should return a type name node when "my-type" arrived', function() {
+        const typeExprStr = 'my-type';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createTypeNameNode(typeExprStr);
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a type name node when "$" arrived', function() {
+        const typeExprStr = '$';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createTypeNameNode(typeExprStr);
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a type name node when "_" arrived', function() {
+        const typeExprStr = '_';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createTypeNameNode(typeExprStr);
+        expect(node).to.deep.equal(expectedNode);
+      });
+    });
+    describe('Multipart', function () {
+      it('should return a member type node when "owner.Member" arrived', function() {
+        const typeExprStr = 'owner.Member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Member'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member type node when "owner . Member" arrived', function() {
+        const typeExprStr = 'owner . Member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Member');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member type node when \'owner."Mem.ber"\' arrived', function() {
+        const typeExprStr = 'owner."Mem.ber"';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Mem.ber',
+          'double'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when \'owner."Mem\\ber"\' arrived', function() {
+        const typeExprStr = 'owner."Mem\\ber"';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Mem\\ber',
+          'double'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when "owner.\'Mem\\ber\'" arrived', function() {
+        const typeExprStr = 'owner.\'Mem\\ber\'';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Mem\\ber',
+          'single'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when \'owner."Mem.ber\\""\' arrived', function() {
+        const typeExprStr = 'owner."Mem.ber\\""';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Mem.ber"',
+          'double'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when \'owner."Me\\m\\\\ber"\' arrived', function() {
+        const typeExprStr = 'owner."Me\\m\\"ber\\\\"';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Me\\m"ber\\',
+          'double');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when \'owner."Mem\\\\ber\\""\' arrived', function() {
+        const typeExprStr = 'owner."Mem\\\\ber\\""';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Mem\\ber"',
+          'double');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should throw when \'owner."Mem.ber\\"\' arrived', function() {
+        const typeExprStr = 'owner."Mem.ber\\"';
+        expect(function () {
+          Parser.parse(typeExprStr);
+        }).to.throw('Expected "\\""');
+      });
+
+
+      it('should return a member type node when "superOwner.owner.Member" arrived', function() {
+        const typeExprStr = 'superOwner.owner.Member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+            createMemberTypeNode(
+              createTypeNameNode('superOwner'), 'owner'),
+            'Member');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member type node when "superOwner.owner.Member=" arrived', function() {
+        const typeExprStr = 'superOwner.owner.Member=';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createOptionalTypeNode(
+          createMemberTypeNode(
+            createMemberTypeNode(
+              createTypeNameNode('superOwner'),
+            'owner'),
+          'Member'),
+          OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an inner member type node when "owner~innerMember" arrived', function() {
+        const typeExprStr = 'owner~innerMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInnerMemberTypeNode(
+          createTypeNameNode('owner'),
+          'innerMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an inner member type node when "owner ~ innerMember" arrived', function() {
+        const typeExprStr = 'owner ~ innerMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInnerMemberTypeNode(
+          createTypeNameNode('owner'),
+          'innerMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an inner member type node when "superOwner~owner~innerMember" ' +
+         'arrived', function() {
+        const typeExprStr = 'superOwner~owner~innerMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInnerMemberTypeNode(
+            createInnerMemberTypeNode(
+              createTypeNameNode('superOwner'), 'owner'),
+            'innerMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an inner member type node when "superOwner~owner~innerMember=" ' +
+         'arrived', function() {
+        const typeExprStr = 'superOwner~owner~innerMember=';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createOptionalTypeNode(
+          createInnerMemberTypeNode(
+            createInnerMemberTypeNode(
+              createTypeNameNode('superOwner'),
+            'owner'),
+          'innerMember'),
+          OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an instance member type node when "owner#instanceMember" arrived', function() {
+        const typeExprStr = 'owner#instanceMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+          createTypeNameNode('owner'),
+          'instanceMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an instance member type node when "owner # instanceMember" ' +
+         'arrived', function() {
+        const typeExprStr = 'owner # instanceMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+          createTypeNameNode('owner'),
+          'instanceMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an instance member type node when "superOwner#owner#instanceMember" ' +
+         'arrived', function() {
+        const typeExprStr = 'superOwner#owner#instanceMember';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+            createInstanceMemberTypeNode(
+              createTypeNameNode('superOwner'), 'owner'),
+            'instanceMember');
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return an instance member type node when "superOwner#owner#instanceMember=" ' +
+         'arrived', function() {
+        const typeExprStr = 'superOwner#owner#instanceMember=';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createOptionalTypeNode(
+          createInstanceMemberTypeNode(
+            createInstanceMemberTypeNode(
+              createTypeNameNode('superOwner'),
+            'owner'),
+          'instanceMember'),
+          OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member type node when "owner.event:Member" arrived', function() {
+        const typeExprStr = 'owner.event:Member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          'Member',
+          'none',
+          true);
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+    });
+    describe('external', function () {
+      it('should return a module name node when "external:string" arrived', function() {
+        const typeExprStr = 'external:string';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createExternalNameNode(createTypeNameNode('string'));
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a module name node when "external : String#rot13" arrived', function() {
+        const typeExprStr = 'external : String#rot13';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createExternalNameNode(
+          createInstanceMemberTypeNode(createTypeNameNode('String'), 'rot13'));
+        expect(node).to.deep.equal(expectedNode);
+      });
+    });
+
+    describe('module', function () {
+      it('should return a module name node when "module:path/to/file" arrived', function() {
+        const typeExprStr = 'module:path/to/file';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(createFilePathNode('path/to/file'));
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a module name node when "module : path/to/file" arrived', function() {
+        const typeExprStr = 'module : path/to/file';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(createFilePathNode('path/to/file'));
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member node when "(module:path/to/file).member" arrived', function() {
+        const typeExprStr = '(module:path/to/file).member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createParenthesizedNode(
+            createModuleNameNode(createFilePathNode('path/to/file'))
+          ),
+          'member'
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+
+      it('should return a member node when "module:path/to/file.member" arrived', function() {
+        const typeExprStr = 'module:path/to/file.member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(
+          createMemberTypeNode(createFilePathNode('path/to/file'), 'member')
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member node when "module:path/to/file.event:member" arrived', function() {
+        const typeExprStr = 'module:path/to/file.event:member';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(
+          createMemberTypeNode(createFilePathNode('path/to/file'), 'member', 'none', true)
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+    });
   });
 
+  describe('Types with modifiers', function () {
+    it('should return an optional unknown type node when "?=" arrived', function() {
+      const typeExprStr = '?=';
+      const node = Parser.parse(typeExprStr);
 
-  it('should return a generic type node when "Generic.<ParamType>" arrived', function() {
-    const typeExprStr = 'Generic.<ParamType>';
-    const node = Parser.parse(typeExprStr);
+      const expectedNode = createOptionalTypeNode(
+        createUnknownTypeNode(),
+        OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+      );
+      expect(node).to.deep.equal(expectedNode);
+    });
 
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType'),
-    ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
+    it('should return an optional type node when "string=" arrived', function() {
+      const typeExprStr = 'string=';
+      const node = Parser.parse(typeExprStr);
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      const expectedNode = createOptionalTypeNode(
+        createTypeNameNode('string'),
+        OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+      );
 
-
-  it('should return a generic type node when "Generic.<ParamType1,ParamType2>"' +
-     ' arrived', function() {
-    const typeExprStr = 'Generic.<ParamType1,ParamType2>';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType1'),
-        createTypeNameNode('ParamType2'),
-      ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a generic type node when "Generic .< ParamType1 , ParamType2 >"' +
-     ' arrived', function() {
-    const typeExprStr = 'Generic .< ParamType1 , ParamType2 >';
-    const node = Parser.parse(typeExprStr);
+    it('should return an optional type node when "=string" arrived (deprecated)', function() {
+      const typeExprStr = '=string';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Generic'), [
-        createTypeNameNode('ParamType1'),
-        createTypeNameNode('ParamType2'),
-      ], GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT);
+      const expectedNode = createOptionalTypeNode(
+        createTypeNameNode('string'),
+        OptionalTypeSyntax.PREFIX_EQUALS_SIGN
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a generic type node when "ParamType[]" arrived', function() {
-    const typeExprStr = 'ParamType[]';
-    const node = Parser.parse(typeExprStr);
+    it('should return a nullable type node when "?string" arrived', function() {
+      const typeExprStr = '?string';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'), [
-        createTypeNameNode('ParamType'),
-      ], GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a generic type node when "ParamType[][]" arrived', function() {
-    const typeExprStr = 'ParamType[][]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'), [
-        createGenericTypeNode(
-          createTypeNameNode('Array'), [
-            createTypeNameNode('ParamType'),
-        ], GenericTypeSyntax.SQUARE_BRACKET),
-      ], GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a generic type node when "ParamType [ ] [ ]" arrived', function() {
-    const typeExprStr = 'ParamType [ ] [ ]';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createGenericTypeNode(
-      createTypeNameNode('Array'), [
-        createGenericTypeNode(
-          createTypeNameNode('Array'), [
-            createTypeNameNode('ParamType'),
-        ], GenericTypeSyntax.SQUARE_BRACKET),
-      ], GenericTypeSyntax.SQUARE_BRACKET);
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an optional type node when "string=" arrived', function() {
-    const typeExprStr = 'string=';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createTypeNameNode('string'),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an optional type node when "=string" arrived (deprecated)', function() {
-    const typeExprStr = '=string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createTypeNameNode('string'),
-      OptionalTypeSyntax.PREFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a nullable type node when "?string" arrived', function() {
-    const typeExprStr = '?string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNullableTypeNode(
-      createTypeNameNode('string'),
-      NullableTypeSyntax.PREFIX_QUESTION_MARK
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a nullable type node when "string?" arrived (deprecated)', function() {
-    const typeExprStr = 'string?';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNullableTypeNode(
-      createTypeNameNode('string'),
-      NullableTypeSyntax.SUFFIX_QUESTION_MARK
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an optional type node when "string =" arrived', function() {
-    const typeExprStr = 'string =';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createTypeNameNode('string'),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an optional type node when "= string" arrived (deprecated)', function() {
-    const typeExprStr = '= string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createTypeNameNode('string'),
-      OptionalTypeSyntax.PREFIX_EQUALS_SIGN
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a nullable type node when "? string" arrived', function() {
-    const typeExprStr = '? string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNullableTypeNode(
-      createTypeNameNode('string'),
-      NullableTypeSyntax.PREFIX_QUESTION_MARK
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a nullable type node when "string ?" arrived (deprecated)', function() {
-    const typeExprStr = 'string ?';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNullableTypeNode(
-      createTypeNameNode('string'),
-      NullableTypeSyntax.SUFFIX_QUESTION_MARK
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return an optional type node when "?string=" arrived', function() {
-    const typeExprStr = '?string=';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createOptionalTypeNode(
-      createNullableTypeNode(
+      const expectedNode = createNullableTypeNode(
         createTypeNameNode('string'),
         NullableTypeSyntax.PREFIX_QUESTION_MARK
-      ),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return an optional type node when "string?=" arrived', function() {
-    const typeExprStr = 'string?=';
-    const node = Parser.parse(typeExprStr);
+    it('should return a nullable type node when "string?" arrived (deprecated)', function() {
+      const typeExprStr = 'string?';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createOptionalTypeNode(
-      createNullableTypeNode(
+      const expectedNode = createNullableTypeNode(
         createTypeNameNode('string'),
         NullableTypeSyntax.SUFFIX_QUESTION_MARK
-      ),
-      OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
-    );
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should throw an error when "?!string" arrived', function() {
-    const typeExprStr = '?!string';
+    it('should return an optional type node when "string =" arrived', function() {
+      const typeExprStr = 'string =';
+      const node = Parser.parse(typeExprStr);
 
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
+      const expectedNode = createOptionalTypeNode(
+        createTypeNameNode('string'),
+        OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+      );
 
-
-  it('should throw an error when "!?string" arrived', function() {
-    const typeExprStr = '!?string';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a variadic type node when "...PrefixVariadic" arrived', function() {
-    const typeExprStr = '...PrefixVariadic';
-    const node = Parser.parse(typeExprStr);
+    it('should return an optional type node when "= string" arrived (deprecated)', function() {
+      const typeExprStr = '= string';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createVariadicTypeNode(
-      createTypeNameNode('PrefixVariadic'),
-      VariadicTypeSyntax.PREFIX_DOTS
-    );
+      const expectedNode = createOptionalTypeNode(
+        createTypeNameNode('string'),
+        OptionalTypeSyntax.PREFIX_EQUALS_SIGN
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a variadic type node when "SuffixVariadic..." arrived', function() {
-    const typeExprStr = 'SuffixVariadic...';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createVariadicTypeNode(
-      createTypeNameNode('SuffixVariadic'),
-      VariadicTypeSyntax.SUFFIX_DOTS
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a variadic type node when "..." arrived', function() {
-    const typeExprStr = '...';
-    const node = Parser.parse(typeExprStr);
+    it('should return a nullable type node when "? string" arrived', function() {
+      const typeExprStr = '? string';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createVariadicTypeNode(
-      null,
-      VariadicTypeSyntax.ONLY_DOTS
-    );
+      const expectedNode = createNullableTypeNode(
+        createTypeNameNode('string'),
+        NullableTypeSyntax.PREFIX_QUESTION_MARK
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a variadic type node when "...!Object" arrived', function() {
-    const typeExprStr = '...!Object';
-    const node = Parser.parse(typeExprStr);
+    it('should return a nullable type node when "string ?" arrived (deprecated)', function() {
+      const typeExprStr = 'string ?';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createVariadicTypeNode(
-      createNotNullableTypeNode(
+      const expectedNode = createNullableTypeNode(
+        createTypeNameNode('string'),
+        NullableTypeSyntax.SUFFIX_QUESTION_MARK
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return an optional type node when "?string=" arrived', function() {
+      const typeExprStr = '?string=';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createOptionalTypeNode(
+        createNullableTypeNode(
+          createTypeNameNode('string'),
+          NullableTypeSyntax.PREFIX_QUESTION_MARK
+        ),
+        OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return an optional type node when "string?=" arrived', function() {
+      const typeExprStr = 'string?=';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createOptionalTypeNode(
+        createNullableTypeNode(
+          createTypeNameNode('string'),
+          NullableTypeSyntax.SUFFIX_QUESTION_MARK
+        ),
+        OptionalTypeSyntax.SUFFIX_EQUALS_SIGN
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should throw an error when "?!string" arrived', function() {
+      const typeExprStr = '?!string';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+
+    it('should throw an error when "!?string" arrived', function() {
+      const typeExprStr = '!?string';
+
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
+
+    it('should return a variadic type node when "...PrefixVariadic" arrived', function() {
+      const typeExprStr = '...PrefixVariadic';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createVariadicTypeNode(
+        createTypeNameNode('PrefixVariadic'),
+        VariadicTypeSyntax.PREFIX_DOTS
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a variadic type node when "SuffixVariadic..." arrived', function() {
+      const typeExprStr = 'SuffixVariadic...';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createVariadicTypeNode(
+        createTypeNameNode('SuffixVariadic'),
+        VariadicTypeSyntax.SUFFIX_DOTS
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a variadic type node when "..." arrived', function() {
+      const typeExprStr = '...';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createVariadicTypeNode(
+        null,
+        VariadicTypeSyntax.ONLY_DOTS
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a variadic type node when "...!Object" arrived', function() {
+      const typeExprStr = '...!Object';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createVariadicTypeNode(
+        createNotNullableTypeNode(
+          createTypeNameNode('Object'),
+          NotNullableTypeSyntax.PREFIX_BANG
+        ),
+        VariadicTypeSyntax.PREFIX_DOTS
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a variadic type node when "...?" arrived', function() {
+      const typeExprStr = '...?';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createVariadicTypeNode(
+        createUnknownTypeNode(),
+        VariadicTypeSyntax.PREFIX_DOTS
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a not nullable type node when "!Object" arrived', function() {
+      const typeExprStr = '!Object';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNotNullableTypeNode(
         createTypeNameNode('Object'),
         NotNullableTypeSyntax.PREFIX_BANG
-      ),
-      VariadicTypeSyntax.PREFIX_DOTS
-    );
+      );
 
-    expect(node).to.deep.equal(expectedNode);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a not nullable type node when "Object!" arrived', function() {
+      const typeExprStr = 'Object!';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNotNullableTypeNode(
+        createTypeNameNode('Object'),
+        NotNullableTypeSyntax.SUFFIX_BANG
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a not nullable type node when "! Object" arrived', function() {
+      const typeExprStr = '! Object';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNotNullableTypeNode(
+        createTypeNameNode('Object'),
+        NotNullableTypeSyntax.PREFIX_BANG
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+
+    it('should return a not nullable type node when "Object !" arrived', function() {
+      const typeExprStr = 'Object !';
+      const node = Parser.parse(typeExprStr);
+
+      const expectedNode = createNotNullableTypeNode(
+        createTypeNameNode('Object'),
+        NotNullableTypeSyntax.SUFFIX_BANG
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
   });
 
+  describe('Type combinations', function () {
 
-  it('should return a variadic type node when "...?" arrived', function() {
-    const typeExprStr = '...?';
-    const node = Parser.parse(typeExprStr);
+    it('should return a union type when "LeftType|RightType" arrived', function() {
+      const typeExprStr = 'LeftType|RightType';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createVariadicTypeNode(
-      createUnknownTypeNode(),
-      VariadicTypeSyntax.PREFIX_DOTS
-    );
+      const expectedNode = createUnionTypeNode(
+        createTypeNameNode('LeftType'),
+        createTypeNameNode('RightType'),
+        UnionTypeSyntax.PIPE
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a not nullable type node when "!Object" arrived', function() {
-    const typeExprStr = '!Object';
-    const node = Parser.parse(typeExprStr);
+    it('should return a union type when "LeftType|MiddleType|RightType" arrived', function() {
+      const typeExprStr = 'LeftType|MiddleType|RightType';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createNotNullableTypeNode(
-      createTypeNameNode('Object'),
-      NotNullableTypeSyntax.PREFIX_BANG
-    );
+      const expectedNode = createUnionTypeNode(
+        createTypeNameNode('LeftType'),
+        createUnionTypeNode(
+          createTypeNameNode('MiddleType'),
+          createTypeNameNode('RightType'),
+          UnionTypeSyntax.PIPE
+        ), UnionTypeSyntax.PIPE);
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a not nullable type node when "Object!" arrived', function() {
-    const typeExprStr = 'Object!';
-    const node = Parser.parse(typeExprStr);
+    it('should return a union type when "(LeftType|RightType)" arrived', function() {
+      const typeExprStr = '(LeftType|RightType)';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createNotNullableTypeNode(
-      createTypeNameNode('Object'),
-      NotNullableTypeSyntax.SUFFIX_BANG
-    );
+      const expectedNode = createParenthesizedNode(
+        createUnionTypeNode(
+          createTypeNameNode('LeftType'),
+          createTypeNameNode('RightType')
+        )
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a not nullable type node when "! Object" arrived', function() {
-    const typeExprStr = '! Object';
-    const node = Parser.parse(typeExprStr);
+    it('should return a union type when "( LeftType | RightType )" arrived', function() {
+      const typeExprStr = '( LeftType | RightType )';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createNotNullableTypeNode(
-      createTypeNameNode('Object'),
-      NotNullableTypeSyntax.PREFIX_BANG
-    );
+      const expectedNode = createParenthesizedNode(
+        createUnionTypeNode(
+          createTypeNameNode('LeftType'),
+          createTypeNameNode('RightType')
+        )
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
 
-  it('should return a not nullable type node when "Object !" arrived', function() {
-    const typeExprStr = 'Object !';
-    const node = Parser.parse(typeExprStr);
+    it('should return a union type when "LeftType/RightType" arrived', function() {
+      const typeExprStr = 'LeftType/RightType';
+      const node = Parser.parse(typeExprStr);
 
-    const expectedNode = createNotNullableTypeNode(
-      createTypeNameNode('Object'),
-      NotNullableTypeSyntax.SUFFIX_BANG
-    );
+      const expectedNode = createUnionTypeNode(
+        createTypeNameNode('LeftType'),
+        createTypeNameNode('RightType'),
+        UnionTypeSyntax.SLASH
+      );
 
-    expect(node).to.deep.equal(expectedNode);
-  });
+      expect(node).to.deep.equal(expectedNode);
+    });
 
+    it('should throw a syntax error when "(unclosedParenthesis, " arrived', function() {
+      const typeExprStr = '(unclosedParenthesis, ';
 
-  it('should return a function type node when "function()" arrived', function() {
-    const typeExprStr = 'function()';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [], null,
-      { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with a param when "function(Param)" arrived', function() {
-    const typeExprStr = 'function(Param)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [ createTypeNameNode('Param') ], null,
-      { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with several params when "function(Param1,Param2)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(Param1,Param2)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [ createTypeNameNode('Param1'), createTypeNameNode('Param2') ], null,
-      { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with variadic params when "function(...VariadicParam)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(...VariadicParam)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [
-        createVariadicTypeNode(
-          createTypeNameNode('VariadicParam'),
-          VariadicTypeSyntax.PREFIX_DOTS
-        ),
-      ],
-      null, { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with variadic params when "function(Param,...VariadicParam)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(Param,...VariadicParam)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [
-        createTypeNameNode('Param'),
-        createVariadicTypeNode(
-          createTypeNameNode('VariadicParam'),
-          VariadicTypeSyntax.PREFIX_DOTS
-        ),
-      ],
-      null, { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should throw an error when "function(...VariadicParam, UnexpectedLastParam)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(...VariadicParam, UnexpectedLastParam)';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should return a function type node with returns when "function():Returned"' +
-     ' arrived', function() {
-    const typeExprStr = 'function():Returned';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [], createTypeNameNode('Returned'),
-      { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with a context type when "function(this:ThisObject)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(this:ThisObject)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [], null,
-      { 'this': createTypeNameNode('ThisObject'), 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node with a context type when ' +
-     '"function(this:ThisObject, param1)" arrived', function() {
-    const typeExprStr = 'function(this:ThisObject, param1)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [createTypeNameNode('param1')],
-      null,
-      { 'this': createTypeNameNode('ThisObject'), 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node as a constructor when "function(new:NewObject)"' +
-     ' arrived', function() {
-    const typeExprStr = 'function(new:NewObject)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [], null,
-      { 'this': null, 'new': createTypeNameNode('NewObject') }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a function type node as a constructor when ' +
-     '"function(new:NewObject, param1)" arrived', function() {
-    const typeExprStr = 'function(new:NewObject, param1)';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [createTypeNameNode('param1')],
-      null,
-      { 'this': null, 'new': createTypeNameNode('NewObject') }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return an arrow function type node when "() => string" arrived', function() {
-    const typeExprStr = '() => string';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createArrowFunctionTypeNode(
-      [], createTypeNameNode('string'),
-      { 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should throw an error when "function(new:NewObject, this:ThisObject)" ' +
-     'arrived', function() {
-    const typeExprStr = 'function(new:NewObject, this:ThisObject)';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should throw an error when "function(this:ThisObject, new:NewObject)" ' +
-     'arrived', function() {
-    const typeExprStr = 'function(this:ThisObject, new:NewObject)';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should return a function type node when "function( Param1 , Param2 ) : Returned"' +
-     ' arrived', function() {
-    const typeExprStr = 'function( Param1 , Param2 ) : Returned';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createFunctionTypeNode(
-      [ createTypeNameNode('Param1'), createTypeNameNode('Param2') ],
-      createTypeNameNode('Returned'),
-      { 'this': null, 'new': null }
-    );
-
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "0123456789" arrived', function() {
-    const typeExprStr = '0123456789';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "0.0" arrived', function() {
-    const typeExprStr = '0.0';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "-0" arrived', function() {
-    const typeExprStr = '-0';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "0b01" arrived', function() {
-    const typeExprStr = '0b01';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "0o01234567" arrived', function() {
-    const typeExprStr = '0o01234567';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a number value type node when "0x0123456789abcdef" arrived', function() {
-    const typeExprStr = '0x0123456789abcdef';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createNumberValueNode(typeExprStr);
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a string value type node when \'""\' arrived', function() {
-    const typeExprStr = '""';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createStringValueNode('');
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a string value type node when \'"string"\' arrived', function() {
-    const typeExprStr = '"string"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createStringValueNode('string');
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a string value type node when \'"マルチバイト"\' arrived', function() {
-    const typeExprStr = '"マルチバイト"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createStringValueNode('マルチバイト');
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-
-  it('should return a string value type node when \'"\\n\\"\\t"\' arrived', function() {
-    const typeExprStr = '"\\n\\"\\t"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createStringValueNode('\\n"\\t');
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should return a string value type node when \'"\\string with\\ \\"escapes\\\\"\' arrived', function() {
-    const typeExprStr = '"\\string with\\ \\"escapes\\\\"';
-    const node = Parser.parse(typeExprStr);
-
-    const expectedNode = createStringValueNode('\\string with\\ "escapes\\');
-    expect(node).to.deep.equal(expectedNode);
-  });
-
-  it('should throw for string value type node with unescaped quotes', function() {
-    const typeExprStr = '"string with "unescaped quote"';
-    expect(function () {
-      Parser.parse(typeExprStr);
-    }).to.throw('or end of input but "u" found.');
-  });
-
-  it('should throw for string value type node with unescaped quotes (preceded by escaped backslash)', function() {
-    const typeExprStr = '"string with \\\\"unescaped quote"';
-    expect(function () {
-      Parser.parse(typeExprStr);
-    }).to.throw('or end of input but "u" found.');
-  });
-
-
-  it('should throw a syntax error when "" arrived', function() {
-    const typeExprStr = '';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should throw a syntax error when "Invalid type" arrived', function() {
-    const typeExprStr = 'Invalid type';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should throw a syntax error when "Promise*Error" arrived', function() {
-    const typeExprStr = 'Promise*Error';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
-  });
-
-
-  it('should throw a syntax error when "(unclosedParenthesis, " arrived', function() {
-    const typeExprStr = '(unclosedParenthesis, ';
-
-    expect(function() {
-      Parser.parse(typeExprStr);
-    }).to.throw(Parser.SyntaxError);
+      expect(function() {
+        Parser.parse(typeExprStr);
+      }).to.throw(Parser.SyntaxError);
+    });
   });
 
 
@@ -1651,21 +1705,21 @@ function createGenericTypeNode(genericTypeName, paramExprs, syntaxType) {
   };
 }
 
+function createArrowFunctionTypeNode(paramNodes, returnedNode, modifierMap) {
+  return {
+    type: NodeType.ARROW,
+    params: paramNodes,
+    returns: returnedNode,
+    new: modifierMap.new,
+  };
+}
+
 function createFunctionTypeNode(paramNodes, returnedNode, modifierMap) {
   return {
     type: NodeType.FUNCTION,
     params: paramNodes,
     returns: returnedNode,
     this: modifierMap.this,
-    new: modifierMap.new,
-  };
-}
-
-function createArrowFunctionTypeNode(paramNodes, returnedNode, modifierMap) {
-  return {
-    type: NodeType.ARROW,
-    params: paramNodes,
-    returns: returnedNode,
     new: modifierMap.new,
   };
 }

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -140,7 +140,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
     it('should throw a syntax error when "Invalid type" arrived', function() {
@@ -148,7 +148,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
   });
 
@@ -370,7 +370,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
   });
 
@@ -633,7 +633,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
 
@@ -715,7 +715,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
 
@@ -725,7 +725,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
 
@@ -1287,7 +1287,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
 
@@ -1296,7 +1296,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
 
     it('should return a variadic type node when "...PrefixVariadic" arrived', function() {
@@ -1498,7 +1498,7 @@ describe('Parser', function() {
 
       expect(function() {
         Parser.parse(typeExprStr);
-      }).to.throw(Parser.SyntaxError);
+      }).to.throw(Parser.JSDocTypeSyntaxError);
     });
   });
 

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -9,371 +9,414 @@ const Publishing = require('../lib/publishing.js');
 const {publish, createDefaultPublisher} = Publishing;
 
 describe('publish', function() {
-  it('should have a default publisher for each node type', function() {
-    const publisher = createDefaultPublisher();
-    expect(Object.getOwnPropertyNames(publisher)).to.include.members(
-      Object.getOwnPropertyNames(NodeType).map(p => NodeType[p])
-    );
+  describe('Publishers', function () {
+    it('should have a default publisher for each node type', function() {
+      const publisher = createDefaultPublisher();
+      expect(Object.getOwnPropertyNames(publisher)).to.include.members(
+        Object.getOwnPropertyNames(NodeType).map(p => NodeType[p])
+      );
+    });
+
+    it('should can take a custom publisher by the 2nd argument', function() {
+      const ast = {
+        type: 'NAME',
+        name: 'MyClass',
+      };
+
+      const customPublisher = createDefaultPublisher();
+      customPublisher.NAME = function(node) {
+        return '<a href="./types/' + node.name + '.html">' + node.name + '</a>';
+      };
+
+      const string = publish(ast, customPublisher);
+      expect(string).to.equal('<a href="./types/MyClass.html">MyClass</a>');
+    });
   });
 
+  describe('Primitive types', function () {
+    it('should return an undefined type with an "undefined" keyword', function() {
+      const node = parse('undefined');
+      expect(publish(node)).to.equal('undefined');
+    });
 
-  it('should return a primitive type name', function() {
-    const node = parse('boolean');
-    expect(publish(node)).to.equal('boolean');
+    it('should return a null type with an "null" keyword', function() {
+      const node = parse('null');
+      expect(publish(node)).to.equal('null');
+    });
+
+    it('should return a primitive (boolean) type name', function() {
+      const node = parse('boolean');
+      expect(publish(node)).to.equal('boolean');
+    });
+
+    it('should return a string value type', function() {
+      const node = parse('"stringValue"');
+      expect(publish(node)).to.equal('"stringValue"');
+    });
+
+    it('should return a string value type (single quotes)', function() {
+      const node = parse("'stringValue'");
+      expect(publish(node)).to.equal("'stringValue'");
+    });
+
+    it('should return a string value type with escaped quote', function() {
+      const node = parse('"string \\"Value"');
+      expect(publish(node)).to.equal('"string \\"Value"');
+    });
+
+    it('should return a string value type with single extra backslash for odd count backslash series not before a quote', function() {
+      const node = parse('"\\Odd count backslash sequence not before a quote\\add\\\\\\one backslash\\."');
+      expect(publish(node)).to.equal('"\\\\Odd count backslash sequence not before a quote\\\\add\\\\\\\\one backslash\\\\."');
+    });
+
+    it('should return a string value type without adding backslashes for escaped backslash sequences (i.e., even count)', function() {
+      const node = parse('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
+      expect(publish(node)).to.equal('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
+    });
+
+
+    it('should return a number value type', function() {
+      const node = parse('0123456789');
+      expect(publish(node)).to.equal('0123456789');
+    });
+
+
+    it('should return a bin number value type', function() {
+      const node = parse('0b01');
+      expect(publish(node)).to.equal('0b01');
+    });
+
+
+    it('should return an oct number value type', function() {
+      const node = parse('0o01234567');
+      expect(publish(node)).to.equal('0o01234567');
+    });
+
+
+    it('should return a hex number value type', function() {
+      const node = parse('0x0123456789abcdef');
+      expect(publish(node)).to.equal('0x0123456789abcdef');
+    });
   });
 
+  describe('Wildcard types', function () {
+    it('should return an all type', function() {
+      const node = parse('*');
+      expect(publish(node)).to.equal('*');
+    });
 
-  it('should return a global type name', function() {
-    const node = parse('Window');
-    expect(publish(node)).to.equal('Window');
+    it('should return an unknown type', function() {
+      const node = parse('?');
+      expect(publish(node)).to.equal('?');
+    });
   });
 
+  describe('Generics', function () {
+    it('should return a generic type with a parameter', function() {
+      const node = parse('Array.<string>');
+      expect(publish(node)).to.equal('Array.<string>');
+    });
 
-  it('should return an user-defined type name', function() {
-    const node = parse('goog.ui.Menu');
-    expect(publish(node)).to.equal('goog.ui.Menu');
+
+    it('should return a generic type with 2 parameters', function() {
+      const node = parse('Object.<string, number>');
+      expect(publish(node)).to.equal('Object.<string, number>');
+    });
+
+
+    it('should return a JsDoc-formal generic type', function() {
+      const node = parse('String[]');
+      expect(publish(node)).to.equal('String[]');
+    });
   });
 
+  describe('Record types', function () {
+    it('should return a record type with an entry', function() {
+      const node = parse('{myNum}');
+      expect(publish(node)).to.equal('{myNum}');
+    });
 
-  it('should return a generic type has a parameter', function() {
-    const node = parse('Array.<string>');
-    expect(publish(node)).to.equal('Array.<string>');
+
+    it('should return a record type with 2 entries', function() {
+      const node = parse('{myNum: number, myObject}');
+      expect(publish(node)).to.equal('{myNum: number, myObject}');
+    });
   });
 
+  describe('Tuple types', function () {
+    it('should return a tuple type', function() {
+      const node = parse('[]');
+      expect(publish(node)).to.equal('[]');
+    });
 
-  it('should return a generic type has 2 parameters', function() {
-    const node = parse('Object.<string, number>');
-    expect(publish(node)).to.equal('Object.<string, number>');
+
+    it('should return a tuple type with an entry', function() {
+      const node = parse('[number]');
+      expect(publish(node)).to.equal('[number]');
+    });
+
+
+    it('should return a tuple type with 2 entries', function() {
+      const node = parse('[number, MyObject]');
+      expect(publish(node)).to.equal('[number, MyObject]');
+    });
+
+
+    it('should return a generic type with a parameter as a record type', function() {
+      const node = parse('Array<{length}>');
+      expect(publish(node)).to.equal('Array<{length}>');
+    });
+
+
+    it('should return a generic type with a parameter as a tuple type', function() {
+      const node = parse('Array<[string, number]>');
+      expect(publish(node)).to.equal('Array<[string, number]>');
+    });
   });
 
+  describe('Function/Constructor/Arrow types', function () {
+    it('should return a function type', function() {
+      const node = parse('Function');
+      expect(publish(node)).to.equal('Function');
+    });
 
-  it('should return a JsDoc-formal generic type', function() {
-    const node = parse('String[]');
-    expect(publish(node)).to.equal('String[]');
+
+    it('should return a function type with no parameters', function() {
+      const node = parse('function()');
+      expect(publish(node)).to.equal('function()');
+    });
+
+
+    it('should return a function type with a parameter', function() {
+      const node = parse('function(string)');
+      expect(publish(node)).to.equal('function(string)');
+    });
+
+
+    it('should return a function type with 2 parameters', function() {
+      const node = parse('function(string, boolean)');
+      expect(publish(node)).to.equal('function(string, boolean)');
+    });
+
+
+    it('should return a function type with a return', function() {
+      const node = parse('function(): number');
+      expect(publish(node)).to.equal('function(): number');
+    });
+
+
+    it('should return a function type with a context', function() {
+      const node = parse('function(this:goog.ui.Menu, string)');
+      expect(publish(node)).to.equal('function(this: goog.ui.Menu, string)');
+    });
+
+
+    it('should return a constructor type', function() {
+      const node = parse('function(new:goog.ui.Menu, string)');
+      expect(publish(node)).to.equal('function(new: goog.ui.Menu, string)');
+    });
+
+
+    it('should return a function type with a variable parameter', function() {
+      const node = parse('function(string, ...number): number');
+      expect(publish(node)).to.equal('function(string, ...number): number');
+    });
+
+
+    it('should return a function type having parameters with some type operators', function() {
+      const node = parse('function(?string=, number=)');
+      expect(publish(node)).to.equal('function(?string=, number=)');
+    });
+
+    it('should return an arrow type with no parameters', function() {
+      const node = parse('() => string');
+      expect(publish(node)).to.equal('() => string');
+    });
+
+    it('should return an arrow type with two parameters', function() {
+      const node = parse('(x: true, y: false) => string');
+      expect(publish(node)).to.equal('(x: true, y: false) => string');
+    });
+
+    it('should return an arrow type with one parameter', function() {
+      const node = parse('(x: true) => string');
+      expect(publish(node)).to.equal('(x: true) => string');
+    });
+
+    it('should return an arrow type with one variadic parameter', function() {
+      const node = parse('(...x: any[]) => string');
+      expect(publish(node)).to.equal('(...x: any[]) => string');
+    });
+
+    it('should return a construct signature with one parameter', function() {
+      const node = parse('new (x: true) => string');
+      expect(publish(node)).to.equal('new (x: true) => string');
+    });
+
+    it('should return a goog.ui.Component#forEachChild', function() {
+      const node = parse('function(this:T,?,number):?');
+      expect(publish(node)).to.equal('function(this: T, ?, number): ?');
+    });
   });
 
+  describe('BroadNamepathExpr types', function () {
+    describe('Single component', function () {
+      it('should return a global type name', function() {
+        const node = parse('Window');
+        expect(publish(node)).to.equal('Window');
+      });
+    });
 
-  it('should return a formal type union', function() {
-    const node = parse('(number|boolean)');
-    expect(publish(node)).to.equal('(number|boolean)');
+    describe('Multipart', function () {
+      it('should return a user-defined type name', function() {
+        const node = parse('goog.ui.Menu');
+        expect(publish(node)).to.equal('goog.ui.Menu');
+      });
+
+      it('should return a quoted `MemberName` type', function() {
+        const node = parse('namespace."memberNameValue"');
+        expect(publish(node)).to.equal('namespace."memberNameValue"');
+      });
+
+      it('should return a quoted `MemberName` type', function() {
+        const node = parse("namespace.'memberNameValue'");
+        expect(publish(node)).to.equal("namespace.'memberNameValue'");
+      });
+
+      it('should return a quoted `MemberName` type with escaped quote', function() {
+        const node = parse('namespace."member name \\"Value"');
+        expect(publish(node)).to.equal('namespace."member name \\"Value"');
+      });
+
+      it('should return a quoted `MemberName` type with single extra backslash for odd count backslash series not before a quote', function() {
+        const node = parse('namespace."\\Odd count backslash sequence not before a quote\\add\\\\\\one backslash\\."');
+        expect(publish(node)).to.equal('namespace."\\\\Odd count backslash sequence not before a quote\\\\add\\\\\\\\one backslash\\\\."');
+      });
+
+      it('should return a quoted `MemberName` type without adding backslashes for escaped backslash sequences (i.e., even count)', function() {
+        const node = parse('namespace."\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
+        expect(publish(node)).to.equal('namespace."\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
+      });
+    });
+
+    describe('external', function () {
+      it('should return an external node type', function() {
+        const node = parse('external:string');
+        expect(publish(node)).to.equal('external:string');
+      });
+    });
+
+
+    describe('module', function () {
+      it('should return a module type', function() {
+        const node = parse('module:foo/bar');
+        expect(publish(node)).to.equal('module:foo/bar');
+      });
+
+      it('should return a module type with member', function() {
+        const node = parse('module:foo/bar#abc');
+        expect(publish(node)).to.equal('module:foo/bar#abc');
+      });
+
+      it('should return a module type with event member', function() {
+        const node = parse('module:foo/bar#event:abc');
+        expect(publish(node)).to.equal('module:foo/bar#event:abc');
+      });
+
+
+      it('should return a module type with a prefix nullable type operator', function() {
+        const node = parse('?module:foo/bar');
+        expect(publish(node)).to.equal('?module:foo/bar');
+      });
+
+
+      it('should return a module type with a postfix nullable type operator', function() {
+        const node = parse('module:foo/bar?');
+        expect(publish(node)).to.equal('?module:foo/bar');
+      });
+
+      it('should return a module type with a generic type operator', function() {
+        // Because the new generic type syntax was arrived, the old type generic
+        // with the module keyword is not equivalent to the legacy behavior.
+        //
+        // For example, we get 2 parts as 'module:foo/bar.' and '<string>', when
+        // the following type expression are arrived.
+        //   const node = parse('module:foo/bar.<string>');
+        const node = parse('module:foo/bar<string>');
+        expect(publish(node)).to.equal('module:foo/bar<string>');
+      });
+    });
   });
 
+  describe('Types with modifiers', function () {
+    it('should return a variable type', function () {
+      const node = parse('...number');
+      expect(publish(node)).to.equal('...number');
+    });
 
-  it('should return a informal type union', function() {
-    const node = parse('number|boolean');
-    expect(publish(node)).to.equal('number|boolean');
+
+    it('should return an optional type with an optional type operator on the head', function() {
+      const node = parse('=number');
+      expect(publish(node)).to.equal('number=');
+    });
+
+
+    it('should return an optional type with an optional type operator on the tail', function() {
+      const node = parse('number=');
+      expect(publish(node)).to.equal('number=');
+    });
+
+    it('should return a nullable type with a nullable type operator on the head', function() {
+      const node = parse('?number');
+      expect(publish(node)).to.equal('?number');
+    });
+
+
+    it('should return a nullable type with a nullable type operator on the tail', function() {
+      const node = parse('goog.ui.Component?');
+      expect(publish(node)).to.equal('?goog.ui.Component');
+    });
+
+
+    it('should return a non-nullable type with a nullable type operator on the head', function() {
+      const node = parse('!Object');
+      expect(publish(node)).to.equal('!Object');
+    });
+
+
+    it('should return a non-nullable type with a nullable type operator on the tail', function() {
+      const node = parse('Object!');
+      expect(publish(node)).to.equal('!Object');
+    });
   });
 
-  it('should return a type query node', function() {
-    const node = parse('typeof x');
-    expect(publish(node)).to.equal('typeof x');
+  describe('Type combinations', function () {
+    it('should return a formal type union', function() {
+      const node = parse('(number|boolean)');
+      expect(publish(node)).to.equal('(number|boolean)');
+    });
+
+
+    it('should return a informal type union', function() {
+      const node = parse('number|boolean');
+      expect(publish(node)).to.equal('number|boolean');
+    });
   });
 
-  it('should return a key query node', function() {
-    const node = parse('keyof x');
-    expect(publish(node)).to.equal('keyof x');
-  })
-
-  it('should return an import type node', function() {
-    const node = parse('import("./lodash4ever")');
-    expect(publish(node)).to.equal('import("./lodash4ever")');
-  });
-
-  it('should return a record type with an entry', function() {
-    const node = parse('{myNum}');
-    expect(publish(node)).to.equal('{myNum}');
-  });
-
-
-  it('should return a record type with 2 entries', function() {
-    const node = parse('{myNum: number, myObject}');
-    expect(publish(node)).to.equal('{myNum: number, myObject}');
-  });
-
-
-  it('should return a tuple type', function() {
-    const node = parse('[]');
-    expect(publish(node)).to.equal('[]');
-  });
-
-
-  it('should return a tuple type with an entry', function() {
-    const node = parse('[number]');
-    expect(publish(node)).to.equal('[number]');
-  });
-
-
-  it('should return a tuple type with 2 entries', function() {
-    const node = parse('[number, MyObject]');
-    expect(publish(node)).to.equal('[number, MyObject]');
-  });
-
-
-  it('should return a generic type has a parameter as a record type', function() {
-    const node = parse('Array<{length}>');
-    expect(publish(node)).to.equal('Array<{length}>');
-  });
-
-
-  it('should return a generic type has a parameter as a tuple type', function() {
-    const node = parse('Array<[string, number]>');
-    expect(publish(node)).to.equal('Array<[string, number]>');
-  });
-
-
-  it('should return a nullable type has a nullable type operator on the head', function() {
-    const node = parse('?number');
-    expect(publish(node)).to.equal('?number');
-  });
-
-
-  it('should return a nullable type has a nullable type operator on the tail', function() {
-    const node = parse('goog.ui.Component?');
-    expect(publish(node)).to.equal('?goog.ui.Component');
-  });
-
-
-  it('should return a non-nullable type has a nullable type operator on the head', function() {
-    const node = parse('!Object');
-    expect(publish(node)).to.equal('!Object');
-  });
-
-
-  it('should return a non-nullable type has a nullable type operator on the tail', function() {
-    const node = parse('Object!');
-    expect(publish(node)).to.equal('!Object');
-  });
-
-
-  it('should return a function type', function() {
-    const node = parse('Function');
-    expect(publish(node)).to.equal('Function');
-  });
-
-
-  it('should return a function type has no parameters', function() {
-    const node = parse('function()');
-    expect(publish(node)).to.equal('function()');
-  });
-
-
-  it('should return a function type has a parameter', function() {
-    const node = parse('function(string)');
-    expect(publish(node)).to.equal('function(string)');
-  });
-
-
-  it('should return a function type has 2 parameters', function() {
-    const node = parse('function(string, boolean)');
-    expect(publish(node)).to.equal('function(string, boolean)');
-  });
-
-
-  it('should return a function type has a return', function() {
-    const node = parse('function(): number');
-    expect(publish(node)).to.equal('function(): number');
-  });
-
-
-  it('should return a function type has a context', function() {
-    const node = parse('function(this:goog.ui.Menu, string)');
-    expect(publish(node)).to.equal('function(this: goog.ui.Menu, string)');
-  });
-
-
-  it('should return a constructor type', function() {
-    const node = parse('function(new:goog.ui.Menu, string)');
-    expect(publish(node)).to.equal('function(new: goog.ui.Menu, string)');
-  });
-
-
-  it('should return a function type has a variable parameter', function() {
-    const node = parse('function(string, ...number): number');
-    expect(publish(node)).to.equal('function(string, ...number): number');
-  });
-
-
-  it('should return a function type has parameters have some type operators', function() {
-    const node = parse('function(?string=, number=)');
-    expect(publish(node)).to.equal('function(?string=, number=)');
-  });
-
-  it('should return an arrow type with no parameters', function() {
-    const node = parse('() => string');
-    expect(publish(node)).to.equal('() => string');
-  });
-
-  it('should return an arrow type with two parameters', function() {
-    const node = parse('(x: true, y: false) => string');
-    expect(publish(node)).to.equal('(x: true, y: false) => string');
-  });
-
-  it('should return an arrow type with one parameter', function() {
-    const node = parse('(x: true) => string');
-    expect(publish(node)).to.equal('(x: true) => string');
-  });
-
-  it('should return an arrow type with one variadic parameter', function() {
-    const node = parse('(...x: any[]) => string');
-    expect(publish(node)).to.equal('(...x: any[]) => string');
-  });
-
-  it('should return a construct signature with one parameter', function() {
-    const node = parse('new (x: true) => string');
-    expect(publish(node)).to.equal('new (x: true) => string');
-  });
-
-  it('should return a goog.ui.Component#forEachChild', function() {
-    const node = parse('function(this:T,?,number):?');
-    expect(publish(node)).to.equal('function(this: T, ?, number): ?');
-  });
-
-
-  it('should return a variable type', function() {
-    const node = parse('...number');
-    expect(publish(node)).to.equal('...number');
-  });
-
-
-  it('should return an optional type has an optional type operator on the head', function() {
-    const node = parse('=number');
-    expect(publish(node)).to.equal('number=');
-  });
-
-
-  it('should return an optional type has an optional type operator on the tail', function() {
-    const node = parse('number=');
-    expect(publish(node)).to.equal('number=');
-  });
-
-
-  it('should return an all type', function() {
-    const node = parse('*');
-    expect(publish(node)).to.equal('*');
-  });
-
-
-  it('should return an unknown type', function() {
-    const node = parse('?');
-    expect(publish(node)).to.equal('?');
-  });
-
-
-  it('should return an undefined type with an "undefined" keyword', function() {
-    const node = parse('undefined');
-    expect(publish(node)).to.equal('undefined');
-  });
-
-
-  it('should return a null type with an "null" keyword', function() {
-    const node = parse('null');
-    expect(publish(node)).to.equal('null');
-  });
-
-
-  it('should return a module type', function() {
-    const node = parse('module:foo/bar');
-    expect(publish(node)).to.equal('module:foo/bar');
-  });
-
-  it('should return a module type with member', function() {
-    const node = parse('module:foo/bar#abc');
-    expect(publish(node)).to.equal('module:foo/bar#abc');
-  });
-
-  it('should return a module type with event member', function() {
-    const node = parse('module:foo/bar#event:abc');
-    expect(publish(node)).to.equal('module:foo/bar#event:abc');
-  });
-
-
-  it('should return a module type with a prefix nullable type operator', function() {
-    const node = parse('?module:foo/bar');
-    expect(publish(node)).to.equal('?module:foo/bar');
-  });
-
-
-  it('should return a module type with a postfix nullable type operator', function() {
-    const node = parse('module:foo/bar?');
-    expect(publish(node)).to.equal('?module:foo/bar');
-  });
-
-
-  it('should return a string value type', function() {
-    const node = parse('"stringValue"');
-    expect(publish(node)).to.equal('"stringValue"');
-  });
-
-  it('should return a string value type with escaped quote', function() {
-    const node = parse('"string \\"Value"');
-    expect(publish(node)).to.equal('"string \\"Value"');
-  });
-
-  it('should return a string value type with single extra backslash for odd count backslash series not before a quote', function() {
-    const node = parse('"\\Odd count backslash sequence not before a quote\\add\\\\\\one backslash\\."');
-    expect(publish(node)).to.equal('"\\\\Odd count backslash sequence not before a quote\\\\add\\\\\\\\one backslash\\\\."');
-  });
-
-  it('should return a string value type without adding backslashes for escaped backslash sequences (i.e., even count)', function() {
-    const node = parse('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
-    expect(publish(node)).to.equal('"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\"');
-  });
-
-
-  it('should return a number value type', function() {
-    const node = parse('0123456789');
-    expect(publish(node)).to.equal('0123456789');
-  });
-
-
-  it('should return a bin number value type', function() {
-    const node = parse('0b01');
-    expect(publish(node)).to.equal('0b01');
-  });
-
-
-  it('should return an oct number value type', function() {
-    const node = parse('0o01234567');
-    expect(publish(node)).to.equal('0o01234567');
-  });
-
-
-  it('should return a hex number value type', function() {
-    const node = parse('0x0123456789abcdef');
-    expect(publish(node)).to.equal('0x0123456789abcdef');
-  });
-
-
-  it('should return an external node type', function() {
-    const node = parse('external:string');
-    expect(publish(node)).to.equal('external:string');
-  });
-
-
-  it('should return a module type with a generic type operator', function() {
-    // Because the new generic type syntax was arrived, the old type generic
-    // with the module keyword is not equivalent to the legacy behavior.
-    //
-    // For example, we get 2 parts as 'module:foo/bar.' and '<string>', when
-    // the following type expression are arrived.
-    //   const node = parse('module:foo/bar.<string>');
-    const node = parse('module:foo/bar<string>');
-    expect(publish(node)).to.equal('module:foo/bar<string>');
-  });
-
-
-  it('should can take a custom publisher by the 2nd argument', function() {
-    const ast = {
-      type: 'NAME',
-      name: 'MyClass',
-    };
-
-    const customPublisher = createDefaultPublisher();
-    customPublisher.NAME = function(node) {
-      return '<a href="./types/' + node.name + '.html">' + node.name + '</a>';
-    };
-
-    const string = publish(ast, customPublisher);
-    expect(string).to.equal('<a href="./types/MyClass.html">MyClass</a>');
+  describe('Types with operations', function () {
+    it('should return a type query node', function() {
+      const node = parse('typeof x');
+      expect(publish(node)).to.equal('typeof x');
+    });
+
+    it('should return a key query node', function() {
+      const node = parse('keyof x');
+      expect(publish(node)).to.equal('keyof x');
+    })
+
+    it('should return an import type node', function() {
+      const node = parse('import("./lodash4ever")');
+      expect(publish(node)).to.equal('import("./lodash4ever")');
+    });
   });
 });

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -1,465 +1,480 @@
 'use strict';
 
 const {expect} = require('chai');
+const entries = require('object.entries-ponyfill');
+
 const NodeType = require('../lib/NodeType.js');
 const {traverse} = require('../lib/traversing.js');
 
 /** @typedef {{type: import('../lib/NodeType').Type}} Node */
 
 describe('traversing', function() {
-  const testCases = {
-    'should visit a name node': {
-      given: createNameNode('name'),
-      then: [
-        ['enter', NodeType.NAME, null, null],
-        ['leave', NodeType.NAME, null, null],
-      ],
-    },
-
-    'should visit a member node': {
-      given: createMemberNode('child', createNameNode('owner')),
-      then: [
-        ['enter', NodeType.MEMBER, null, null],
-        ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER, null, null],
-      ],
-    },
-
-    'should visit a nested member node': {
-      given: createMemberNode('superchild', createMemberNode('child', createNameNode('owner'))),
-      then: [
-        ['enter', NodeType.MEMBER, null, null],
-        ['enter', NodeType.MEMBER, 'owner', NodeType.MEMBER],
-        ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER, 'owner', NodeType.MEMBER],
-        ['leave', NodeType.MEMBER, null, null],
-      ],
-    },
-
-    'should visit an union node': {
-      given: createUnionNode(createNameNode('left'), createNameNode('right')),
-      then: [
-        ['enter', NodeType.UNION, null, null],
-        ['enter', NodeType.NAME, 'left', NodeType.UNION],
-        ['leave', NodeType.NAME, 'left', NodeType.UNION],
-        ['enter', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.UNION, null, null],
-      ],
-    },
-
-    'should visit a type query node': {
-      given: createTypeQueryNode(createNameNode('t')),
-      then: [
-        ['enter', NodeType.TYPE_QUERY, null, null],
-        ['enter', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
-        ['leave', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
-        ['leave', NodeType.TYPE_QUERY, null, null],
-      ],
-    },
-
-    'should visit a key query node': {
-      given: createKeyQueryNode(createNameNode('t')),
-      then: [
-        ['enter', NodeType.KEY_QUERY, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.KEY_QUERY],
-        ['leave', NodeType.NAME, 'value', NodeType.KEY_QUERY],
-        ['leave', NodeType.KEY_QUERY, null, null],
-      ],
-    },
-
-    'should visit an import type node': {
-      given: createImportNode(createStringLiteral('jquery')),
-      then: [
-        ['enter', NodeType.IMPORT, null, null],
-        ['enter', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
-        ['leave', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
-        ['leave', NodeType.IMPORT, null, null],
-      ],
-    },
-
-    'should visit a nested union node': {
-      given: createUnionNode(
-        createUnionNode(
-          createNameNode('left'),
-          createNameNode('middle')
-        ),
-        createNameNode('right')
-      ),
-      then: [
-        ['enter', NodeType.UNION, null, null],
-        ['enter', NodeType.UNION, 'left', NodeType.UNION],
-        ['enter', NodeType.NAME, 'left', NodeType.UNION],
-        ['leave', NodeType.NAME, 'left', NodeType.UNION],
-        ['enter', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.UNION, 'left', NodeType.UNION],
-        ['enter', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.NAME, 'right', NodeType.UNION],
-        ['leave', NodeType.UNION, null, null],
-      ],
-    },
-
-    'should visit a variadic node': {
-      given: { type: NodeType.VARIADIC, value: createNameNode('variadic') },
-      then: [
-        ['enter', NodeType.VARIADIC, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.VARIADIC],
-        ['leave', NodeType.NAME, 'value', NodeType.VARIADIC],
-        ['leave', NodeType.VARIADIC, null, null],
-      ],
-    },
-
-    'should visit a record node that is empty': {
-      given: {
-        type: NodeType.RECORD,
-        entries: [],
-      },
-      then: [
-        ['enter', NodeType.RECORD, null, null],
-        ['leave', NodeType.RECORD, null, null],
-      ],
-    },
-
-    'should visit a record node that has multiple entries': {
-      given: {
-        type: NodeType.RECORD,
-        entries: [
-          createRecordEntry('key1', createNameNode('key1')),
-          createRecordEntry('key2', createNameNode('key2')),
+  const testCaseGroups = {
+    'Primitive types': {
+      'should visit a string value node': {
+        given: { type: NodeType.STRING_VALUE, value: 'stringValue' },
+        then: [
+          ['enter', NodeType.STRING_VALUE, null, null],
+          ['leave', NodeType.STRING_VALUE, null, null],
         ],
       },
-      then: [
-        ['enter', NodeType.RECORD, null, null],
-        ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
-        ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
-        ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
-        ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
-        ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
-        ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
-        ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
-        ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
-        ['leave', NodeType.RECORD, null, null],
-      ],
-    },
 
-    'should visit a tuple node that is empty': {
-      given: {
-        type: NodeType.TUPLE,
-        entries: [],
-      },
-      then: [
-        ['enter', NodeType.TUPLE, null, null],
-        ['leave', NodeType.TUPLE, null, null],
-      ],
-    },
-
-    'should visit a tuple node that has multiple entries': {
-      given: {
-        type: NodeType.TUPLE,
-        entries: [
-          createNameNode('object1'),
-          createNameNode('object2'),
+      'should visit a number value node': {
+        given: { type: NodeType.NUMBER_VALUE, value: 'numberValue' },
+        then: [
+          ['enter', NodeType.NUMBER_VALUE, null, null],
+          ['leave', NodeType.NUMBER_VALUE, null, null],
         ],
       },
-      then: [
-        ['enter', NodeType.TUPLE, null, null],
-        ['enter', NodeType.NAME, 'entries', NodeType.TUPLE],
-        ['leave', NodeType.NAME, 'entries', NodeType.TUPLE],
-        ['enter', NodeType.NAME, 'entries', NodeType.TUPLE],
-        ['leave', NodeType.NAME, 'entries', NodeType.TUPLE],
-        ['leave', NodeType.TUPLE, null, null],
-      ],
     },
-
-    'should visit a generic node that is empty': {
-      given: {
-        type: NodeType.GENERIC,
-        subject: createNameNode('subject'),
-        objects: [],
-      },
-      then: [
-        ['enter', NodeType.GENERIC, null, null],
-        ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
-        ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
-        ['leave', NodeType.GENERIC, null, null],
-      ],
-    },
-
-    'should visit a generic node that has multiple objects': {
-      given: {
-        type: NodeType.GENERIC,
-        subject: createNameNode('subject'),
-        objects: [
-          createNameNode('object1'),
-          createNameNode('object2'),
+    'Wildcard types': {
+      'should visit an any node': {
+        given: {
+          type: NodeType.ANY,
+        },
+        then: [
+          ['enter', NodeType.ANY, null, null],
+          ['leave', NodeType.ANY, null, null],
         ],
       },
-      then: [
-        ['enter', NodeType.GENERIC, null, null],
-        ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
-        ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
-        ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
-        ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
-        ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
-        ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
-        ['leave', NodeType.GENERIC, null, null],
-      ],
-    },
 
-    'should visit a module node': {
-      given: {
-        type: NodeType.MODULE,
-        value: createFilePathNode('module'),
-      },
-      then: [
-        ['enter', NodeType.MODULE, null, null],
-        ['enter', NodeType.FILE_PATH, 'value', NodeType.MODULE],
-        ['leave', NodeType.FILE_PATH, 'value', NodeType.MODULE],
-        ['leave', NodeType.MODULE, null, null],
-      ],
-    },
-
-    'should visit an optional node': {
-      given: {
-        type: NodeType.OPTIONAL,
-        value: createNameNode('optional'),
-      },
-      then: [
-        ['enter', NodeType.OPTIONAL, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.OPTIONAL],
-        ['leave', NodeType.NAME, 'value', NodeType.OPTIONAL],
-        ['leave', NodeType.OPTIONAL, null, null],
-      ],
-    },
-
-    'should visit a nullable node': {
-      given: {
-        type: NodeType.NULLABLE,
-        value: createNameNode('nullable'),
-      },
-      then: [
-        ['enter', NodeType.NULLABLE, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.NULLABLE],
-        ['leave', NodeType.NAME, 'value', NodeType.NULLABLE],
-        ['leave', NodeType.NULLABLE, null, null],
-      ],
-    },
-
-    'should visit a non-nullable node': {
-      given: {
-        type: NodeType.NOT_NULLABLE,
-        value: createNameNode('not_nullable'),
-      },
-      then: [
-        ['enter', NodeType.NOT_NULLABLE, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
-        ['leave', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
-        ['leave', NodeType.NOT_NULLABLE, null, null],
-      ],
-    },
-
-    'should visit a function node that has no params and no returns': {
-      given: {
-        type: NodeType.FUNCTION,
-        params: [],
-        returns: null,
-        this: null,
-        new: null,
-      },
-      then: [
-        ['enter', NodeType.FUNCTION, null, null],
-        ['leave', NodeType.FUNCTION, null, null],
-      ],
-    },
-
-    'should visit a function node that has few params and a returns and "this" and "new"': {
-      given: {
-        type: NodeType.FUNCTION,
-        params: [
-          createNameNode('param1'),
-          createNameNode('param2'),
+      'should visit an unknown node': {
+        given: {
+          type: NodeType.UNKNOWN,
+        },
+        then: [
+          ['enter', NodeType.UNKNOWN, null, null],
+          ['leave', NodeType.UNKNOWN, null, null],
         ],
-        returns: createNameNode('return'),
-        this: createNameNode('this'),
-        new: createNameNode('new'),
       },
-      then: [
-        ['enter', NodeType.FUNCTION, null, null],
-        ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
-        ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
-        ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
-        ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
-        ['enter', NodeType.NAME, 'returns', NodeType.FUNCTION],
-        ['leave', NodeType.NAME, 'returns', NodeType.FUNCTION],
-        ['enter', NodeType.NAME, 'this', NodeType.FUNCTION],
-        ['leave', NodeType.NAME, 'this', NodeType.FUNCTION],
-        ['enter', NodeType.NAME, 'new', NodeType.FUNCTION],
-        ['leave', NodeType.NAME, 'new', NodeType.FUNCTION],
-        ['leave', NodeType.FUNCTION, null, null],
-      ],
     },
-
-    'should visit an arrow function that has two params and a returns': {
-      given: {
-        type: NodeType.ARROW,
-        params: [
-          { type: NodeType.NAMED_PARAMETER, name: 'param1', typeName: createNameNode('type1') },
-          { type: NodeType.NAMED_PARAMETER, name: 'param2', typeName: createNameNode('type2') },
+    'Generic types': {
+      'should visit a generic node that is empty': {
+        given: {
+          type: NodeType.GENERIC,
+          subject: createNameNode('subject'),
+          objects: [],
+        },
+        then: [
+          ['enter', NodeType.GENERIC, null, null],
+          ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
+          ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
+          ['leave', NodeType.GENERIC, null, null],
         ],
-        returns: createNameNode('return'),
       },
-      then: [
-        ['enter', NodeType.ARROW, null, null],
-        ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.ARROW, null, null],
-      ],
-    },
 
-    'should visit an arrow function that has one variadic param and a returns': {
-      given: {
-        type: NodeType.ARROW,
-        params: [
-          {
-            type: NodeType.VARIADIC,
-            value: {
-              type: NodeType.NAMED_PARAMETER,
-              name: 'param1',
-              typeName: createNameNode('type1'),
+      'should visit a generic node that has multiple objects': {
+        given: {
+          type: NodeType.GENERIC,
+          subject: createNameNode('subject'),
+          objects: [
+            createNameNode('object1'),
+            createNameNode('object2'),
+          ],
+        },
+        then: [
+          ['enter', NodeType.GENERIC, null, null],
+          ['enter', NodeType.NAME, 'subject', NodeType.GENERIC],
+          ['leave', NodeType.NAME, 'subject', NodeType.GENERIC],
+          ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
+          ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
+          ['enter', NodeType.NAME, 'objects', NodeType.GENERIC],
+          ['leave', NodeType.NAME, 'objects', NodeType.GENERIC],
+          ['leave', NodeType.GENERIC, null, null],
+        ],
+      },
+    },
+    'Record types': {
+      'should visit a record node that is empty': {
+        given: {
+          type: NodeType.RECORD,
+          entries: [],
+        },
+        then: [
+          ['enter', NodeType.RECORD, null, null],
+          ['leave', NodeType.RECORD, null, null],
+        ],
+      },
+
+      'should visit a record node that has multiple entries': {
+        given: {
+          type: NodeType.RECORD,
+          entries: [
+            createRecordEntry('key1', createNameNode('key1')),
+            createRecordEntry('key2', createNameNode('key2')),
+          ],
+        },
+        then: [
+          ['enter', NodeType.RECORD, null, null],
+          ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+          ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+          ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+          ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+          ['enter', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+          ['enter', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+          ['leave', NodeType.NAME, 'value', NodeType.RECORD_ENTRY],
+          ['leave', NodeType.RECORD_ENTRY, 'entries', NodeType.RECORD],
+          ['leave', NodeType.RECORD, null, null],
+        ],
+      },
+    },
+    'Tuple types': {
+      'should visit a tuple node that is empty': {
+        given: {
+          type: NodeType.TUPLE,
+          entries: [],
+        },
+        then: [
+          ['enter', NodeType.TUPLE, null, null],
+          ['leave', NodeType.TUPLE, null, null],
+        ],
+      },
+
+      'should visit a tuple node that has multiple entries': {
+        given: {
+          type: NodeType.TUPLE,
+          entries: [
+            createNameNode('object1'),
+            createNameNode('object2'),
+          ],
+        },
+        then: [
+          ['enter', NodeType.TUPLE, null, null],
+          ['enter', NodeType.NAME, 'entries', NodeType.TUPLE],
+          ['leave', NodeType.NAME, 'entries', NodeType.TUPLE],
+          ['enter', NodeType.NAME, 'entries', NodeType.TUPLE],
+          ['leave', NodeType.NAME, 'entries', NodeType.TUPLE],
+          ['leave', NodeType.TUPLE, null, null],
+        ],
+      },
+    },
+    'Function/Constructor/Arrow types': {
+      'should visit a function node that has no params and no returns': {
+        given: {
+          type: NodeType.FUNCTION,
+          params: [],
+          returns: null,
+          this: null,
+          new: null,
+        },
+        then: [
+          ['enter', NodeType.FUNCTION, null, null],
+          ['leave', NodeType.FUNCTION, null, null],
+        ],
+      },
+
+      'should visit a function node that has few params and a returns and "this" and "new"': {
+        given: {
+          type: NodeType.FUNCTION,
+          params: [
+            createNameNode('param1'),
+            createNameNode('param2'),
+          ],
+          returns: createNameNode('return'),
+          this: createNameNode('this'),
+          new: createNameNode('new'),
+        },
+        then: [
+          ['enter', NodeType.FUNCTION, null, null],
+          ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
+          ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
+          ['enter', NodeType.NAME, 'params', NodeType.FUNCTION],
+          ['leave', NodeType.NAME, 'params', NodeType.FUNCTION],
+          ['enter', NodeType.NAME, 'returns', NodeType.FUNCTION],
+          ['leave', NodeType.NAME, 'returns', NodeType.FUNCTION],
+          ['enter', NodeType.NAME, 'this', NodeType.FUNCTION],
+          ['leave', NodeType.NAME, 'this', NodeType.FUNCTION],
+          ['enter', NodeType.NAME, 'new', NodeType.FUNCTION],
+          ['leave', NodeType.NAME, 'new', NodeType.FUNCTION],
+          ['leave', NodeType.FUNCTION, null, null],
+        ],
+      },
+
+      'should visit an arrow function that has two params and a returns': {
+        given: {
+          type: NodeType.ARROW,
+          params: [
+            { type: NodeType.NAMED_PARAMETER, name: 'param1', typeName: createNameNode('type1') },
+            { type: NodeType.NAMED_PARAMETER, name: 'param2', typeName: createNameNode('type2') },
+          ],
+          returns: createNameNode('return'),
+        },
+        then: [
+          ['enter', NodeType.ARROW, null, null],
+          ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAMED_PARAMETER, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.ARROW, null, null],
+        ],
+      },
+
+      'should visit an arrow function that has one variadic param and a returns': {
+        given: {
+          type: NodeType.ARROW,
+          params: [
+            {
+              type: NodeType.VARIADIC,
+              value: {
+                type: NodeType.NAMED_PARAMETER,
+                name: 'param1',
+                typeName: createNameNode('type1'),
+              },
             },
-          },
+          ],
+          returns: createNameNode('return'),
+        },
+        then: [
+          ['enter', NodeType.ARROW, null, null],
+          ['enter', NodeType.VARIADIC, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
+          ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
+          ['leave', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
+          ['leave', NodeType.VARIADIC, 'params', NodeType.ARROW],
+          ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.ARROW, null, null],
         ],
-        returns: createNameNode('return'),
       },
-      then: [
-        ['enter', NodeType.ARROW, null, null],
-        ['enter', NodeType.VARIADIC, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
-        ['enter', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAME, 'typeName', NodeType.NAMED_PARAMETER],
-        ['leave', NodeType.NAMED_PARAMETER, 'value', NodeType.VARIADIC],
-        ['leave', NodeType.VARIADIC, 'params', NodeType.ARROW],
-        ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
-        ['leave', NodeType.ARROW, null, null],
-      ],
     },
-
-    'should visit an any node': {
-      given: {
-        type: NodeType.ANY,
+    'NamepathExpr types': {
+      'should visit a name node': {
+        given: createNameNode('name'),
+        then: [
+          ['enter', NodeType.NAME, null, null],
+          ['leave', NodeType.NAME, null, null],
+        ],
       },
-      then: [
-        ['enter', NodeType.ANY, null, null],
-        ['leave', NodeType.ANY, null, null],
-      ],
-    },
 
-    'should visit an unknown node': {
-      given: {
-        type: NodeType.UNKNOWN,
+      'should visit a member node': {
+        given: createMemberNode('child', createNameNode('owner')),
+        then: [
+          ['enter', NodeType.MEMBER, null, null],
+          ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
+          ['leave', NodeType.MEMBER, null, null],
+        ],
       },
-      then: [
-        ['enter', NodeType.UNKNOWN, null, null],
-        ['leave', NodeType.UNKNOWN, null, null],
-      ],
-    },
 
-    'should visit an inner member node': {
-      given: createInnerMemberNode('child', createNameNode('owner')),
-      then: [
-        ['enter', NodeType.INNER_MEMBER, null, null],
-        ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER, null, null],
-      ],
-    },
+      'should visit a nested member node': {
+        given: createMemberNode('superchild', createMemberNode('child', createNameNode('owner'))),
+        then: [
+          ['enter', NodeType.MEMBER, null, null],
+          ['enter', NodeType.MEMBER, 'owner', NodeType.MEMBER],
+          ['enter', NodeType.NAME, 'owner', NodeType.MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.MEMBER],
+          ['leave', NodeType.MEMBER, 'owner', NodeType.MEMBER],
+          ['leave', NodeType.MEMBER, null, null],
+        ],
+      },
 
-    'should visit a nested inner member node': {
-      given: createInnerMemberNode('superchild',
-        createInnerMemberNode('child', createNameNode('owner'))),
-      then: [
-        ['enter', NodeType.INNER_MEMBER, null, null],
-        ['enter', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
-        ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
-        ['leave', NodeType.INNER_MEMBER, null, null],
-      ],
-    },
+      'should visit an inner member node': {
+        given: createInnerMemberNode('child', createNameNode('owner')),
+        then: [
+          ['enter', NodeType.INNER_MEMBER, null, null],
+          ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+          ['leave', NodeType.INNER_MEMBER, null, null],
+        ],
+      },
 
-    'should visit an instance member node': {
-      given: createInstanceMemberNode('child', createNameNode('owner')),
-      then: [
-        ['enter', NodeType.INSTANCE_MEMBER, null, null],
-        ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER, null, null],
-      ],
-    },
+      'should visit a nested inner member node': {
+        given: createInnerMemberNode('superchild',
+          createInnerMemberNode('child', createNameNode('owner'))),
+        then: [
+          ['enter', NodeType.INNER_MEMBER, null, null],
+          ['enter', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
+          ['enter', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.INNER_MEMBER],
+          ['leave', NodeType.INNER_MEMBER, 'owner', NodeType.INNER_MEMBER],
+          ['leave', NodeType.INNER_MEMBER, null, null],
+        ],
+      },
 
-    'should visit a nested instance member node': {
-      given: createInstanceMemberNode('superchild',
-        createInstanceMemberNode('child', createNameNode('owner'))),
-      then: [
-        ['enter', NodeType.INSTANCE_MEMBER, null, null],
-        ['enter', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
-        ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
-        ['leave', NodeType.INSTANCE_MEMBER, null, null],
-      ],
-    },
+      'should visit an instance member node': {
+        given: createInstanceMemberNode('child', createNameNode('owner')),
+        then: [
+          ['enter', NodeType.INSTANCE_MEMBER, null, null],
+          ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+          ['leave', NodeType.INSTANCE_MEMBER, null, null],
+        ],
+      },
 
-    'should visit a string value node': {
-      given: { type: NodeType.STRING_VALUE, value: 'stringValue' },
-      then: [
-        ['enter', NodeType.STRING_VALUE, null, null],
-        ['leave', NodeType.STRING_VALUE, null, null],
-      ],
+      'should visit a nested instance member node': {
+        given: createInstanceMemberNode('superchild',
+          createInstanceMemberNode('child', createNameNode('owner'))),
+        then: [
+          ['enter', NodeType.INSTANCE_MEMBER, null, null],
+          ['enter', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
+          ['enter', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+          ['leave', NodeType.NAME, 'owner', NodeType.INSTANCE_MEMBER],
+          ['leave', NodeType.INSTANCE_MEMBER, 'owner', NodeType.INSTANCE_MEMBER],
+          ['leave', NodeType.INSTANCE_MEMBER, null, null],
+        ],
+      },
     },
-
-    'should visit a number value node': {
-      given: { type: NodeType.NUMBER_VALUE, value: 'numberValue' },
-      then: [
-        ['enter', NodeType.NUMBER_VALUE, null, null],
-        ['leave', NodeType.NUMBER_VALUE, null, null],
-      ],
+    'External': {
+      'should visit an external node': {
+        given: { type: NodeType.EXTERNAL, value: createNameNode('external') },
+        then: [
+          ['enter', NodeType.EXTERNAL, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.EXTERNAL],
+          ['leave', NodeType.NAME, 'value', NodeType.EXTERNAL],
+          ['leave', NodeType.EXTERNAL, null, null],
+        ],
+      },
     },
+    'Modules': {
+      'should visit a module node': {
+        given: {
+          type: NodeType.MODULE,
+          value: createFilePathNode('module'),
+        },
+        then: [
+          ['enter', NodeType.MODULE, null, null],
+          ['enter', NodeType.FILE_PATH, 'value', NodeType.MODULE],
+          ['leave', NodeType.FILE_PATH, 'value', NodeType.MODULE],
+          ['leave', NodeType.MODULE, null, null],
+        ],
+      },
+    },
+    'Types with modifiers': {
+      'should visit a variadic node': {
+        given: { type: NodeType.VARIADIC, value: createNameNode('variadic') },
+        then: [
+          ['enter', NodeType.VARIADIC, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.VARIADIC],
+          ['leave', NodeType.NAME, 'value', NodeType.VARIADIC],
+          ['leave', NodeType.VARIADIC, null, null],
+        ],
+      },
+      'should visit an optional node': {
+        given: {
+          type: NodeType.OPTIONAL,
+          value: createNameNode('optional'),
+        },
+        then: [
+          ['enter', NodeType.OPTIONAL, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.OPTIONAL],
+          ['leave', NodeType.NAME, 'value', NodeType.OPTIONAL],
+          ['leave', NodeType.OPTIONAL, null, null],
+        ],
+      },
 
-    'should visit an external node': {
-      given: { type: NodeType.EXTERNAL, value: createNameNode('external') },
-      then: [
-        ['enter', NodeType.EXTERNAL, null, null],
-        ['enter', NodeType.NAME, 'value', NodeType.EXTERNAL],
-        ['leave', NodeType.NAME, 'value', NodeType.EXTERNAL],
-        ['leave', NodeType.EXTERNAL, null, null],
-      ],
+      'should visit a nullable node': {
+        given: {
+          type: NodeType.NULLABLE,
+          value: createNameNode('nullable'),
+        },
+        then: [
+          ['enter', NodeType.NULLABLE, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.NULLABLE],
+          ['leave', NodeType.NAME, 'value', NodeType.NULLABLE],
+          ['leave', NodeType.NULLABLE, null, null],
+        ],
+      },
+
+      'should visit a non-nullable node': {
+        given: {
+          type: NodeType.NOT_NULLABLE,
+          value: createNameNode('not_nullable'),
+        },
+        then: [
+          ['enter', NodeType.NOT_NULLABLE, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
+          ['leave', NodeType.NAME, 'value', NodeType.NOT_NULLABLE],
+          ['leave', NodeType.NOT_NULLABLE, null, null],
+        ],
+      },
+    },
+    'Type combinations': {
+      'should visit a union node': {
+        given: createUnionNode(createNameNode('left'), createNameNode('right')),
+        then: [
+          ['enter', NodeType.UNION, null, null],
+          ['enter', NodeType.NAME, 'left', NodeType.UNION],
+          ['leave', NodeType.NAME, 'left', NodeType.UNION],
+          ['enter', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.UNION, null, null],
+        ],
+      },
+      'should visit a nested union node': {
+        given: createUnionNode(
+          createUnionNode(
+            createNameNode('left'),
+            createNameNode('middle')
+          ),
+          createNameNode('right')
+        ),
+        then: [
+          ['enter', NodeType.UNION, null, null],
+          ['enter', NodeType.UNION, 'left', NodeType.UNION],
+          ['enter', NodeType.NAME, 'left', NodeType.UNION],
+          ['leave', NodeType.NAME, 'left', NodeType.UNION],
+          ['enter', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.UNION, 'left', NodeType.UNION],
+          ['enter', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.NAME, 'right', NodeType.UNION],
+          ['leave', NodeType.UNION, null, null],
+        ],
+      },
+    },
+    'Types with operations': {
+      'should visit a type query node': {
+        given: createTypeQueryNode(createNameNode('t')),
+        then: [
+          ['enter', NodeType.TYPE_QUERY, null, null],
+          ['enter', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
+          ['leave', NodeType.NAME, 'name', NodeType.TYPE_QUERY],
+          ['leave', NodeType.TYPE_QUERY, null, null],
+        ],
+      },
+
+      'should visit a key query node': {
+        given: createKeyQueryNode(createNameNode('t')),
+        then: [
+          ['enter', NodeType.KEY_QUERY, null, null],
+          ['enter', NodeType.NAME, 'value', NodeType.KEY_QUERY],
+          ['leave', NodeType.NAME, 'value', NodeType.KEY_QUERY],
+          ['leave', NodeType.KEY_QUERY, null, null],
+        ],
+      },
+
+      'should visit an import type node': {
+        given: createImportNode(createStringLiteral('jquery')),
+        then: [
+          ['enter', NodeType.IMPORT, null, null],
+          ['enter', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
+          ['leave', NodeType.STRING_VALUE, 'path', NodeType.IMPORT],
+          ['leave', NodeType.IMPORT, null, null],
+        ],
+      },
     },
   };
 
-  Object.keys(testCases).forEach(function(testCaseName) {
-    const testCaseInfo = testCases[testCaseName];
+  entries(testCaseGroups).forEach(function ([testCaseGroup, testCases]) {
+    describe(testCaseGroup, function () {
+      entries(testCases).forEach(function([testCaseName, testCaseInfo]) {
+        it(testCaseName, function() {
+          const visitedOrder = [];
+          const onEnterSpy = createEventSpy('enter', visitedOrder);
+          const onLeaveSpy = createEventSpy('leave', visitedOrder);
 
-    it(testCaseName, function() {
-      const visitedOrder = [];
-      const onEnterSpy = createEventSpy('enter', visitedOrder);
-      const onLeaveSpy = createEventSpy('leave', visitedOrder);
+          traverse(testCaseInfo.given, onEnterSpy, onLeaveSpy);
 
-      traverse(testCaseInfo.given, onEnterSpy, onLeaveSpy);
-
-      expect(visitedOrder).to.deep.equal(testCaseInfo.then);
+          expect(visitedOrder).to.deep.equal(testCaseInfo.then);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Builds on #72 .

BREAKING CHANGE: Rename exported `SyntaxError` to `JSDocTypeSyntaxError` to avoid shadowing upon destructuring (fixes #67)