### PR TITLE
Export mode-specific SyntaxError's

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 
 /** @typedef {import('./lib/parsing').AstNode} AstNode */
 
-const {parse, JSDocTypeSyntaxError} = require('./lib/parsing.js');
+const {
+  parse,
+  JSDocTypeSyntaxError,
+  JSDocSyntaxError,
+  ClosureSyntaxError,
+  TypeScriptSyntaxError,
+} = require('./lib/parsing.js');
 const {publish, createDefaultPublisher} = require('./lib/publishing.js');
 const {traverse} = require('./lib/traversing.js');
 const NodeType = require('./lib/NodeType.js');
@@ -16,6 +22,9 @@ const SyntaxType = require('./lib/SyntaxType.js');
 module.exports = {
   parse,
   JSDocTypeSyntaxError,
+  JSDocSyntaxError,
+  ClosureSyntaxError,
+  TypeScriptSyntaxError,
   publish,
   createDefaultPublisher,
   traverse,


### PR DESCRIPTION
Realized our demo will need these...

(This is probably more of a bug for missing these in the exports than a feature, but it wasn't exactly broken either.)