### PR TITLE
traversal: change expected `new` on arrow from a node to a string

### DIFF
--- a/lib/traversing.js
+++ b/lib/traversing.js
@@ -99,7 +99,6 @@ const _childNodesMap = {
   ARROW: {
     params: _PropertyAccessor.NODE_LIST,
     returns: _PropertyAccessor.NULLABLE_NODE,
-    new: _PropertyAccessor.NULLABLE_NODE,
   },
   ANY: {},
   UNKNOWN: {},

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -190,6 +190,21 @@ describe('traversing', function() {
         ],
       },
 
+      'should visit an arrow function with no params and `new`': {
+        given: {
+          type: NodeType.ARROW,
+          params: [],
+          returns: createNameNode('return'),
+          new: 'new',
+        },
+        then: [
+          ['enter', NodeType.ARROW, null, null],
+          ['enter', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.NAME, 'returns', NodeType.ARROW],
+          ['leave', NodeType.ARROW, null, null],
+        ],
+      },
+
       'should visit an arrow function that has two params and a returns': {
         given: {
           type: NodeType.ARROW,


### PR DESCRIPTION
fix: for traversal, change the expected `new` on arrow from a node to a string; fixes #103