### PR TITLE
Add a full type definition for the AST nodes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/** @typedef {import('./lib/parsing').AstNode} AstNode */
+
 const {parse, JSDocTypeSyntaxError} = require('./lib/parsing.js');
 const {publish, createDefaultPublisher} = require('./lib/publishing.js');
 const {traverse} = require('./lib/traversing.js');

--- a/lib/parsing.js
+++ b/lib/parsing.js
@@ -1,5 +1,30 @@
 'use strict';
 
+/**
+ * @typedef AstNode
+ * @property {string} type
+ * @property {'none'|'single'|'double'} [quoteStyle]
+ * @property {string} [key]
+ * @property {string} [name]
+ * @property {string} [number]
+ * @property {string} [path]
+ * @property {string} [string]
+ * @property {boolean} [hasEventPrefix]
+ * @property {boolean} [typeName]
+ * @property {Object<string,any>} [meta]
+ * @property {AstNode} [returns]
+ * @property {AstNode} [new]
+ * @property {AstNode} [value]
+ * @property {AstNode} [left]
+ * @property {AstNode} [right]
+ * @property {AstNode} [owner]
+ * @property {AstNode} [subject]
+ * @property {AstNode} [this]
+ * @property {AstNode[]} [entries]
+ * @property {AstNode[]} [objects]
+ * @property {AstNode[]} [params]
+ */
+
 const {SyntaxError: JSDocTypeSyntaxError, parse} = require('../peg_lib/jsdoctype.js');
 
 module.exports = {
@@ -14,7 +39,9 @@ module.exports = {
   /**
    * Parse the specified type expression string.
    * @param {string} typeExprStr Type expression string.
-   * @return {Object} AST.
+   * @return {AstNode} AST.
    */
-  parse,
+  parse (typeExprStr) {
+    return parse(typeExprStr);
+  },
 };

--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -4,11 +4,12 @@ const {OPTIONAL} = require('./NodeType');
 const {OptionalTypeSyntax} = require('./SyntaxType');
 const {format} = require('util');
 
+/** @typedef {import('./parsing').AstNode} AstNode */
 /** @typedef {(node) => string} ConcretePublish */
-/** @typedef {{ [T in import('./NodeType').Type]: (node, publish: ConcretePublish) => string }} Publisher */
+/** @typedef {{ [T in import('./NodeType').Type]: (node: AstNode, publish: ConcretePublish) => string }} Publisher */
 
 /**
- * @param node
+ * @param {AstNode} node
  * @param {Publisher} [opt_publisher]
  * @return {string}
  */


### PR DESCRIPTION
As a follow up to #84 I thought it could be nifty to actually add a full type definition for the AST nodes.

It can probably be much improved, but this was a first quick stab at it.