### PR TITLE
External

### DIFF
--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -155,7 +155,8 @@ function createDefaultPublisher() {
       return numberValueNode.number;
     },
     EXTERNAL (externalNode, concretePublish) {
-      return format('external:%s', concretePublish(externalNode.value));
+      const {name, quoteStyle} = externalNode;
+      return format('external:%s', addQuotesForName(name, quoteStyle));
     },
     PARENTHESIS (parenthesizedNode, concretePublish) {
       return format('(%s)', concretePublish(parenthesizedNode.value));

--- a/peg_lib/jsdoctype.js
+++ b/peg_lib/jsdoctype.js
@@ -262,12 +262,45 @@ function peg$parse(input, options) {
       peg$c39 = peg$literalExpectation("external", false),
       peg$c40 = ":",
       peg$c41 = peg$literalExpectation(":", false),
-      peg$c42 = function(value) {
-                         return {
-                           type: NodeType.EXTERNAL,
-                           value
-                         };
-                       },
+      peg$c42 = function(external, memberPartWithOperators) {
+                return memberPartWithOperators.reduce(function(owner, tokens) {
+                  const operatorType = tokens[1];
+                  const eventNamespace = tokens[3];
+                  const MemberName = tokens[5];
+                  const {quoteStyle, name: memberName} = MemberName;
+
+                  switch (operatorType) {
+                    case NamepathOperatorType.MEMBER:
+                      return {
+                        type: NodeType.MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    case NamepathOperatorType.INSTANCE_MEMBER:
+                      return {
+                        type: NodeType.INSTANCE_MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    case NamepathOperatorType.INNER_MEMBER:
+                      return {
+                        type: NodeType.INNER_MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    default:
+                      throw new Error('Unexpected operator type: "' + operatorType + '"');
+                  }
+                }, Object.assign({
+                  type: NodeType.EXTERNAL
+                }, external));
+              },
       peg$c43 = "module",
       peg$c44 = peg$literalExpectation("module", false),
       peg$c45 = function(value) {
@@ -1861,7 +1894,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseExternalNameExpr() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
     var key    = peg$currPos * 84 + 15,
         cached = peg$resultsCache[key];
@@ -1893,11 +1926,116 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseNamepathExpr();
+            s5 = peg$parseMemberName();
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c42(s5);
-              s0 = s1;
+              s6 = [];
+              s7 = peg$currPos;
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseInfixNamepathOperator();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    if (input.substr(peg$currPos, 6) === peg$c7) {
+                      s11 = peg$c7;
+                      peg$currPos += 6;
+                    } else {
+                      s11 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                    }
+                    if (s11 === peg$FAILED) {
+                      s11 = null;
+                    }
+                    if (s11 !== peg$FAILED) {
+                      s12 = peg$parse_();
+                      if (s12 !== peg$FAILED) {
+                        s13 = peg$parseMemberName();
+                        if (s13 !== peg$FAILED) {
+                          s8 = [s8, s9, s10, s11, s12, s13];
+                          s7 = s8;
+                        } else {
+                          peg$currPos = s7;
+                          s7 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s7;
+                        s7 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s7;
+                      s7 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s7;
+                    s7 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s7;
+                  s7 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s7;
+                s7 = peg$FAILED;
+              }
+              while (s7 !== peg$FAILED) {
+                s6.push(s7);
+                s7 = peg$currPos;
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parseInfixNamepathOperator();
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 6) === peg$c7) {
+                        s11 = peg$c7;
+                        peg$currPos += 6;
+                      } else {
+                        s11 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c8); }
+                      }
+                      if (s11 === peg$FAILED) {
+                        s11 = null;
+                      }
+                      if (s11 !== peg$FAILED) {
+                        s12 = peg$parse_();
+                        if (s12 !== peg$FAILED) {
+                          s13 = peg$parseMemberName();
+                          if (s13 !== peg$FAILED) {
+                            s8 = [s8, s9, s10, s11, s12, s13];
+                            s7 = s8;
+                          } else {
+                            peg$currPos = s7;
+                            s7 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s7;
+                          s7 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s7;
+                        s7 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s7;
+                      s7 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s7;
+                    s7 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s7;
+                  s7 = peg$FAILED;
+                }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c42(s5, s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -1154,21 +1154,47 @@ describe('Parser', function() {
       });
     });
     describe('external', function () {
-      it('should return a module name node when "external:string" arrived', function() {
+      it('should return an external name node when "external:string" arrived', function() {
         const typeExprStr = 'external:string';
         const node = Parser.parse(typeExprStr);
 
-        const expectedNode = createExternalNameNode(createTypeNameNode('string'));
+        const expectedNode = createExternalNameNode('string');
         expect(node).to.deep.equal(expectedNode);
       });
 
 
-      it('should return a module name node when "external : String#rot13" arrived', function() {
+      it('should return an external name node when "external : String#rot13" arrived', function() {
         const typeExprStr = 'external : String#rot13';
         const node = Parser.parse(typeExprStr);
 
-        const expectedNode = createExternalNameNode(
-          createInstanceMemberTypeNode(createTypeNameNode('String'), 'rot13'));
+        const expectedNode = createInstanceMemberTypeNode(
+          createExternalNameNode('String'),
+          'rot13'
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return an external name node when `external:"jQuery.fn"` arrived', function() {
+        const typeExprStr = 'external:"jQuery.fn"';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createExternalNameNode('jQuery.fn', 'double');
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return an external name node when `external:"jQuery.fn".someMethod#event:abc` arrived', function() {
+        const typeExprStr = 'external:"jQuery.fn".someMethod#event:abc';
+        const node = Parser.parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+          createMemberTypeNode(
+            createExternalNameNode('jQuery.fn', 'double'),
+            'someMethod'
+          ),
+          'abc',
+          'none',
+          true
+        );
         expect(node).to.deep.equal(expectedNode);
       });
     });
@@ -1730,10 +1756,11 @@ function createModuleNameNode(value) {
   };
 }
 
-function createExternalNameNode(value) {
+function createExternalNameNode(name, quoteStyle = 'none') {
   return {
     type: NodeType.EXTERNAL,
-    value: value,
+    name,
+    quoteStyle,
   };
 }
 

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -329,6 +329,18 @@ describe('publish', function() {
         const node = parse('external:string');
         expect(publish(node)).to.equal('external:string');
       });
+      it('should return an external node type with an instance member method', function() {
+        const node = parse('external : String#rot13');
+        expect(publish(node)).to.equal('external:String#rot13');
+      });
+      it('should return a quoted external node type', function() {
+        const node = parse('external:"jQuery.fn"');
+        expect(publish(node)).to.equal('external:"jQuery.fn"');
+      });
+      it('should return a quoted external node type with a static member method and event', function() {
+        const node = parse('external:"jQuery.fn".someMethod#event:abc');
+        expect(publish(node)).to.equal('external:"jQuery.fn".someMethod#event:abc');
+      });
     });
 
 


### PR DESCRIPTION
- BREAKING CHANGE: `ExternalNameExpr` replace property `value` on return object with `name` and `quoteStyle`, and embed this within any `owner`-containing member (as with NamepathExpr)
- BREAKING CHANGE: on `ExternalNameExpr`, accept `MemberName` in place of `NamepathExpr` ("external:..." should point to a (quotable) name, optionally with members, but not a name path with parenthesized literals, imports, etc.)
- fix: allow quotes in `ExternalNameExpr` (for `external:"..."`)
- feat: preserve quote style for `ExternalNameExpr`
- testing(parsing): fix test descriptions ("a module name node" should instead be "an external name node")

Fixes #58.