### PR TITLE
Empty variadic any

### DIFF
--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const {OPTIONAL} = require('./NodeType');
-const {OptionalTypeSyntax} = require('./SyntaxType');
+const {OptionalTypeSyntax, VariadicTypeSyntax} = require('./SyntaxType');
 const {format} = require('util');
 
 /** @typedef {import('./parsing').AstNode} AstNode */
@@ -62,7 +62,7 @@ function createDefaultPublisher() {
                     concretePublish(unionNode.right));
     },
     VARIADIC (variadicNode, concretePublish) {
-      if (!variadicNode.value) {
+      if (variadicNode.meta.syntax === VariadicTypeSyntax.ONLY_DOTS) {
         return '...';
       }
       return format('...%s', concretePublish(variadicNode.value));

--- a/peg_lib/jsdoctype.js
+++ b/peg_lib/jsdoctype.js
@@ -733,7 +733,7 @@ function peg$parse(input, options) {
       peg$c173 = function() {
                             return {
                               type: NodeType.VARIADIC,
-                              value: null,
+                              value: { type: NodeType.ANY },
                               meta: { syntax: VariadicTypeSyntax.ONLY_DOTS },
                             };
                           },

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -1166,7 +1166,7 @@ SuffixVariadicTypeExpr = operand:VariadicTypeExprOperand "..." {
 AnyVariadicTypeExpr = "..." {
                       return {
                         type: NodeType.VARIADIC,
-                        value: null,
+                        value: { type: NodeType.ANY },
                         meta: { syntax: VariadicTypeSyntax.ONLY_DOTS },
                       };
                     }

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -632,7 +632,7 @@ describe('Parser', function() {
       const expectedNode = createTupleTypeNode([
         createTypeNameNode('TupleAnyVarargs'),
         createVariadicTypeNode(
-          null,
+          createAnyTypeNode(),
           VariadicTypeSyntax.ONLY_DOTS
         ),
       ]);
@@ -1494,7 +1494,7 @@ describe('Parser', function() {
       const node = parse(typeExprStr);
 
       const expectedNode = createVariadicTypeNode(
-        null,
+        createAnyTypeNode(),
         VariadicTypeSyntax.ONLY_DOTS
       );
 

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -355,12 +355,14 @@ describe('traversing', function() {
         ],
       },
       'should visit an empty variadic node': {
-        given: { type: NodeType.VARIADIC, value: null },
+        given: { type: NodeType.VARIADIC, value: {
+          type: NodeType.ANY,
+        }},
         then: [
           // eventName, node && node.type, propName, parentNode && parentNode.type
           ['enter', NodeType.VARIADIC, null, null],
-          ['enter', null, 'value', NodeType.VARIADIC],
-          ['leave', null, 'value', NodeType.VARIADIC],
+          ['enter', NodeType.ANY, 'value', NodeType.VARIADIC],
+          ['leave', NodeType.ANY, 'value', NodeType.VARIADIC],
           ['leave', NodeType.VARIADIC, null, null],
         ],
       },
@@ -569,7 +571,7 @@ function createInstanceMemberNode(name, owner) {
 
 function createEventSpy(eventName, result) {
   return function(node, propName, parentNode) {
-    result.push([eventName, node && node.type, propName, parentNode && parentNode.type]);
+    result.push([eventName, node.type, propName, parentNode && parentNode.type]);
   };
 }
 


### PR DESCRIPTION
Though this is a breaking change, I think it is worth it to provide consistency in traversal (and this particular node type hasn't been supported very long anyways).

I think this makes more sense than fixing things at our eslint-plugin-jsdoc level (as per this PR: https://github.com/gajus/eslint-plugin-jsdoc/pull/419 ).
