### PR TITLE
Coverage

### DIFF
--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -111,16 +111,6 @@ NamepathExpr = rootOwner:(ParenthesizedExpr / ImportTypeExpr / TypeNameExpr) mem
  *   - https://developers.google.com/closure/compiler/docs/js-for-compiler#types
  */
 TypeNameExpr = TypeNameExprJsDocFlavored
-/*
-             / TypeNameExprStrict
-
-TypeNameExprStrict = name:JsIdentifier {
-                     return {
-                       type: NodeType.NAME,
-                       name
-                     };
-                   }
-*/
 
 // JSDoc allow to use hyphens in identifier contexts.
 // See https://github.com/jsdoctypeparser/jsdoctypeparser/issues/15

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -36,27 +36,6 @@ TopTypeExpr = _ expr:( VariadicTypeExpr
            return expr;
          }
 
-TopLevel = _ expr:( VariadicTypeExpr
-                  / UnionTypeExpr
-                  / UnaryUnionTypeExpr
-                  / ArrayTypeExpr
-                  / GenericTypeExpr
-                  / RecordTypeExpr
-                  / TupleTypeExpr
-                  / ArrowTypeExpr
-                  / FunctionTypeExpr
-                  / TypeQueryExpr
-                  / KeyQueryExpr
-                  / BroadNamepathExpr
-                  / ParenthesizedExpr
-                  / ValueExpr
-                  / AnyTypeExpr
-                  / UnknownTypeExpr
-                  ) _ {
-           return expr;
-         }
-
-
 /*
  * White spaces.
  */
@@ -109,6 +88,7 @@ NamepathExpr = rootOwner:(ParenthesizedExpr / ImportTypeExpr / TypeNameExpr) mem
                        quoteStyle,
                        hasEventPrefix: Boolean(eventNamespace),
                      };
+                   /* istanbul ignore next */
                    default:
                      throw new Error('Unexpected operator type: "' + operatorType + '"');
                  }
@@ -131,8 +111,8 @@ NamepathExpr = rootOwner:(ParenthesizedExpr / ImportTypeExpr / TypeNameExpr) mem
  *   - https://developers.google.com/closure/compiler/docs/js-for-compiler#types
  */
 TypeNameExpr = TypeNameExprJsDocFlavored
+/*
              / TypeNameExprStrict
-
 
 TypeNameExprStrict = name:JsIdentifier {
                      return {
@@ -140,7 +120,7 @@ TypeNameExprStrict = name:JsIdentifier {
                        name
                      };
                    }
-
+*/
 
 // JSDoc allow to use hyphens in identifier contexts.
 // See https://github.com/jsdoctypeparser/jsdoctypeparser/issues/15
@@ -272,6 +252,7 @@ ExternalNameExpr = "external" _ ":" _ external:(MemberName) memberPartWithOperat
                   quoteStyle,
                   hasEventPrefix: Boolean(eventNamespace),
                 };
+              /* istanbul ignore next */
               default:
                 throw new Error('Unexpected operator type: "' + operatorType + '"');
             }
@@ -334,6 +315,7 @@ ModulePathExpr = rootOwner:(FilePathExpr) memberPartWithOperators:(_ InfixNamepa
                          quoteStyle,
                          hasEventPrefix: Boolean(eventNamespace),
                        };
+                     /* istanbul ignore next */
                      default:
                        throw new Error('Unexpected operator type: "' + operatorType + '"');
                    }
@@ -812,12 +794,12 @@ ArrowTypeExpr = newModifier:"new"? _ paramsPart:ArrowTypeExprParamsList _ "=>" _
                    };
 }
 
-ArrowTypeExprParamsList = "(" _ params:ArrowTypeExprParams _ ")" {
-                            return params;
-                          }
-                        / "(" _ ")" {
-                            return [];
-                          }
+ArrowTypeExprParamsList = "(" _ ")" {
+                      return [];
+                    } /
+                    "(" _ params:ArrowTypeExprParams _ ")" {
+                      return params;
+                    }
 ArrowTypeExprParams = paramsWithComma:(JsIdentifier _ ":" _ FunctionTypeExprParamOperand? _ "," _)* lastParam:VariadicNameExpr? {
   return paramsWithComma.reduceRight(function(params, tokens) {
     const param = { type: NodeType.NAMED_PARAMETER, name: tokens[0], typeName: tokens[4] };
@@ -872,11 +854,11 @@ FunctionTypeExprParamsList = "(" _ modifier:FunctionTypeExprModifier _ "," _ par
                            / "(" _ modifier:FunctionTypeExprModifier _ ")" {
                                return { params: [], modifier };
                              }
-                           / "(" _ params:FunctionTypeExprParams _ ")" {
-                               return { params, modifier: { nodeThis: null, nodeNew: null } };
-                             }
                            / "(" _ ")" {
                                return { params: [], modifier: { nodeThis: null, nodeNew: null } };
+                             }
+                           / "(" _ params:FunctionTypeExprParams _ ")" {
+                               return { params, modifier: { nodeThis: null, nodeNew: null } };
                              }
 
 
@@ -1048,10 +1030,10 @@ RecordTypeExprEntryOperand = UnionTypeExpr
  * Spec:
  *   - https://www.typescriptlang.org/docs/handbook/basic-types.html#tuple
  */
-TupleTypeExpr = "[" _ entries:TupleTypeExprEntries? _ "]" {
+TupleTypeExpr = "[" _ entries:TupleTypeExprEntries _ "]" {
   return {
     type: NodeType.TUPLE,
-    entries: entries || [],
+    entries,
   }
 }
 

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -40,6 +40,14 @@ describe('Parser', function() {
       expect(node).to.deep.equal(expectedNode);
     });
 
+    it('should return a number value type node when ".05" arrived', function() {
+      const typeExprStr = '.05';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
     it('should return a number value type node when "-0" arrived', function() {
       const typeExprStr = '-0';
       const node = parse(typeExprStr);
@@ -89,6 +97,14 @@ describe('Parser', function() {
       expect(node).to.deep.equal(expectedNode);
     });
 
+    it('should return a number value type node when "3.14e54" arrived', function() {
+      const typeExprStr = '3.14e54';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createNumberValueNode(typeExprStr);
+      expect(node).to.deep.equal(expectedNode);
+    });
+
     it('should return a number value type node when "0b01" arrived', function() {
       const typeExprStr = '0b01';
       const node = parse(typeExprStr);
@@ -129,6 +145,22 @@ describe('Parser', function() {
       const node = parse(typeExprStr);
 
       const expectedNode = createStringValueNode('', 'single');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a string value type node when "\'\\a\'" arrived', function() {
+      const typeExprStr = "'\\a'";
+      const node = parse(typeExprStr);
+
+      const expectedNode = createStringValueNode('\\a', 'single');
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a string value type node when "\'\\a\\\'\'" arrived', function() {
+      const typeExprStr = "'\\a\\''";
+      const node = parse(typeExprStr);
+
+      const expectedNode = createStringValueNode("\\a'", 'single');
       expect(node).to.deep.equal(expectedNode);
     });
 
@@ -516,6 +548,19 @@ describe('Parser', function() {
       expect(node).to.deep.equal(expectedNode);
     });
 
+    it('should return a record type node when "{key1:ValueType1,key2:ValueType2\r\n}"' +
+       ' arrived', function() {
+      const typeExprStr = '{key1:ValueType1,key2:ValueType2\r\n}';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
+        createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
 
     it('should return a record type node when "{key:ValueType1,keyOnly}"' +
        ' arrived', function() {
@@ -544,6 +589,18 @@ describe('Parser', function() {
       expect(node).to.deep.equal(expectedNode);
     });
 
+    it('should return a record type node when "{ key1 : ValueType1 , key2 : ValueType2  }"' +
+       ' arrived', function() {
+      const typeExprStr = '{ key1 : ValueType1 , key2 : ValueType2  }';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('key1', createTypeNameNode('ValueType1')),
+        createRecordEntryNode('key2', createTypeNameNode('ValueType2')),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
 
     it('should return a record type node when "{\'quoted-key\':ValueType}"' +
        ' arrived', function() {
@@ -552,6 +609,30 @@ describe('Parser', function() {
 
       const expectedNode = createRecordTypeNode([
         createRecordEntryNode('quoted-key', createTypeNameNode('ValueType'), 'single'),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a record type node when "{\'\\quoted-key\':ValueType}"' +
+       ' arrived', function() {
+      const typeExprStr = '{\'\\quoted-key\':ValueType}';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('\\quoted-key', createTypeNameNode('ValueType'), 'single'),
+      ]);
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+
+    it('should return a record type node when "{\'q\\uoted-key\':ValueType}"' +
+       ' arrived', function() {
+      const typeExprStr = '{\'q\\uoted-key\':ValueType}';
+      const node = parse(typeExprStr);
+
+      const expectedNode = createRecordTypeNode([
+        createRecordEntryNode('q\\uoted-key', createTypeNameNode('ValueType'), 'single'),
       ]);
 
       expect(node).to.deep.equal(expectedNode);
@@ -926,6 +1007,32 @@ describe('Parser', function() {
         expect(node).to.deep.equal(expectedNode);
       });
 
+      it('should return a member type node when "owner.\'\'" arrived', function() {
+        const typeExprStr = 'owner.\'\'';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          '',
+          'single'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member type node when "owner.\'\\a\'" arrived', function() {
+        const typeExprStr = 'owner.\'\\a\'';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createMemberTypeNode(
+          createTypeNameNode('owner'),
+          '\\a',
+          'single'
+        );
+
+        expect(node).to.deep.equal(expectedNode);
+      });
+
       it('should return a member type node when \'owner."Mem\\ber"\' arrived', function() {
         const typeExprStr = 'owner."Mem\\ber"';
         const node = parse(typeExprStr);
@@ -1174,11 +1281,36 @@ describe('Parser', function() {
         expect(node).to.deep.equal(expectedNode);
       });
 
+      it('should return an external name node when "external : String~rot13" arrived', function() {
+        const typeExprStr = 'external : String~rot13';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createInnerMemberTypeNode(
+          createExternalNameNode('String'),
+          'rot13'
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
       it('should return an external name node when `external:"jQuery.fn"` arrived', function() {
         const typeExprStr = 'external:"jQuery.fn"';
         const node = parse(typeExprStr);
 
         const expectedNode = createExternalNameNode('jQuery.fn', 'double');
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return an external name node when `external:"jQuery.fn".someMethod#abc` arrived', function() {
+        const typeExprStr = 'external:"jQuery.fn".someMethod#abc';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+          createMemberTypeNode(
+            createExternalNameNode('jQuery.fn', 'double'),
+            'someMethod'
+          ),
+          'abc'
+        );
         expect(node).to.deep.equal(expectedNode);
       });
 
@@ -1191,6 +1323,19 @@ describe('Parser', function() {
             createExternalNameNode('jQuery.fn', 'double'),
             'someMethod'
           ),
+          'abc',
+          'none',
+          true
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return an external name node when `external:"jQuery.fn"#event:abc` arrived', function() {
+        const typeExprStr = 'external:"jQuery.fn"#event:abc';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createInstanceMemberTypeNode(
+          createExternalNameNode('jQuery.fn', 'double'),
           'abc',
           'none',
           true
@@ -1252,6 +1397,24 @@ describe('Parser', function() {
         expect(node).to.deep.equal(expectedNode);
       });
 
+      it('should return a member node when "module:path/to#file#event:member" arrived', function() {
+        const typeExprStr = 'module:path/to#file#event:member';
+        const node = parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(
+          createInstanceMemberTypeNode(
+            createInstanceMemberTypeNode(
+              createFilePathNode('path/to'),
+              'file'
+            ),
+            'member',
+            'none',
+            true
+          )
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
       it('should return a member node when \'module:"path/to/file".event:member\' arrived', function() {
         const typeExprStr = 'module:"path/to/file".event:member';
         const node = parse(typeExprStr);
@@ -1268,6 +1431,26 @@ describe('Parser', function() {
 
         const expectedNode = createModuleNameNode(
           createMemberTypeNode(createFilePathNode('path\\to\\file"', 'double'), 'member', 'none', true)
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member node when "module:\'\\path\'.event:member" arrived', function() {
+        const typeExprStr = "module:'\\path'.event:member";
+        const node = parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(
+          createMemberTypeNode(createFilePathNode('\\path', 'single'), 'member', 'none', true)
+        );
+        expect(node).to.deep.equal(expectedNode);
+      });
+
+      it('should return a member node when "module:\'path\\\\to\\file\\\'\'.event:member" arrived', function() {
+        const typeExprStr = "module:'path\\\\to\\file\\''.event:member";
+        const node = parse(typeExprStr);
+
+        const expectedNode = createModuleNameNode(
+          createMemberTypeNode(createFilePathNode("path\\to\\file'", 'single'), 'member', 'none', true)
         );
         expect(node).to.deep.equal(expectedNode);
       });


### PR DESCRIPTION
- Refactoring: Remove unused `TopLevel`; comment out or
    ignore unneeded/redundant expressions and reorder to ensure
    coverage
- Testing: Add tests for two digit sequences (after
    no-leading-0-decimal, after scientific notation)
- Testing: Cover single quotes
- Testing: Record type node whitespace and key quoting
- Testing: `external` private, instance, and event members
- Testing: Multiple instance member `module`

This PR should effectively bring 100% coverage. However, we will need to wait on the possible merging of https://github.com/pegjs/pegjs/pull/632 to provide an API for us to auto-add coverage ignore statements to the generated PEG parser and thereby get nyc to be able to reflect the fact that we have 100% coverage (currently peg produces various code, especially `else` statements for missing tokens, which I expect shouldn't really be needed to consider the parser source as being fully "covered").