### PR TITLE
Parse TypeScript style optional keys

### DIFF
--- a/lib/SyntaxType.js
+++ b/lib/SyntaxType.js
@@ -66,6 +66,7 @@ const VariadicTypeSyntax = {
 const OptionalTypeSyntax = {
   PREFIX_EQUALS_SIGN: 'PREFIX_EQUALS_SIGN',
   SUFFIX_EQUALS_SIGN: 'SUFFIX_EQUALS_SIGN',
+  SUFFIX_KEY_QUESTION_MARK: 'SUFFIX_KEY_QUESTION_MARK',
 };
 
 const NullableTypeSyntax = {

--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const {OPTIONAL} = require('./NodeType');
+const {OptionalTypeSyntax} = require('./SyntaxType');
 const {format} = require('util');
 
 /** @typedef {(node) => string} ConcretePublish */
@@ -67,7 +69,13 @@ function createDefaultPublisher() {
     },
     RECORD_ENTRY (entryNode, concretePublish) {
       if (!entryNode.value) return addQuotesForName(entryNode.key, entryNode.quoteStyle);
-      return format('%s: %s', addQuotesForName(entryNode.key, entryNode.quoteStyle), concretePublish(entryNode.value));
+      const keySuffix = (
+        entryNode.value.type === OPTIONAL &&
+        entryNode.value.meta.syntax === OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK
+      )
+        ? '?'
+        : '';
+      return format('%s%s: %s', addQuotesForName(entryNode.key, entryNode.quoteStyle), keySuffix, concretePublish(entryNode.value));
     },
     TUPLE (tupleNode, concretePublish) {
       const concretePublishedEntries = tupleNode.entries.map(concretePublish);
@@ -97,6 +105,9 @@ function createDefaultPublisher() {
       return addQuotesForName(filePathNode.path, filePathNode.quoteStyle);
     },
     OPTIONAL (optionalNode, concretePublish) {
+      if (optionalNode.meta.syntax === OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK) {
+        return concretePublish(optionalNode.value);
+      }
       return format('%s=', concretePublish(optionalNode.value));
     },
     NULLABLE (nullableNode, concretePublish) {

--- a/peg_lib/jsdoctype.js
+++ b/peg_lib/jsdoctype.js
@@ -650,13 +650,17 @@ function peg$parse(input, options) {
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c157 = function(keyInfo, value) {
+      peg$c157 = function(keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
                                 key,
-                                value,
-                                quoteStyle
+                                quoteStyle,
+                                value: optional !== '?' ? value : {
+                                  type: NodeType.OPTIONAL,
+                                  value,
+                                  meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK },
+                                }
                               };
                             },
       peg$c158 = function(keyInfo) {
@@ -6145,7 +6149,7 @@ function peg$parse(input, options) {
   }
 
   function peg$parseRecordTypeExprEntry() {
-    var s0, s1, s2, s3, s4, s5;
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     var key    = peg$currPos * 84 + 71,
         cached = peg$resultsCache[key];
@@ -6161,21 +6165,42 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 58) {
-          s3 = peg$c40;
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c55;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c41); }
+          if (peg$silentFails === 0) { peg$fail(peg$c56); }
+        }
+        if (s3 === peg$FAILED) {
+          s3 = null;
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseRecordTypeExprEntryOperand();
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s5 = peg$c40;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c41); }
+            }
             if (s5 !== peg$FAILED) {
-              peg$savedPos = s0;
-              s1 = peg$c157(s1, s5);
-              s0 = s1;
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseRecordTypeExprEntryOperand();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c157(s1, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;

--- a/tests/fixtures/typescript-types
+++ b/tests/fixtures/typescript-types
@@ -57,6 +57,7 @@
 {[ tuple, with, keyof foo, and, ...rest ]}
 {[ tuple, with, typeof foo, and, keyof foo]}
 {[ tuple, with, typeof foo, keyof foo, and, ...rest ]}
+{{ object?: string, key: string }}
 //{(own: list, of: constituents) => x}
 //{{ (own: list, constituents): x }}
 //{{ new (own: list, constituents): x }}

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -492,14 +492,14 @@ describe('Parser', function() {
       const typeExprStr = '{"key"Only"}';
       expect(function () {
         Parser.parse(typeExprStr);
-      }).to.throw('Expected ",", ":", "}", or [ \\t\\r\\n ] but "O" found.');
+      }).to.throw('Expected ",", ":", "?", "}", or [ \\t\\r\\n ] but "O" found.');
     });
 
     it('should throw when \'{"key\\\\"Only"}\' arrived', function() {
       const typeExprStr = '{"key\\\\"Only"}';
       expect(function () {
         Parser.parse(typeExprStr);
-      }).to.throw('Expected ",", ":", "}", or [ \\t\\r\\n ] but "O" found.');
+      }).to.throw('Expected ",", ":", "?", "}", or [ \\t\\r\\n ] but "O" found.');
     });
 
 

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -166,6 +166,16 @@ describe('publish', function() {
       const node = parse('{"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\": number, "myObject"}');
       expect(publish(node)).to.equal('{"\\\\Even count (escaped)\\\\\\\\backslash sequences\\\\remain\\\\": number, "myObject"}');
     });
+
+    it('should return an optional record type by type', function() {
+      const node = parse('{myNum: number=}');
+      expect(publish(node)).to.equal('{myNum: number=}');
+    });
+
+    it('should return an optional record type by key', function() {
+      const node = parse('{myNum?: number}');
+      expect(publish(node)).to.equal('{myNum?: number}');
+    });
   });
 
   describe('Tuple types', function () {


### PR DESCRIPTION
Typescript says this about optional keys in the object literal type:

```javascript
/**
 * @type {{ a: string, b: number= }}
 */
var wrong;
/**
 * Use postfix question on the property name instead:
 * @type {{ a: string, b?: number }}
 */
var right;
```

This can be seen on: https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html#patterns-that-are-known-not-to-be-supported

Previously only way to define an optional key was through a parameter on the type of that key, but as can be seen that isn't supported by TypeScript currently, they rather prefer to have
the key suffixed by a `?`, something that this commit adds support for.

Related discussions in the Closure project, which has not arrived at a conclusion yet: https://github.com/google/closure-compiler/issues/126