### PR TITLE
Whitespace after keywords

### DIFF
--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {OPTIONAL} = require('./NodeType');
+const {OPTIONAL, PARENTHESIS} = require('./NodeType');
 const {OptionalTypeSyntax, VariadicTypeSyntax} = require('./SyntaxType');
 const {format} = require('util');
 
@@ -179,6 +179,9 @@ function createDefaultPublisher() {
       return format('typeof %s', concretePublish(typeQueryNode.name));
     },
     KEY_QUERY (keyQueryNode, concretePublish) {
+      if (keyQueryNode.value.type === PARENTHESIS) {
+        return format('keyof%s', concretePublish(keyQueryNode.value));
+      }
       return format('keyof %s', concretePublish(keyQueryNode.value));
     },
     IMPORT (importNode, concretePublish) {

--- a/peg_lib/jsdoctype-closure.js
+++ b/peg_lib/jsdoctype-closure.js
@@ -792,7 +792,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 0,
+    var key    = peg$currPos * 68 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -862,10 +862,67 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parse_() {
-    var s0, s1, s2, s3;
+  function peg$parseWS() {
+    var s0, s1, s2;
 
-    var key    = peg$currPos * 66 + 1,
+    var key    = peg$currPos * 68 + 1,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    if (peg$c1.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c2); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (peg$c3.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        if (peg$c5.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c6); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse_() {
+    var s0, s1;
+
+    var key    = peg$currPos * 68 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -875,86 +932,38 @@ function peg$parse(input, options) {
     }
 
     s0 = [];
-    if (peg$c1.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c2); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = peg$currPos;
-      if (peg$c3.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c4); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        if (peg$c5.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c6); }
-        }
-        if (s3 !== peg$FAILED) {
-          s2 = [s2, s3];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    }
+    s1 = peg$parseWS();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c1.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+      s1 = peg$parseWS();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse__() {
+    var s0, s1;
+
+    var key    = peg$currPos * 68 + 3,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = [];
+    s1 = peg$parseWS();
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
+        s1 = peg$parseWS();
       }
-      if (s1 === peg$FAILED) {
-        s1 = peg$currPos;
-        if (peg$c3.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c4); }
-        }
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
-        if (s2 !== peg$FAILED) {
-          if (peg$c5.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c6); }
-          }
-          if (s3 !== peg$FAILED) {
-            s2 = [s2, s3];
-            s1 = s2;
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      }
+    } else {
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -965,7 +974,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 66 + 2,
+    var key    = peg$currPos * 68 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1027,7 +1036,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 66 + 3,
+    var key    = peg$currPos * 68 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1163,7 +1172,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 4,
+    var key    = peg$currPos * 68 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1231,7 +1240,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 5,
+    var key    = peg$currPos * 68 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1490,7 +1499,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 66 + 6,
+    var key    = peg$currPos * 68 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1515,7 +1524,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 7,
+    var key    = peg$currPos * 68 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1618,7 +1627,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 8,
+    var key    = peg$currPos * 68 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1649,7 +1658,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 9,
+    var key    = peg$currPos * 68 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1680,7 +1689,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 10,
+    var key    = peg$currPos * 68 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1711,7 +1720,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 11,
+    var key    = peg$currPos * 68 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1736,7 +1745,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 66 + 12,
+    var key    = peg$currPos * 68 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1905,7 +1914,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 13,
+    var key    = peg$currPos * 68 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1969,7 +1978,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 66 + 14,
+    var key    = peg$currPos * 68 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2102,7 +2111,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 15,
+    var key    = peg$currPos * 68 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2388,7 +2397,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 16,
+    var key    = peg$currPos * 68 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2419,7 +2428,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 17,
+    var key    = peg$currPos * 68 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2450,7 +2459,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 18,
+    var key    = peg$currPos * 68 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2472,7 +2481,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 19,
+    var key    = peg$currPos * 68 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2722,7 +2731,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 20,
+    var key    = peg$currPos * 68 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2756,7 +2765,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 21,
+    var key    = peg$currPos * 68 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2813,7 +2822,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 22,
+    var key    = peg$currPos * 68 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3043,7 +3052,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 23,
+    var key    = peg$currPos * 68 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3124,7 +3133,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 24,
+    var key    = peg$currPos * 68 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3205,7 +3214,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 25,
+    var key    = peg$currPos * 68 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3286,7 +3295,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 26,
+    var key    = peg$currPos * 68 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3347,7 +3356,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 27,
+    var key    = peg$currPos * 68 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3393,7 +3402,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 28,
+    var key    = peg$currPos * 68 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3415,7 +3424,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 29,
+    var key    = peg$currPos * 68 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3440,7 +3449,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 30,
+    var key    = peg$currPos * 68 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3480,7 +3489,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 31,
+    var key    = peg$currPos * 68 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3498,7 +3507,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c88); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseQualifiedMemberName();
         if (s3 !== peg$FAILED) {
@@ -3526,7 +3535,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 32,
+    var key    = peg$currPos * 68 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3572,7 +3581,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 33,
+    var key    = peg$currPos * 68 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3618,7 +3627,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 34,
+    var key    = peg$currPos * 68 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3664,7 +3673,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 35,
+    var key    = peg$currPos * 68 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3689,7 +3698,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 36,
+    var key    = peg$currPos * 68 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3732,7 +3741,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 37,
+    var key    = peg$currPos * 68 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3778,7 +3787,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 38,
+    var key    = peg$currPos * 68 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3824,7 +3833,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 66 + 39,
+    var key    = peg$currPos * 68 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3876,7 +3885,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 40,
+    var key    = peg$currPos * 68 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3940,7 +3949,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 41,
+    var key    = peg$currPos * 68 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3971,7 +3980,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 42,
+    var key    = peg$currPos * 68 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4020,7 +4029,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 43,
+    var key    = peg$currPos * 68 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4123,7 +4132,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 66 + 44,
+    var key    = peg$currPos * 68 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4145,7 +4154,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 45,
+    var key    = peg$currPos * 68 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4176,7 +4185,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 46,
+    var key    = peg$currPos * 68 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4207,7 +4216,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 66 + 47,
+    var key    = peg$currPos * 68 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4232,7 +4241,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 66 + 48,
+    var key    = peg$currPos * 68 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4319,7 +4328,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 66 + 49,
+    var key    = peg$currPos * 68 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4545,7 +4554,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 50,
+    var key    = peg$currPos * 68 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4667,7 +4676,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 51,
+    var key    = peg$currPos * 68 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4776,7 +4785,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 52,
+    var key    = peg$currPos * 68 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4825,7 +4834,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 53,
+    var key    = peg$currPos * 68 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4871,7 +4880,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 54,
+    var key    = peg$currPos * 68 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4938,7 +4947,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 55,
+    var key    = peg$currPos * 68 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5320,7 +5329,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 66 + 56,
+    var key    = peg$currPos * 68 + 58,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5408,7 +5417,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 66 + 57,
+    var key    = peg$currPos * 68 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5676,7 +5685,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 58,
+    var key    = peg$currPos * 68 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5722,7 +5731,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 66 + 59,
+    var key    = peg$currPos * 68 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5786,7 +5795,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 60,
+    var key    = peg$currPos * 68 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5832,7 +5841,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 66 + 61,
+    var key    = peg$currPos * 68 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5857,7 +5866,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 66 + 62,
+    var key    = peg$currPos * 68 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5897,7 +5906,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 66 + 63,
+    var key    = peg$currPos * 68 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5937,7 +5946,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 66 + 64,
+    var key    = peg$currPos * 68 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5968,7 +5977,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 66 + 65,
+    var key    = peg$currPos * 68 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-jsdoc.js
+++ b/peg_lib/jsdoctype-jsdoc.js
@@ -801,7 +801,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 0,
+    var key    = peg$currPos * 69 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -871,10 +871,67 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parse_() {
-    var s0, s1, s2, s3;
+  function peg$parseWS() {
+    var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 1,
+    var key    = peg$currPos * 69 + 1,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    if (peg$c1.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c2); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (peg$c3.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        if (peg$c5.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c6); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse_() {
+    var s0, s1;
+
+    var key    = peg$currPos * 69 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -884,86 +941,38 @@ function peg$parse(input, options) {
     }
 
     s0 = [];
-    if (peg$c1.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c2); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = peg$currPos;
-      if (peg$c3.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c4); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        if (peg$c5.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c6); }
-        }
-        if (s3 !== peg$FAILED) {
-          s2 = [s2, s3];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    }
+    s1 = peg$parseWS();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c1.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+      s1 = peg$parseWS();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse__() {
+    var s0, s1;
+
+    var key    = peg$currPos * 69 + 3,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = [];
+    s1 = peg$parseWS();
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
+        s1 = peg$parseWS();
       }
-      if (s1 === peg$FAILED) {
-        s1 = peg$currPos;
-        if (peg$c3.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c4); }
-        }
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
-        if (s2 !== peg$FAILED) {
-          if (peg$c5.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c6); }
-          }
-          if (s3 !== peg$FAILED) {
-            s2 = [s2, s3];
-            s1 = s2;
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      }
+    } else {
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -974,7 +983,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 67 + 2,
+    var key    = peg$currPos * 69 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1036,7 +1045,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 3,
+    var key    = peg$currPos * 69 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1172,7 +1181,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 4,
+    var key    = peg$currPos * 69 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1240,7 +1249,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 5,
+    var key    = peg$currPos * 69 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1499,7 +1508,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 67 + 6,
+    var key    = peg$currPos * 69 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1524,7 +1533,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 7,
+    var key    = peg$currPos * 69 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1627,7 +1636,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 8,
+    var key    = peg$currPos * 69 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1658,7 +1667,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 9,
+    var key    = peg$currPos * 69 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1689,7 +1698,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 10,
+    var key    = peg$currPos * 69 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1720,7 +1729,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 11,
+    var key    = peg$currPos * 69 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1745,7 +1754,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 67 + 12,
+    var key    = peg$currPos * 69 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1914,7 +1923,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 13,
+    var key    = peg$currPos * 69 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1978,7 +1987,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 14,
+    var key    = peg$currPos * 69 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2111,7 +2120,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 15,
+    var key    = peg$currPos * 69 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2397,7 +2406,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 16,
+    var key    = peg$currPos * 69 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2428,7 +2437,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 17,
+    var key    = peg$currPos * 69 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2459,7 +2468,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 18,
+    var key    = peg$currPos * 69 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2481,7 +2490,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 19,
+    var key    = peg$currPos * 69 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2731,7 +2740,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 20,
+    var key    = peg$currPos * 69 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2765,7 +2774,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 21,
+    var key    = peg$currPos * 69 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2822,7 +2831,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 22,
+    var key    = peg$currPos * 69 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3052,7 +3061,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 23,
+    var key    = peg$currPos * 69 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3133,7 +3142,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 24,
+    var key    = peg$currPos * 69 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3214,7 +3223,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 25,
+    var key    = peg$currPos * 69 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3295,7 +3304,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 26,
+    var key    = peg$currPos * 69 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3356,7 +3365,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 27,
+    var key    = peg$currPos * 69 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3402,7 +3411,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 28,
+    var key    = peg$currPos * 69 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3424,7 +3433,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 29,
+    var key    = peg$currPos * 69 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3449,7 +3458,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 30,
+    var key    = peg$currPos * 69 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3489,7 +3498,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 31,
+    var key    = peg$currPos * 69 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3535,7 +3544,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 32,
+    var key    = peg$currPos * 69 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3581,7 +3590,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 33,
+    var key    = peg$currPos * 69 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3627,7 +3636,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 34,
+    var key    = peg$currPos * 69 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3652,7 +3661,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 35,
+    var key    = peg$currPos * 69 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3695,7 +3704,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 36,
+    var key    = peg$currPos * 69 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3741,7 +3750,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 37,
+    var key    = peg$currPos * 69 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3787,7 +3796,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 38,
+    var key    = peg$currPos * 69 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3839,7 +3848,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 39,
+    var key    = peg$currPos * 69 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3903,7 +3912,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 40,
+    var key    = peg$currPos * 69 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3934,7 +3943,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 41,
+    var key    = peg$currPos * 69 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3983,7 +3992,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 42,
+    var key    = peg$currPos * 69 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4086,7 +4095,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 67 + 43,
+    var key    = peg$currPos * 69 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4108,7 +4117,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 44,
+    var key    = peg$currPos * 69 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4139,7 +4148,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 45,
+    var key    = peg$currPos * 69 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4170,7 +4179,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 67 + 46,
+    var key    = peg$currPos * 69 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4195,7 +4204,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 47,
+    var key    = peg$currPos * 69 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4314,7 +4323,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 48,
+    var key    = peg$currPos * 69 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4357,7 +4366,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 67 + 49,
+    var key    = peg$currPos * 69 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4444,7 +4453,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 50,
+    var key    = peg$currPos * 69 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4670,7 +4679,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 51,
+    var key    = peg$currPos * 69 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4792,7 +4801,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 52,
+    var key    = peg$currPos * 69 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4901,7 +4910,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 53,
+    var key    = peg$currPos * 69 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4950,7 +4959,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 54,
+    var key    = peg$currPos * 69 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4996,7 +5005,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 55,
+    var key    = peg$currPos * 69 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5063,7 +5072,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 56,
+    var key    = peg$currPos * 69 + 58,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5445,7 +5454,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 57,
+    var key    = peg$currPos * 69 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5533,7 +5542,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 58,
+    var key    = peg$currPos * 69 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5801,7 +5810,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 59,
+    var key    = peg$currPos * 69 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5850,7 +5859,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 60,
+    var key    = peg$currPos * 69 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5914,7 +5923,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 61,
+    var key    = peg$currPos * 69 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5960,7 +5969,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 62,
+    var key    = peg$currPos * 69 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5985,7 +5994,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 63,
+    var key    = peg$currPos * 69 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6025,7 +6034,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 64,
+    var key    = peg$currPos * 69 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6065,7 +6074,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 65,
+    var key    = peg$currPos * 69 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6096,7 +6105,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 66,
+    var key    = peg$currPos * 69 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-permissive.js
+++ b/peg_lib/jsdoctype-permissive.js
@@ -878,7 +878,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 0,
+    var key    = peg$currPos * 82 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -963,10 +963,67 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parse_() {
-    var s0, s1, s2, s3;
+  function peg$parseWS() {
+    var s0, s1, s2;
 
-    var key    = peg$currPos * 80 + 1,
+    var key    = peg$currPos * 82 + 1,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    if (peg$c1.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c2); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (peg$c3.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        if (peg$c5.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c6); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse_() {
+    var s0, s1;
+
+    var key    = peg$currPos * 82 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -976,86 +1033,38 @@ function peg$parse(input, options) {
     }
 
     s0 = [];
-    if (peg$c1.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c2); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = peg$currPos;
-      if (peg$c3.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c4); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        if (peg$c5.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c6); }
-        }
-        if (s3 !== peg$FAILED) {
-          s2 = [s2, s3];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    }
+    s1 = peg$parseWS();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c1.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+      s1 = peg$parseWS();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse__() {
+    var s0, s1;
+
+    var key    = peg$currPos * 82 + 3,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = [];
+    s1 = peg$parseWS();
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
+        s1 = peg$parseWS();
       }
-      if (s1 === peg$FAILED) {
-        s1 = peg$currPos;
-        if (peg$c3.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c4); }
-        }
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
-        if (s2 !== peg$FAILED) {
-          if (peg$c5.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c6); }
-          }
-          if (s3 !== peg$FAILED) {
-            s2 = [s2, s3];
-            s1 = s2;
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      }
+    } else {
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -1066,7 +1075,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 80 + 2,
+    var key    = peg$currPos * 82 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1128,7 +1137,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 80 + 3,
+    var key    = peg$currPos * 82 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1267,7 +1276,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 4,
+    var key    = peg$currPos * 82 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1335,7 +1344,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 5,
+    var key    = peg$currPos * 82 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1594,7 +1603,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 80 + 6,
+    var key    = peg$currPos * 82 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1619,7 +1628,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 7,
+    var key    = peg$currPos * 82 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1722,7 +1731,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 8,
+    var key    = peg$currPos * 82 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1753,7 +1762,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 9,
+    var key    = peg$currPos * 82 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1784,7 +1793,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 10,
+    var key    = peg$currPos * 82 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1815,7 +1824,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 11,
+    var key    = peg$currPos * 82 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1840,7 +1849,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 80 + 12,
+    var key    = peg$currPos * 82 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2009,7 +2018,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 13,
+    var key    = peg$currPos * 82 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2073,7 +2082,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 80 + 14,
+    var key    = peg$currPos * 82 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2206,7 +2215,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 15,
+    var key    = peg$currPos * 82 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2492,7 +2501,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 16,
+    var key    = peg$currPos * 82 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2523,7 +2532,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 17,
+    var key    = peg$currPos * 82 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2554,7 +2563,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 18,
+    var key    = peg$currPos * 82 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2576,7 +2585,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 19,
+    var key    = peg$currPos * 82 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2826,7 +2835,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 20,
+    var key    = peg$currPos * 82 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2860,7 +2869,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 21,
+    var key    = peg$currPos * 82 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2917,7 +2926,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 22,
+    var key    = peg$currPos * 82 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3147,7 +3156,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 23,
+    var key    = peg$currPos * 82 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3228,7 +3237,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 24,
+    var key    = peg$currPos * 82 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3309,7 +3318,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 25,
+    var key    = peg$currPos * 82 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3390,7 +3399,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 26,
+    var key    = peg$currPos * 82 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3451,7 +3460,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 27,
+    var key    = peg$currPos * 82 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3509,7 +3518,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 28,
+    var key    = peg$currPos * 82 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3570,7 +3579,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 29,
+    var key    = peg$currPos * 82 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3628,7 +3637,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 30,
+    var key    = peg$currPos * 82 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3650,7 +3659,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 31,
+    var key    = peg$currPos * 82 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3675,7 +3684,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 32,
+    var key    = peg$currPos * 82 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3721,7 +3730,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 33,
+    var key    = peg$currPos * 82 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3739,7 +3748,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseQualifiedMemberName();
         if (s3 !== peg$FAILED) {
@@ -3767,7 +3776,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 34,
+    var key    = peg$currPos * 82 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3785,7 +3794,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseKeyQueryExprOperand();
         if (s3 !== peg$FAILED) {
@@ -3813,7 +3822,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 35,
+    var key    = peg$currPos * 82 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3874,7 +3883,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 36,
+    var key    = peg$currPos * 82 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3956,7 +3965,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 37,
+    var key    = peg$currPos * 82 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4002,7 +4011,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 38,
+    var key    = peg$currPos * 82 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4048,7 +4057,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 39,
+    var key    = peg$currPos * 82 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4094,7 +4103,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 40,
+    var key    = peg$currPos * 82 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4119,7 +4128,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 41,
+    var key    = peg$currPos * 82 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4168,7 +4177,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 42,
+    var key    = peg$currPos * 82 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4214,7 +4223,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 43,
+    var key    = peg$currPos * 82 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4260,7 +4269,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 80 + 44,
+    var key    = peg$currPos * 82 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4312,7 +4321,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 45,
+    var key    = peg$currPos * 82 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4376,7 +4385,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 46,
+    var key    = peg$currPos * 82 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4407,7 +4416,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 47,
+    var key    = peg$currPos * 82 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4471,7 +4480,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 48,
+    var key    = peg$currPos * 82 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4574,7 +4583,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 80 + 49,
+    var key    = peg$currPos * 82 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4596,7 +4605,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 50,
+    var key    = peg$currPos * 82 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4627,7 +4636,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 51,
+    var key    = peg$currPos * 82 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4658,7 +4667,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 80 + 52,
+    var key    = peg$currPos * 82 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4683,7 +4692,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 53,
+    var key    = peg$currPos * 82 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4802,7 +4811,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 54,
+    var key    = peg$currPos * 82 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4857,7 +4866,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 55,
+    var key    = peg$currPos * 82 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4936,7 +4945,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 56,
+    var key    = peg$currPos * 82 + 58,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5036,7 +5045,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 80 + 57,
+    var key    = peg$currPos * 82 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5208,7 +5217,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 58,
+    var key    = peg$currPos * 82 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5290,7 +5299,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 80 + 59,
+    var key    = peg$currPos * 82 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5377,7 +5386,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 80 + 60,
+    var key    = peg$currPos * 82 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5603,7 +5612,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 61,
+    var key    = peg$currPos * 82 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5725,7 +5734,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 62,
+    var key    = peg$currPos * 82 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5834,7 +5843,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 63,
+    var key    = peg$currPos * 82 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5898,7 +5907,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 64,
+    var key    = peg$currPos * 82 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5956,7 +5965,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 65,
+    var key    = peg$currPos * 82 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6023,7 +6032,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 66,
+    var key    = peg$currPos * 82 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6405,7 +6414,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 80 + 67,
+    var key    = peg$currPos * 82 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6493,7 +6502,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 68,
+    var key    = peg$currPos * 82 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6761,7 +6770,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 69,
+    var key    = peg$currPos * 82 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6819,7 +6828,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 70,
+    var key    = peg$currPos * 82 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6883,7 +6892,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 80 + 71,
+    var key    = peg$currPos * 82 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6992,7 +7001,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 72,
+    var key    = peg$currPos * 82 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7056,7 +7065,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 80 + 73,
+    var key    = peg$currPos * 82 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7120,7 +7129,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 74,
+    var key    = peg$currPos * 82 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7181,7 +7190,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 80 + 75,
+    var key    = peg$currPos * 82 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7206,7 +7215,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 80 + 76,
+    var key    = peg$currPos * 82 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7246,7 +7255,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 80 + 77,
+    var key    = peg$currPos * 82 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7286,7 +7295,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 80 + 78,
+    var key    = peg$currPos * 82 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7317,7 +7326,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 80 + 79,
+    var key    = peg$currPos * 82 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-permissive.js
+++ b/peg_lib/jsdoctype-permissive.js
@@ -453,11 +453,11 @@ function peg$parse(input, options) {
       peg$c93 = "keyof",
       peg$c94 = peg$literalExpectation("keyof", false),
       peg$c95 = function(operator, operand) {
-        return {
-          type: NodeType.KEY_QUERY,
-          value: operand,
-        }
-      },
+          return {
+            type: NodeType.KEY_QUERY,
+            value: operand,
+          }
+        },
       peg$c96 = "import",
       peg$c97 = peg$literalExpectation("import", false),
       peg$c98 = "(",
@@ -3812,6 +3812,30 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c93) {
+        s1 = peg$c93;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseParenthesizedExpr();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c95(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };

--- a/peg_lib/jsdoctype-typescript.js
+++ b/peg_lib/jsdoctype-typescript.js
@@ -765,7 +765,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 0,
+    var key    = peg$currPos * 77 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -850,10 +850,67 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parse_() {
-    var s0, s1, s2, s3;
+  function peg$parseWS() {
+    var s0, s1, s2;
 
-    var key    = peg$currPos * 75 + 1,
+    var key    = peg$currPos * 77 + 1,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    if (peg$c1.test(input.charAt(peg$currPos))) {
+      s0 = input.charAt(peg$currPos);
+      peg$currPos++;
+    } else {
+      s0 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c2); }
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (peg$c3.test(input.charAt(peg$currPos))) {
+        s1 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c4); }
+      }
+      if (s1 === peg$FAILED) {
+        s1 = null;
+      }
+      if (s1 !== peg$FAILED) {
+        if (peg$c5.test(input.charAt(peg$currPos))) {
+          s2 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s2 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c6); }
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = [s1, s2];
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse_() {
+    var s0, s1;
+
+    var key    = peg$currPos * 77 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -863,86 +920,38 @@ function peg$parse(input, options) {
     }
 
     s0 = [];
-    if (peg$c1.test(input.charAt(peg$currPos))) {
-      s1 = input.charAt(peg$currPos);
-      peg$currPos++;
-    } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c2); }
-    }
-    if (s1 === peg$FAILED) {
-      s1 = peg$currPos;
-      if (peg$c3.test(input.charAt(peg$currPos))) {
-        s2 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c4); }
-      }
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
-      if (s2 !== peg$FAILED) {
-        if (peg$c5.test(input.charAt(peg$currPos))) {
-          s3 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c6); }
-        }
-        if (s3 !== peg$FAILED) {
-          s2 = [s2, s3];
-          s1 = s2;
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      } else {
-        peg$currPos = s1;
-        s1 = peg$FAILED;
-      }
-    }
+    s1 = peg$parseWS();
     while (s1 !== peg$FAILED) {
       s0.push(s1);
-      if (peg$c1.test(input.charAt(peg$currPos))) {
-        s1 = input.charAt(peg$currPos);
-        peg$currPos++;
-      } else {
-        s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c2); }
+      s1 = peg$parseWS();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parse__() {
+    var s0, s1;
+
+    var key    = peg$currPos * 77 + 3,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = [];
+    s1 = peg$parseWS();
+    if (s1 !== peg$FAILED) {
+      while (s1 !== peg$FAILED) {
+        s0.push(s1);
+        s1 = peg$parseWS();
       }
-      if (s1 === peg$FAILED) {
-        s1 = peg$currPos;
-        if (peg$c3.test(input.charAt(peg$currPos))) {
-          s2 = input.charAt(peg$currPos);
-          peg$currPos++;
-        } else {
-          s2 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c4); }
-        }
-        if (s2 === peg$FAILED) {
-          s2 = null;
-        }
-        if (s2 !== peg$FAILED) {
-          if (peg$c5.test(input.charAt(peg$currPos))) {
-            s3 = input.charAt(peg$currPos);
-            peg$currPos++;
-          } else {
-            s3 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c6); }
-          }
-          if (s3 !== peg$FAILED) {
-            s2 = [s2, s3];
-            s1 = s2;
-          } else {
-            peg$currPos = s1;
-            s1 = peg$FAILED;
-          }
-        } else {
-          peg$currPos = s1;
-          s1 = peg$FAILED;
-        }
-      }
+    } else {
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -953,7 +962,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 75 + 2,
+    var key    = peg$currPos * 77 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1015,7 +1024,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 75 + 3,
+    var key    = peg$currPos * 77 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1154,7 +1163,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 4,
+    var key    = peg$currPos * 77 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1222,7 +1231,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 5,
+    var key    = peg$currPos * 77 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1481,7 +1490,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 75 + 6,
+    var key    = peg$currPos * 77 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1506,7 +1515,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 7,
+    var key    = peg$currPos * 77 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1609,7 +1618,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 8,
+    var key    = peg$currPos * 77 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1640,7 +1649,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 9,
+    var key    = peg$currPos * 77 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1671,7 +1680,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 10,
+    var key    = peg$currPos * 77 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1702,7 +1711,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 11,
+    var key    = peg$currPos * 77 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1733,7 +1742,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 12,
+    var key    = peg$currPos * 77 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1764,7 +1773,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 75 + 13,
+    var key    = peg$currPos * 77 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1786,7 +1795,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 14,
+    var key    = peg$currPos * 77 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2036,7 +2045,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 15,
+    var key    = peg$currPos * 77 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2070,7 +2079,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 16,
+    var key    = peg$currPos * 77 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2127,7 +2136,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 17,
+    var key    = peg$currPos * 77 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2357,7 +2366,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 18,
+    var key    = peg$currPos * 77 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2438,7 +2447,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 19,
+    var key    = peg$currPos * 77 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2519,7 +2528,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 20,
+    var key    = peg$currPos * 77 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2600,7 +2609,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 21,
+    var key    = peg$currPos * 77 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2661,7 +2670,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 22,
+    var key    = peg$currPos * 77 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2719,7 +2728,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 23,
+    var key    = peg$currPos * 77 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2780,7 +2789,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 24,
+    var key    = peg$currPos * 77 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2838,7 +2847,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 75 + 25,
+    var key    = peg$currPos * 77 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2860,7 +2869,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 75 + 26,
+    var key    = peg$currPos * 77 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2885,7 +2894,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 27,
+    var key    = peg$currPos * 77 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2931,7 +2940,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 28,
+    var key    = peg$currPos * 77 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2949,7 +2958,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c77); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseQualifiedMemberName();
         if (s3 !== peg$FAILED) {
@@ -2977,7 +2986,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 29,
+    var key    = peg$currPos * 77 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2995,7 +3004,7 @@ function peg$parse(input, options) {
       if (peg$silentFails === 0) { peg$fail(peg$c80); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse_();
+      s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
         s3 = peg$parseKeyQueryExprOperand();
         if (s3 !== peg$FAILED) {
@@ -3023,7 +3032,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 30,
+    var key    = peg$currPos * 77 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3084,7 +3093,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 31,
+    var key    = peg$currPos * 77 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3166,7 +3175,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 32,
+    var key    = peg$currPos * 77 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3212,7 +3221,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 33,
+    var key    = peg$currPos * 77 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3258,7 +3267,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 34,
+    var key    = peg$currPos * 77 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3304,7 +3313,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 75 + 35,
+    var key    = peg$currPos * 77 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3329,7 +3338,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 36,
+    var key    = peg$currPos * 77 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3378,7 +3387,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 37,
+    var key    = peg$currPos * 77 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3424,7 +3433,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 38,
+    var key    = peg$currPos * 77 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3470,7 +3479,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 75 + 39,
+    var key    = peg$currPos * 77 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3522,7 +3531,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 40,
+    var key    = peg$currPos * 77 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3586,7 +3595,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 41,
+    var key    = peg$currPos * 77 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3617,7 +3626,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 42,
+    var key    = peg$currPos * 77 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3681,7 +3690,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 43,
+    var key    = peg$currPos * 77 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3784,7 +3793,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 75 + 44,
+    var key    = peg$currPos * 77 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3806,7 +3815,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 45,
+    var key    = peg$currPos * 77 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3837,7 +3846,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 46,
+    var key    = peg$currPos * 77 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3868,7 +3877,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 75 + 47,
+    var key    = peg$currPos * 77 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3893,7 +3902,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 48,
+    var key    = peg$currPos * 77 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4012,7 +4021,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 49,
+    var key    = peg$currPos * 77 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4067,7 +4076,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 50,
+    var key    = peg$currPos * 77 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4146,7 +4155,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 51,
+    var key    = peg$currPos * 77 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4246,7 +4255,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 75 + 52,
+    var key    = peg$currPos * 77 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4418,7 +4427,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 53,
+    var key    = peg$currPos * 77 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4500,7 +4509,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 75 + 54,
+    var key    = peg$currPos * 77 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4587,7 +4596,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 75 + 55,
+    var key    = peg$currPos * 77 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4813,7 +4822,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 56,
+    var key    = peg$currPos * 77 + 58,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4935,7 +4944,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 57,
+    var key    = peg$currPos * 77 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5044,7 +5053,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 58,
+    var key    = peg$currPos * 77 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5108,7 +5117,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 59,
+    var key    = peg$currPos * 77 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5166,7 +5175,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 60,
+    var key    = peg$currPos * 77 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5233,7 +5242,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 61,
+    var key    = peg$currPos * 77 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5615,7 +5624,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 75 + 62,
+    var key    = peg$currPos * 77 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5703,7 +5712,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 63,
+    var key    = peg$currPos * 77 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5971,7 +5980,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 64,
+    var key    = peg$currPos * 77 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6029,7 +6038,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 65,
+    var key    = peg$currPos * 77 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6093,7 +6102,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 75 + 66,
+    var key    = peg$currPos * 77 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6202,7 +6211,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 67,
+    var key    = peg$currPos * 77 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6266,7 +6275,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 75 + 68,
+    var key    = peg$currPos * 77 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6330,7 +6339,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 69,
+    var key    = peg$currPos * 77 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6391,7 +6400,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 75 + 70,
+    var key    = peg$currPos * 77 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6416,7 +6425,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 75 + 71,
+    var key    = peg$currPos * 77 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6456,7 +6465,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 75 + 72,
+    var key    = peg$currPos * 77 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6496,7 +6505,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 75 + 73,
+    var key    = peg$currPos * 77 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6527,7 +6536,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 75 + 74,
+    var key    = peg$currPos * 77 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-typescript.js
+++ b/peg_lib/jsdoctype-typescript.js
@@ -338,11 +338,11 @@ function peg$parse(input, options) {
       peg$c79 = "keyof",
       peg$c80 = peg$literalExpectation("keyof", false),
       peg$c81 = function(operator, operand) {
-        return {
-          type: NodeType.KEY_QUERY,
-          value: operand,
-        }
-      },
+          return {
+            type: NodeType.KEY_QUERY,
+            value: operand,
+          }
+        },
       peg$c82 = "import",
       peg$c83 = peg$literalExpectation("import", false),
       peg$c84 = "(",
@@ -3022,6 +3022,30 @@ function peg$parse(input, options) {
     } else {
       peg$currPos = s0;
       s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c79) {
+        s1 = peg$c79;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseParenthesizedExpr();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c81(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -40,8 +40,11 @@ TopTypeExpr = _ expr:( VariadicTypeExpr
 /*
  * White spaces.
  */
-_  = ([ \t] / [\r]? [\n])*
+WS  = [ \t] / [\r]? [\n]
 
+_  = WS*
+
+__ = WS+
 
 /*
  * JavaScript identifier names.
@@ -529,7 +532,7 @@ PrefixUnaryUnionTypeExprOperand = GenericTypeExpr
 // from jsdoc mode for now.
 
 // no-jsdoc-begin
-TypeQueryExpr = operator:"typeof" _ name:QualifiedMemberName {
+TypeQueryExpr = operator:"typeof" __ name:QualifiedMemberName {
                 return {
                     type: NodeType.TYPE_QUERY,
                     name,
@@ -538,7 +541,7 @@ TypeQueryExpr = operator:"typeof" _ name:QualifiedMemberName {
 // no-jsdoc-end
 
 // no-jsdoc-begin, no-closure-begin
-KeyQueryExpr = operator:"keyof" _ operand:KeyQueryExprOperand {
+KeyQueryExpr = operator:"keyof" __ operand:KeyQueryExprOperand {
   return {
     type: NodeType.KEY_QUERY,
     value: operand,

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -542,11 +542,17 @@ TypeQueryExpr = operator:"typeof" __ name:QualifiedMemberName {
 
 // no-jsdoc-begin, no-closure-begin
 KeyQueryExpr = operator:"keyof" __ operand:KeyQueryExprOperand {
-  return {
-    type: NodeType.KEY_QUERY,
-    value: operand,
+    return {
+      type: NodeType.KEY_QUERY,
+      value: operand,
+    }
   }
-}
+  / operator:"keyof" operand:ParenthesizedExpr {
+    return {
+      type: NodeType.KEY_QUERY,
+      value: operand,
+    }
+  }
 
 KeyQueryExprOperand = UnionTypeExpr
                     / IntersectionTypeExpr // no-jsdoc, no-closure

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -1916,6 +1916,18 @@ describe('Parser', function() {
     expect(node).to.deep.equal(expectedNode);
   });
 
+  it('should return a key query type node when "keyof(foo)" arrived', function() {
+    const typeExprStr = 'keyof(foo)';
+    const node = parse(typeExprStr);
+
+    const expectedNode = createKeyQueryNode(
+      createParenthesizedNode(
+        createTypeNameNode('foo')
+      )
+    );
+    expect(node).to.deep.equal(expectedNode);
+  });
+
   it('should return a key query type node when "keyof typeof foo" arrived', function() {
     const typeExprStr = 'keyof typeof foo';
     const node = parse(typeExprStr);

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -516,6 +516,11 @@ describe('publish', function() {
       expect(publish(node)).to.equal('keyof x');
     })
 
+    it('should return a parenthesized key query node (with no whitespace)', function() {
+      const node = parse('keyof(x)');
+      expect(publish(node)).to.equal('keyof(x)');
+    })
+
     it('should return an import type node', function() {
       const node = parse('import("./lodash4ever")');
       expect(publish(node)).to.equal('import("./lodash4ever")');

--- a/tests/test_traversing.js
+++ b/tests/test_traversing.js
@@ -534,6 +534,22 @@ describe('traversing', function() {
         ],
       },
 
+      'should visit a parenthesized key query node': {
+        given: createKeyQueryNode(
+          createParenthesizedNode(
+            createNameNode('t')
+          )
+        ),
+        then: [
+          ['enter', NodeType.KEY_QUERY, null, null],
+          ['enter', NodeType.PARENTHESIS, 'value', NodeType.KEY_QUERY],
+          ['enter', NodeType.NAME, 'value', NodeType.PARENTHESIS],
+          ['leave', NodeType.NAME, 'value', NodeType.PARENTHESIS],
+          ['leave', NodeType.PARENTHESIS, 'value', NodeType.KEY_QUERY],
+          ['leave', NodeType.KEY_QUERY, null, null],
+        ],
+      },
+
       'should visit an import type node': {
         given: createImportNode(createStringLiteral('jquery')),
         then: [
@@ -610,6 +626,13 @@ function createKeyQueryNode(value) {
     type: NodeType.KEY_QUERY,
     value: value,
   }
+}
+
+function createParenthesizedNode(value) {
+  return {
+    type: NodeType.PARENTHESIS,
+    value: value,
+  };
 }
 
 function createImportNode(path) {


### PR DESCRIPTION
fix: insist on whitespace after keywords "typeof" and "keyof"
