### PR TITLE
Fix for traversal with `external`

### DIFF
--- a/lib/traversing.js
+++ b/lib/traversing.js
@@ -109,9 +109,7 @@ const _childNodesMap = {
   },
   STRING_VALUE: {},
   NUMBER_VALUE: {},
-  EXTERNAL: {
-    value: _PropertyAccessor.NODE,
-  },
+  EXTERNAL: {},
   FILE_PATH: {},
   PARENTHESIS: {
     value: _PropertyAccessor.NODE,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsdoctypeparser",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@types/node": {
-      "version": "12.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.10.tgz",
-      "integrity": "sha512-LcsGbPomWsad6wmMNv7nBLw7YYYyfdYcz6xryKYQhx89c3XXan+8Q6AJ43G5XDIaklaVkK3mE4fCb0SBvMiPSQ==",
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.12.tgz",
+      "integrity": "sha512-Uy0PN4R5vgBUXFoJrKryf5aTk3kJ8Rv3PdlHjl6UaX+Cqp1QE0yPQ68MPXGrZOfG7gZVNDIJZYyot0B9ubXUrQ==",
       "dev": true
     },
     "acorn": {
@@ -1693,7 +1693,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@types/node": "^12.0.10",
+    "@types/node": "^12.0.12",
     "chai": "^4.2.0",
     "eslint": "^6.0.1",
     "mkdirp": "^0.5.1",

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -323,11 +323,9 @@ describe('traversing', function() {
     },
     'External': {
       'should visit an external node': {
-        given: { type: NodeType.EXTERNAL, value: createNameNode('external') },
+        given: { type: NodeType.EXTERNAL, name: 'external', quoteStyle: 'double' },
         then: [
           ['enter', NodeType.EXTERNAL, null, null],
-          ['enter', NodeType.NAME, 'value', NodeType.EXTERNAL],
-          ['leave', NodeType.NAME, 'value', NodeType.EXTERNAL],
           ['leave', NodeType.EXTERNAL, null, null],
         ],
       },


### PR DESCRIPTION
fix(traversal): external no longer traverses name node children (it includes the `name` and `quoteStyle` directly)