### PR TITLE
test(no‑syntax‑error): Improve error messages when parsing fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pretest": "npm-run-all lint build",
     "test": "npm-run-all mocha typecheck",
     "lint": "eslint .",
-    "mocha": "mocha tests",
+    "mocha": "mocha tests/test_*",
     "typecheck": "tsc",
     "clean": "rimraf ./peg_lib",
     "postclean": "mkdirp ./peg_lib",

--- a/tests/test_syntax_error.js
+++ b/tests/test_syntax_error.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
 const util = require('util');
 const Parser = require('../lib/parsing.js');
+const {readFixtureSync} = require('./utils.js');
 
+/** @type {{[fixtureName: string]: import('./utils').Fixture}} */
 const Fixtures = {
   TYPESCRIPT: readFixtureSync('erring-typescript-types'),
 };
@@ -12,7 +12,8 @@ const Fixtures = {
 describe('Parser', function() {
   it('should throw errors when parsing erring tests/fixtures/*', function() {
     Object.keys(Fixtures).forEach(function(fixtureName) {
-      Fixtures[fixtureName].forEach(function({skip, typeExprStr, position}) {
+      const fixture = Fixtures[fixtureName];
+      fixture.forEach(function({skip, typeExprStr, position}) {
         if (skip) return;
 
         let parsed;
@@ -23,35 +24,16 @@ describe('Parser', function() {
           return;
         }
 
-        const debugMessage = util.format('Should have erred parsing %s at %s:%d; instead parsed as:\n\n%s',
-                                       typeExprStr,
-                                       position.filePath,
-                                       position.lineno,
-                                       JSON.stringify(parsed, null,2));
+        const debugMessage = util.format(
+          'Should have erred parsing %s at %s:%d; instead parsed as:\n\n%s',
+          typeExprStr.replace(/\n/g, '\\n'),
+          fixture.filePath,
+          position.lineno,
+          JSON.stringify(parsed, null, 2)
+        );
 
         throw new Error(debugMessage);
       });
     });
   });
 });
-
-
-function readFixtureSync(fileName) {
-  const filePath = path.resolve(__dirname, 'fixtures', fileName);
-
-  return fs.readFileSync(filePath, 'utf8')
-    .trim()
-    .split(/\n/)
-    .map(function(line, lineIdx) {
-      return {
-        // When the line starts with "//", we should skip it.
-        skip: /^\/\//.test(line),
-
-        typeExprStr: line.trim().replace(/^\{(.*)\}$/, '$1').replace(/\\n/g, '\n'),
-        position: {
-          filePath,
-          lineno: lineIdx + 1,
-        },
-      };
-    });
-}

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * @typedef {object} FixtureEntry
+ * @property {boolean} skip
+ * @property {string} typeExprStr
+ * @property {FilePosition} position
+ *
+ * @typedef {object} FilePosition
+ * @property {string} fileName
+ * @property {string} lineno
+ *
+ * @typedef {{fileName: string, filePath: string} & FixtureEntry[]} Fixture
+ */
+
+/**
+ * @param {string} fileName
+ * @return {Fixture}
+ */
+function readFixtureSync(fileName) {
+  const filePath = path.resolve(__dirname, 'fixtures', fileName);
+
+  /** @type {any} */
+  let result = fs.readFileSync(filePath, 'utf8')
+    .trim()
+    .split(/\n/)
+    .map(function(line, lineIdx) {
+      return {
+        // When the line starts with "//", we should skip it.
+        skip: /^\/\//.test(line),
+
+        typeExprStr: line.trim().replace(/^\{(.*)\}$/, '$1').replace(/\\n/g, '\n'),
+        position: {
+          fileName,
+          lineno: lineIdx + 1,
+        },
+      };
+    });
+
+  Object.defineProperties(result, {
+    fileName: {
+      value: fileName,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
+    filePath: {
+      value: path.relative(process.cwd(), filePath),
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    },
+  });
+  return result;
+}
+
+exports.readFixtureSync = readFixtureSync;


### PR DESCRIPTION
This creates a new `it(…)` context per fixture, so that syntax errors in one fixture don’t prevent syntax errors in another fixture from being reported.

I had this sitting around since developing #88.