### PR TITLE
Add initial support for optional parameters in arrow functions

### DIFF
--- a/lib/publishing.js
+++ b/lib/publishing.js
@@ -146,7 +146,9 @@ function createDefaultPublisher() {
       return (functionNode.new ? 'new ' : '') + format('(%s) => %s', publishedParams.join(', '), concretePublish(functionNode.returns));
     },
     NAMED_PARAMETER (parameterNode, concretePublish) {
-      return parameterNode.name + ': ' + concretePublish(parameterNode.typeName);
+      var nameSuffix = parameterNode.meta && parameterNode.meta.syntax === OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK
+      ? '?' : '';
+      return format('%s%s: %s', parameterNode.name, nameSuffix, concretePublish(parameterNode.typeName));
     },
     ANY () {
       return '*';

--- a/peg_lib/jsdoctype-closure.js
+++ b/peg_lib/jsdoctype-closure.js
@@ -424,63 +424,89 @@ function peg$parse(input, options) {
       peg$c81 = peg$literalExpectation("0x", false),
       peg$c82 = /^[0-9a-fA-F]/,
       peg$c83 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c84 = "|",
-      peg$c85 = peg$literalExpectation("|", false),
+      peg$c84 = "&",
+      peg$c85 = peg$literalExpectation("&", false),
       peg$c86 = function(left, right) {
+                      return {
+                          type: NodeType.INTERSECTION,
+                          left,
+                          right,
+                      };
+                    },
+      peg$c87 = "|",
+      peg$c88 = peg$literalExpectation("|", false),
+      peg$c89 = function(left, right) {
                       return {
                           type: NodeType.UNION,
                           left,
                           right,
                       };
                     },
-      peg$c87 = "typeof",
-      peg$c88 = peg$literalExpectation("typeof", false),
-      peg$c89 = function(operator, name) {
+      peg$c90 = "typeof",
+      peg$c91 = peg$literalExpectation("typeof", false),
+      peg$c92 = function(operator, name) {
                       return {
                           type: NodeType.TYPE_QUERY,
                           name,
                       };
                     },
-      peg$c90 = function(operator, operand) {
+      peg$c93 = "keyof",
+      peg$c94 = peg$literalExpectation("keyof", false),
+      peg$c95 = function(operator, operand) {
+          return {
+            type: NodeType.KEY_QUERY,
+            value: operand,
+          }
+        },
+      peg$c96 = "import",
+      peg$c97 = peg$literalExpectation("import", false),
+      peg$c98 = "(",
+      peg$c99 = peg$literalExpectation("(", false),
+      peg$c100 = ")",
+      peg$c101 = peg$literalExpectation(")", false),
+      peg$c102 = function(operator, path) {
+                       return { type: NodeType.IMPORT, path };
+                     },
+      peg$c103 = function(operator, operand) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.PREFIX_QUESTION_MARK },
                                };
                              },
-      peg$c91 = "!",
-      peg$c92 = peg$literalExpectation("!", false),
-      peg$c93 = function(operator, operand) {
+      peg$c104 = "!",
+      peg$c105 = peg$literalExpectation("!", false),
+      peg$c106 = function(operator, operand) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.PREFIX_BANG },
                                   };
                                 },
-      peg$c94 = function(operand, operator) {
+      peg$c107 = function(operand, operator) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.SUFFIX_QUESTION_MARK },
                                };
                              },
-      peg$c95 = function(operand, operator) {
+      peg$c108 = function(operand, operator) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.SUFFIX_BANG },
                                   };
                                 },
-      peg$c96 = "=",
-      peg$c97 = peg$literalExpectation("=", false),
-      peg$c98 = function(operand, operator) {
+      peg$c109 = "=",
+      peg$c110 = peg$literalExpectation("=", false),
+      peg$c111 = function(operand, operator) {
                                return {
                                  type: NodeType.OPTIONAL,
                                  value: operand,
                                  meta: { syntax: OptionalTypeSyntax.SUFFIX_EQUALS_SIGN },
                                };
                              },
-      peg$c99 = function(operand, syntax, params) {
+      peg$c112 = function(operand, syntax, params) {
                         return {
                           type: NodeType.GENERIC,
                           subject: operand,
@@ -488,28 +514,92 @@ function peg$parse(input, options) {
                           meta: { syntax },
                         };
                       },
-      peg$c100 = ",",
-      peg$c101 = peg$literalExpectation(",", false),
-      peg$c102 = function(first, restsWithComma) {
+      peg$c113 = ",",
+      peg$c114 = peg$literalExpectation(",", false),
+      peg$c115 = function(first, restsWithComma) {
                                      return restsWithComma.reduce(function(params, tokens) {
                                        return params.concat([tokens[3]]);
                                      }, [first]);
                                    },
-      peg$c103 = ".<",
-      peg$c104 = peg$literalExpectation(".<", false),
-      peg$c105 = function() {
+      peg$c116 = ".<",
+      peg$c117 = peg$literalExpectation(".<", false),
+      peg$c118 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT;
                                               },
-      peg$c106 = "<",
-      peg$c107 = peg$literalExpectation("<", false),
-      peg$c108 = function() {
+      peg$c119 = "<",
+      peg$c120 = peg$literalExpectation("<", false),
+      peg$c121 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET;
                                               },
-      peg$c109 = ">",
-      peg$c110 = peg$literalExpectation(">", false),
-      peg$c111 = "function",
-      peg$c112 = peg$literalExpectation("function", false),
-      peg$c113 = function(paramsPart, returnedTypePart) {
+      peg$c122 = ">",
+      peg$c123 = peg$literalExpectation(">", false),
+      peg$c124 = "[",
+      peg$c125 = peg$literalExpectation("[", false),
+      peg$c126 = "]",
+      peg$c127 = peg$literalExpectation("]", false),
+      peg$c128 = function(operand, brackets) {
+                      return brackets.reduce(function(operand) {
+                        return {
+                          type: NodeType.GENERIC,
+                          subject: {
+                            type: NodeType.NAME,
+                            name: 'Array'
+                          },
+                          objects: [ operand ],
+                          meta: { syntax: GenericTypeSyntax.SQUARE_BRACKET },
+                        };
+                      }, operand);
+                    },
+      peg$c129 = "new",
+      peg$c130 = peg$literalExpectation("new", false),
+      peg$c131 = "=>",
+      peg$c132 = peg$literalExpectation("=>", false),
+      peg$c133 = function(newModifier, paramsPart, returnedTypeNode) {
+                         return {
+                           type: NodeType.ARROW,
+                           params: paramsPart,
+                           returns: returnedTypeNode,
+                           new: newModifier
+                         };
+      },
+      peg$c134 = function() {
+                            return [];
+                          },
+      peg$c135 = function(params) {
+                            return params;
+                          },
+      peg$c136 = function(id) { return { name: id, optional: true } },
+      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c138 = function(paramsWithComma, lastParam) {
+        return paramsWithComma.reduceRight(function(params, tokens) {
+          const param = { 
+              type: tokens[0].optional 
+                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
+                  : NodeType.NAMED_PARAMETER, 
+              name: tokens[0].name, 
+              typeName: tokens[4] 
+          };
+          return [param].concat(params);
+        }, lastParam ? [lastParam] : []);
+      },
+      peg$c139 = "...",
+      peg$c140 = peg$literalExpectation("...", false),
+      peg$c141 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        if (spread) {
+        return {
+          type: NodeType.VARIADIC,
+          value: operand,
+          meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
+        };
+        }
+        else {
+          return operand;
+        }
+      },
+      peg$c142 = "function",
+      peg$c143 = peg$literalExpectation("function", false),
+      peg$c144 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -520,59 +610,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c114 = "(",
-      peg$c115 = peg$literalExpectation("(", false),
-      peg$c116 = ")",
-      peg$c117 = peg$literalExpectation(")", false),
-      peg$c118 = function(modifier, params) {
+      peg$c145 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c119 = function(modifier) {
+      peg$c146 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c120 = function() {
+      peg$c147 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c121 = function(params) {
+      peg$c148 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c122 = "this",
-      peg$c123 = peg$literalExpectation("this", false),
-      peg$c124 = function(modifierThis) {
+      peg$c149 = "this",
+      peg$c150 = peg$literalExpectation("this", false),
+      peg$c151 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c125 = "new",
-      peg$c126 = peg$literalExpectation("new", false),
-      peg$c127 = function(modifierNew) {
+      peg$c152 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c128 = function(paramsWithComma, lastParam) {
+      peg$c153 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c129 = "{",
-      peg$c130 = peg$literalExpectation("{", false),
-      peg$c131 = "}",
-      peg$c132 = peg$literalExpectation("}", false),
-      peg$c133 = function(entries) {
+      peg$c154 = "{",
+      peg$c155 = peg$literalExpectation("{", false),
+      peg$c156 = "}",
+      peg$c157 = peg$literalExpectation("}", false),
+      peg$c158 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c134 = ";",
-      peg$c135 = peg$literalExpectation(";", false),
-      peg$c136 = function(first, restWithComma) {
+      peg$c159 = ";",
+      peg$c160 = peg$literalExpectation(";", false),
+      peg$c161 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c137 = "readonly",
-      peg$c138 = peg$literalExpectation("readonly", false),
-      peg$c139 = function(readonly, keyInfo, optional, value) {
+      peg$c162 = "readonly",
+      peg$c163 = peg$literalExpectation("readonly", false),
+      peg$c164 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -588,7 +672,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c140 = function(readonly, keyInfo) {
+      peg$c165 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -598,49 +682,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c141 = function(key) {
+      peg$c166 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c142 = function(key) {
+      peg$c167 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c143 = function(key) {
+      peg$c168 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c144 = function(wrapped) {
+      peg$c169 = function(entries) {
+        return {
+          type: NodeType.TUPLE,
+          entries,
+        }
+      },
+      peg$c170 = function(restWithComma, last) {
+        return restWithComma.reduceRight((entries, tokens) => {
+          let [entry] = tokens;
+          return [entry].concat(entries);
+        }, last ? [last] : []);
+      },
+      peg$c171 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c145 = "...",
-      peg$c146 = peg$literalExpectation("...", false),
-      peg$c147 = function(operand) {
+      peg$c172 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c148 = function(operand) {
+      peg$c173 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c149 = function() {
+      peg$c174 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -789,7 +883,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 0,
+    var key    = peg$currPos * 82 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -805,25 +899,40 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = peg$parseUnionTypeExpr();
         if (s2 === peg$FAILED) {
-          s2 = peg$parseUnaryUnionTypeExpr();
+          s2 = peg$parseIntersectionTypeExpr();
           if (s2 === peg$FAILED) {
-            s2 = peg$parseGenericTypeExpr();
+            s2 = peg$parseUnaryUnionTypeExpr();
             if (s2 === peg$FAILED) {
-              s2 = peg$parseRecordTypeExpr();
+              s2 = peg$parseArrayTypeExpr();
               if (s2 === peg$FAILED) {
-                s2 = peg$parseFunctionTypeExpr();
+                s2 = peg$parseGenericTypeExpr();
                 if (s2 === peg$FAILED) {
-                  s2 = peg$parseTypeQueryExpr();
+                  s2 = peg$parseRecordTypeExpr();
                   if (s2 === peg$FAILED) {
-                    s2 = peg$parseBroadNamepathExpr();
+                    s2 = peg$parseTupleTypeExpr();
                     if (s2 === peg$FAILED) {
-                      s2 = peg$parseParenthesizedExpr();
+                      s2 = peg$parseArrowTypeExpr();
                       if (s2 === peg$FAILED) {
-                        s2 = peg$parseValueExpr();
+                        s2 = peg$parseFunctionTypeExpr();
                         if (s2 === peg$FAILED) {
-                          s2 = peg$parseAnyTypeExpr();
+                          s2 = peg$parseTypeQueryExpr();
                           if (s2 === peg$FAILED) {
-                            s2 = peg$parseUnknownTypeExpr();
+                            s2 = peg$parseKeyQueryExpr();
+                            if (s2 === peg$FAILED) {
+                              s2 = peg$parseBroadNamepathExpr();
+                              if (s2 === peg$FAILED) {
+                                s2 = peg$parseParenthesizedExpr();
+                                if (s2 === peg$FAILED) {
+                                  s2 = peg$parseValueExpr();
+                                  if (s2 === peg$FAILED) {
+                                    s2 = peg$parseAnyTypeExpr();
+                                    if (s2 === peg$FAILED) {
+                                      s2 = peg$parseUnknownTypeExpr();
+                                    }
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
                       }
@@ -862,7 +971,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 1,
+    var key    = peg$currPos * 82 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -919,7 +1028,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 2,
+    var key    = peg$currPos * 82 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -943,7 +1052,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 3,
+    var key    = peg$currPos * 82 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -971,7 +1080,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 67 + 4,
+    var key    = peg$currPos * 82 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1033,7 +1142,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 5,
+    var key    = peg$currPos * 82 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1045,7 +1154,10 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseParenthesizedExpr();
     if (s1 === peg$FAILED) {
-      s1 = peg$parseTypeNameExprJsDocFlavored();
+      s1 = peg$parseImportTypeExpr();
+      if (s1 === peg$FAILED) {
+        s1 = peg$parseTypeNameExprJsDocFlavored();
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1169,7 +1281,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 6,
+    var key    = peg$currPos * 82 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1237,7 +1349,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 7,
+    var key    = peg$currPos * 82 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1496,7 +1608,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 67 + 8,
+    var key    = peg$currPos * 82 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1521,7 +1633,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 9,
+    var key    = peg$currPos * 82 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1624,7 +1736,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 10,
+    var key    = peg$currPos * 82 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1655,7 +1767,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 11,
+    var key    = peg$currPos * 82 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1686,7 +1798,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 12,
+    var key    = peg$currPos * 82 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1717,7 +1829,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 13,
+    var key    = peg$currPos * 82 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1742,7 +1854,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 67 + 14,
+    var key    = peg$currPos * 82 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1911,7 +2023,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 15,
+    var key    = peg$currPos * 82 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1975,7 +2087,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 16,
+    var key    = peg$currPos * 82 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2108,7 +2220,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 17,
+    var key    = peg$currPos * 82 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2394,7 +2506,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 18,
+    var key    = peg$currPos * 82 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2425,7 +2537,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 19,
+    var key    = peg$currPos * 82 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2456,7 +2568,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 20,
+    var key    = peg$currPos * 82 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2478,7 +2590,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 21,
+    var key    = peg$currPos * 82 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2728,7 +2840,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 22,
+    var key    = peg$currPos * 82 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2762,7 +2874,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 23,
+    var key    = peg$currPos * 82 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2819,7 +2931,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 24,
+    var key    = peg$currPos * 82 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3049,7 +3161,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 25,
+    var key    = peg$currPos * 82 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3130,7 +3242,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 26,
+    var key    = peg$currPos * 82 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3211,7 +3323,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 27,
+    var key    = peg$currPos * 82 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3289,10 +3401,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnionTypeExpr() {
+  function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 28,
+    var key    = peg$currPos * 82 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3302,11 +3414,11 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    s1 = peg$parseUnionTypeExprOperand();
+    s1 = peg$parseIntersectionTypeExprOperand();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 124) {
+        if (input.charCodeAt(peg$currPos) === 38) {
           s3 = peg$c84;
           peg$currPos++;
         } else {
@@ -3316,9 +3428,9 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseUnionTypeExpr();
+            s5 = peg$parseIntersectionTypeExpr();
             if (s5 === peg$FAILED) {
-              s5 = peg$parseUnionTypeExprOperand();
+              s5 = peg$parseIntersectionTypeExprOperand();
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -3350,10 +3462,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnionTypeExprOperand() {
+  function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 29,
+    var key    = peg$currPos * 82 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3366,13 +3478,234 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseRecordTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseTupleTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseArrowTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseTypeQueryExpr();
+            s0 = peg$parseFunctionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseParenthesizedExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseTypeQueryExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseKeyQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseGenericTypeExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 30,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseUnionTypeExprOperand();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 124) {
+          s3 = peg$c87;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseUnionTypeExpr();
+            if (s5 === peg$FAILED) {
+              s5 = peg$parseUnionTypeExprOperand();
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c89(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnionTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 31,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseUnaryUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRecordTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseTupleTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseArrowTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseFunctionTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseParenthesizedExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseTypeQueryExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseKeyQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseGenericTypeExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnaryUnionTypeExpr() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 32,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSuffixUnaryUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePrefixUnaryUnionTypeExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parsePrefixUnaryUnionTypeExpr() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 33,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parsePrefixNotNullableTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePrefixNullableTypeExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parsePrefixUnaryUnionTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 34,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseGenericTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRecordTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseTupleTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseArrowTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseFunctionTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
                 s0 = peg$parseBroadNamepathExpr();
                 if (s0 === peg$FAILED) {
@@ -3396,10 +3729,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnaryUnionTypeExpr() {
-    var s0;
+  function peg$parseTypeQueryExpr() {
+    var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 30,
+    var key    = peg$currPos * 82 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3408,9 +3741,33 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parseSuffixUnaryUnionTypeExpr();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parsePrefixUnaryUnionTypeExpr();
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c90) {
+      s1 = peg$c90;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseQualifiedMemberName();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c92(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3418,10 +3775,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePrefixUnaryUnionTypeExpr() {
-    var s0;
+  function peg$parseKeyQueryExpr() {
+    var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 31,
+    var key    = peg$currPos * 82 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3430,9 +3787,57 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parsePrefixNotNullableTypeExpr();
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5) === peg$c93) {
+      s1 = peg$c93;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseKeyQueryExprOperand();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c95(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
     if (s0 === peg$FAILED) {
-      s0 = peg$parsePrefixNullableTypeExpr();
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c93) {
+        s1 = peg$c93;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseParenthesizedExpr();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c95(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3440,10 +3845,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePrefixUnaryUnionTypeExprOperand() {
+  function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 32,
+    var key    = peg$currPos * 82 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3452,21 +3857,42 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parseGenericTypeExpr();
+    s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseRecordTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseBroadNamepathExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseValueExpr();
+              s0 = peg$parseFunctionTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseAnyTypeExpr();
+                s0 = peg$parseParenthesizedExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseUnknownTypeExpr();
+                  s0 = peg$parseTypeQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseKeyQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseGenericTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseBroadNamepathExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseValueExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseAnyTypeExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseUnknownTypeExpr();
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -3480,10 +3906,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseTypeQueryExpr() {
-    var s0, s1, s2, s3;
+  function peg$parseImportTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 33,
+    var key    = peg$currPos * 82 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3493,21 +3919,57 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c87) {
-      s1 = peg$c87;
+    if (input.substr(peg$currPos, 6) === peg$c96) {
+      s1 = peg$c96;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c88); }
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parse__();
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseQualifiedMemberName();
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c98;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
         if (s3 !== peg$FAILED) {
-          peg$savedPos = s0;
-          s1 = peg$c89(s1, s3);
-          s0 = s1;
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseStringLiteralExpr();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c100;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c102(s1, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
         } else {
           peg$currPos = s0;
           s0 = peg$FAILED;
@@ -3529,7 +3991,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 34,
+    var key    = peg$currPos * 82 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3552,7 +4014,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s1, s3);
+          s1 = peg$c103(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3575,7 +4037,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 35,
+    var key    = peg$currPos * 82 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3586,11 +4048,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c91;
+      s1 = peg$c104;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c92); }
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3598,7 +4060,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c93(s1, s3);
+          s1 = peg$c106(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3621,7 +4083,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 36,
+    var key    = peg$currPos * 82 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3646,7 +4108,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 37,
+    var key    = peg$currPos * 82 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3661,17 +4123,23 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$parseRecordTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseTupleTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseArrowTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseBroadNamepathExpr();
+              s0 = peg$parseFunctionTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseValueExpr();
+                s0 = peg$parseParenthesizedExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseAnyTypeExpr();
+                  s0 = peg$parseBroadNamepathExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseUnknownTypeExpr();
+                    s0 = peg$parseValueExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseAnyTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseUnknownTypeExpr();
+                      }
+                    }
                   }
                 }
               }
@@ -3689,7 +4157,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 38,
+    var key    = peg$currPos * 82 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3712,7 +4180,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c94(s1, s3);
+          s1 = peg$c107(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3735,7 +4203,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 39,
+    var key    = peg$currPos * 82 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3750,15 +4218,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s3 = peg$c91;
+          s3 = peg$c104;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c92); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c95(s1, s3);
+          s1 = peg$c108(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3781,7 +4249,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 67 + 40,
+    var key    = peg$currPos * 82 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3802,15 +4270,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c96;
+          s3 = peg$c109;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c97); }
+          if (peg$silentFails === 0) { peg$fail(peg$c110); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c98(s1, s3);
+          s1 = peg$c111(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3833,7 +4301,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 41,
+    var key    = peg$currPos * 82 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3858,7 +4326,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseGenericTypeEndToken();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c99(s1, s3, s5);
+                  s1 = peg$c112(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3897,7 +4365,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 42,
+    var key    = peg$currPos * 82 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3928,7 +4396,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 43,
+    var key    = peg$currPos * 82 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3939,25 +4407,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseTypeQueryExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseArrayTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseTypeQueryExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseKeyQueryExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -3977,7 +4460,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 44,
+    var key    = peg$currPos * 82 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3994,11 +4477,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c100;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -4029,11 +4512,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c100;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -4061,7 +4544,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c102(s1, s2);
+        s1 = peg$c115(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4080,7 +4563,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 67 + 45,
+    var key    = peg$currPos * 82 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4102,7 +4585,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 46,
+    var key    = peg$currPos * 82 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4112,16 +4595,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c103) {
-      s1 = peg$c103;
+    if (input.substr(peg$currPos, 2) === peg$c116) {
+      s1 = peg$c116;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c117); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c105();
+      s1 = peg$c118();
     }
     s0 = s1;
 
@@ -4133,7 +4616,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 47,
+    var key    = peg$currPos * 82 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4144,15 +4627,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c106;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c108();
+      s1 = peg$c121();
     }
     s0 = s1;
 
@@ -4164,7 +4647,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 67 + 48,
+    var key    = peg$currPos * 82 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4174,11 +4657,673 @@ function peg$parse(input, options) {
     }
 
     if (input.charCodeAt(peg$currPos) === 62) {
-      s0 = peg$c109;
+      s0 = peg$c122;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c110); }
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrayTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 82 + 54,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseArrayTypeExprOperand();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 91) {
+          s5 = peg$c124;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c125); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s7 = peg$c126;
+              peg$currPos++;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            }
+            if (s7 !== peg$FAILED) {
+              s4 = [s4, s5, s6, s7];
+              s3 = s4;
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      if (s3 !== peg$FAILED) {
+        while (s3 !== peg$FAILED) {
+          s2.push(s3);
+          s3 = peg$currPos;
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 91) {
+              s5 = peg$c124;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c125); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 93) {
+                  s7 = peg$c126;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c127); }
+                }
+                if (s7 !== peg$FAILED) {
+                  s4 = [s4, s5, s6, s7];
+                  s3 = s4;
+                } else {
+                  peg$currPos = s3;
+                  s3 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        }
+      } else {
+        s2 = peg$FAILED;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c128(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrayTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 55,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseUnaryUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRecordTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseTupleTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseArrowTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseFunctionTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseParenthesizedExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseGenericTypeExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseTypeQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseKeyQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseBroadNamepathExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseValueExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseAnyTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseUnknownTypeExpr();
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 82 + 56,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c129) {
+      s1 = peg$c129;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseArrowTypeExprParamsList();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c131) {
+              s5 = peg$c131;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c132); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseFunctionTypeExprReturnableOperand();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c133(s1, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParamsList() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 57,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 40) {
+      s1 = peg$c98;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 41) {
+          s3 = peg$c100;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c134();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c98;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseArrowTypeExprParams();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse_();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s5 = peg$c100;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c135(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeParamIdentifier() {
+    var s0, s1, s2, s3;
+
+    var key    = peg$currPos * 82 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c58;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseJsIdentifier();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137(s1);
+      }
+      s0 = s1;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 82 + 59,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeParamIdentifier();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeParamIdentifier();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseVariadicNameExpr();
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c138(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 82 + 60,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s5 = peg$c43;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseFunctionTypeExprParamOperand();
+                if (s7 === peg$FAILED) {
+                  s7 = null;
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c141(s1, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4189,7 +5334,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 67 + 49,
+    var key    = peg$currPos * 82 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4199,12 +5344,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c111) {
-      s1 = peg$c111;
+    if (input.substr(peg$currPos, 8) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c112); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4245,7 +5390,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c113(s3, s5);
+              s1 = peg$c144(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4276,7 +5421,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 67 + 50,
+    var key    = peg$currPos * 82 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4287,11 +5432,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c114;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4301,11 +5446,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s5 = peg$c100;
+              s5 = peg$c113;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
@@ -4315,15 +5460,15 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c116;
+                      s9 = peg$c100;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c101); }
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c118(s3, s7);
+                      s1 = peg$c145(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4364,11 +5509,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c114;
+        s1 = peg$c98;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c115); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4378,15 +5523,15 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c116;
+                s5 = peg$c100;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c119(s3);
+                s1 = peg$c146(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4411,25 +5556,25 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c114;
+          s1 = peg$c98;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c115); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s3 = peg$c116;
+              s3 = peg$c100;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c117); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c120();
+              s1 = peg$c147();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4446,11 +5591,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c114;
+            s1 = peg$c98;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c115); }
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -4460,15 +5605,15 @@ function peg$parse(input, options) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c116;
+                    s5 = peg$c100;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c117); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c121(s3);
+                    s1 = peg$c148(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4502,7 +5647,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 51,
+    var key    = peg$currPos * 82 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4513,12 +5658,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c122) {
-      s2 = peg$c122;
+    if (input.substr(peg$currPos, 4) === peg$c149) {
+      s2 = peg$c149;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c123); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -4559,18 +5704,18 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c124(s1);
+      s1 = peg$c151(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c125) {
-        s2 = peg$c125;
+      if (input.substr(peg$currPos, 3) === peg$c129) {
+        s2 = peg$c129;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c126); }
+        if (peg$silentFails === 0) { peg$fail(peg$c130); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4611,7 +5756,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c127(s1);
+        s1 = peg$c152(s1);
       }
       s0 = s1;
     }
@@ -4624,7 +5769,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 52,
+    var key    = peg$currPos * 82 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4641,11 +5786,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c100;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -4676,11 +5821,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c100;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -4714,7 +5859,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c128(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4733,7 +5878,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 53,
+    var key    = peg$currPos * 82 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4744,25 +5889,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseTypeQueryExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseUnaryUnionTypeExpr();
+        s0 = peg$parseTypeQueryExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseRecordTypeExpr();
+          s0 = peg$parseKeyQueryExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseFunctionTypeExpr();
+            s0 = peg$parseUnaryUnionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseParenthesizedExpr();
+              s0 = peg$parseRecordTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseTupleTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseArrowTypeExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseFunctionTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseParenthesizedExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -4782,7 +5942,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 54,
+    var key    = peg$currPos * 82 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4795,21 +5955,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseRecordTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseTupleTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseArrowTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseTypeQueryExpr();
+            s0 = peg$parseFunctionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseBroadNamepathExpr();
+                s0 = peg$parseArrayTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseValueExpr();
+                  s0 = peg$parseTypeQueryExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseAnyTypeExpr();
+                    s0 = peg$parseKeyQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseUnknownTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -4828,7 +6000,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 55,
+    var key    = peg$currPos * 82 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4839,11 +6011,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c129;
+      s1 = peg$c154;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c130); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4856,15 +6028,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c131;
+              s5 = peg$c156;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c132); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c133(s3);
+              s1 = peg$c158(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4895,7 +6067,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 67 + 56,
+    var key    = peg$currPos * 82 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4913,11 +6085,11 @@ function peg$parse(input, options) {
       s5 = peg$parse_();
       if (s5 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s6 = peg$c100;
+          s6 = peg$c113;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s6 !== peg$FAILED) {
           s5 = [s5, s6];
@@ -4935,11 +6107,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c134;
+            s6 = peg$c159;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c135); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5034,11 +6206,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s6 = peg$c100;
+            s6 = peg$c113;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5056,11 +6228,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c134;
+              s6 = peg$c159;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c135); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -5154,11 +6326,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c100;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c101); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -5176,11 +6348,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c134;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c135); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -5254,7 +6426,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1, s2);
+          s1 = peg$c161(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5277,7 +6449,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 67 + 57,
+    var key    = peg$currPos * 82 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5288,12 +6460,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c137) {
-      s2 = peg$c137;
+    if (input.substr(peg$currPos, 8) === peg$c162) {
+      s2 = peg$c162;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -5342,7 +6514,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c139(s1, s2, s4, s8);
+                    s1 = peg$c164(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5379,12 +6551,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c137) {
-        s2 = peg$c137;
+      if (input.substr(peg$currPos, 8) === peg$c162) {
+        s2 = peg$c162;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -5406,7 +6578,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c140(s1, s2);
+          s1 = peg$c165(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5426,7 +6598,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 67 + 58,
+    var key    = peg$currPos * 82 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5536,7 +6708,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c141(s2);
+          s1 = peg$c166(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5652,7 +6824,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c142(s2);
+            s1 = peg$c167(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5680,7 +6852,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c143(s1);
+          s1 = peg$c168(s1);
         }
         s0 = s1;
       }
@@ -5694,7 +6866,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 59,
+    var key    = peg$currPos * 82 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5705,23 +6877,272 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseBroadNamepathExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseValueExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseAnyTypeExpr();
+                    s0 = peg$parseArrayTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseUnknownTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 72,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c124;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseTupleTypeExprEntries();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s5 = peg$c126;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c169(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExprEntries() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    var key    = peg$currPos * 82 + 73,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseTupleTypeExprOperand();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c113;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s3 = [s3, s4, s5, s6];
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseTupleTypeExprOperand();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c113;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s3 = [s3, s4, s5, s6];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseVariadicTypeExpr();
+      if (s2 === peg$FAILED) {
+        s2 = peg$parseVariadicTypeExprOperand();
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c170(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 74,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseIntersectionTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseUnaryUnionTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseRecordTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseTupleTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseArrowTypeExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseFunctionTypeExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseParenthesizedExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseTypeQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseKeyQueryExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -5740,7 +7161,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 67 + 60,
+    var key    = peg$currPos * 82 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5751,11 +7172,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c114;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c115); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5765,15 +7186,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c116;
+              s5 = peg$c100;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c117); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3);
+              s1 = peg$c171(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5804,7 +7225,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 61,
+    var key    = peg$currPos * 82 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5815,23 +7236,38 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseTypeQueryExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseBroadNamepathExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseValueExpr();
+                  s0 = peg$parseArrayTypeExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseAnyTypeExpr();
+                    s0 = peg$parseTypeQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseUnknownTypeExpr();
+                      s0 = peg$parseKeyQueryExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseGenericTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseBroadNamepathExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseValueExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseAnyTypeExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseUnknownTypeExpr();
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -5850,7 +7286,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 67 + 62,
+    var key    = peg$currPos * 82 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5875,7 +7311,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 63,
+    var key    = peg$currPos * 82 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5885,18 +7321,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c145) {
-      s1 = peg$c145;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c146); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c147(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5915,7 +7351,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 67 + 64,
+    var key    = peg$currPos * 82 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5927,16 +7363,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c145) {
-        s2 = peg$c145;
+      if (input.substr(peg$currPos, 3) === peg$c139) {
+        s2 = peg$c139;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c146); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c148(s1);
+        s1 = peg$c173(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5955,7 +7391,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 67 + 65,
+    var key    = peg$currPos * 82 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5965,16 +7401,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c145) {
-      s1 = peg$c145;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c146); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c149();
+      s1 = peg$c174();
     }
     s0 = s1;
 
@@ -5986,7 +7422,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 67 + 66,
+    var key    = peg$currPos * 82 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5997,25 +7433,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseTypeQueryExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseTypeQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseKeyQueryExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }

--- a/peg_lib/jsdoctype-closure.js
+++ b/peg_lib/jsdoctype-closure.js
@@ -568,24 +568,29 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { return { name: id, optional: true } },
-      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c136 = function(id) { 
+              return { 
+                name: id, 
+                meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
+              }; 
+            },
+      peg$c137 = function(id) { return { name: id } },
       peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
           const param = { 
-              type: tokens[0].optional 
-                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
-                  : NodeType.NAMED_PARAMETER, 
-              name: tokens[0].name, 
+              name: tokens[0].name,
+              type: NodeType.NAMED_PARAMETER,
               typeName: tokens[4] 
           };
+          if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
       peg$c139 = "...",
       peg$c140 = peg$literalExpectation("...", false),
       peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
         if (spread) {
         return {
           type: NodeType.VARIADIC,
@@ -5275,7 +5280,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseJsIdentifier();
+        s3 = peg$parseArrowTypeParamIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {

--- a/peg_lib/jsdoctype-closure.js
+++ b/peg_lib/jsdoctype-closure.js
@@ -568,43 +568,74 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { 
+      peg$c136 = function(id) { return { name: id } },
+      peg$c137 = function(id) { 
               return { 
                 name: id, 
                 meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
               }; 
             },
-      peg$c137 = function(id) { return { name: id } },
-      peg$c138 = function(paramsWithComma, lastParam) {
-        return paramsWithComma.reduceRight(function(params, tokens) {
+      peg$c138 = function(optionalParams, lastParam) {
+        const paramsArray = optionalParams.reduce((params, paramTokens) => {
+          const id = paramTokens[0];
           const param = { 
-              name: tokens[0].name,
+            type: NodeType.NAMED_PARAMETER,
+            name: id.name,
+            typeName: paramTokens[4]
+          };
+          if (id.meta) param.meta = id.meta;
+          params.push(param);
+          return params;
+        }, []);
+        if (lastParam) paramsArray.push(lastParam);
+
+        return paramsArray;
+      },
+      peg$c139 = function(requiredParams, finalParams) {
+        const paramsArray = requiredParams.reduce((params, paramTokens) => {
+          const param = {
+            type: NodeType.NAMED_PARAMETER,
+            name: paramTokens[0].name,
+            typeName: paramTokens[4]
+          }
+          params.push(param);
+          return params;
+        }, []);
+        return finalParams ? paramsArray.concat(finalParams) : paramsArray;
+          
+        return requiredParams.reduceRight(function(params, tokens) {
+          const param = { 
               type: NodeType.NAMED_PARAMETER,
+              name: tokens[0].name,
               typeName: tokens[4] 
           };
           if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
-        }, lastParam ? [lastParam] : []);
+        }, finalParams ? [finalParams] : []);
       },
-      peg$c139 = "...",
-      peg$c140 = peg$literalExpectation("...", false),
-      peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
-        if (id.meta) operand.meta = id.meta;
-        if (spread) {
+      peg$c140 = "...",
+      peg$c141 = peg$literalExpectation("...", false),
+      peg$c142 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         return {
           type: NodeType.VARIADIC,
           value: operand,
           meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
         };
-        }
-        else {
-          return operand;
-        }
       },
-      peg$c142 = "function",
-      peg$c143 = peg$literalExpectation("function", false),
-      peg$c144 = function(paramsPart, returnedTypePart) {
+      peg$c143 = function(id, type) { // TODO: Add default value support
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c144 = function(id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c145 = "function",
+      peg$c146 = peg$literalExpectation("function", false),
+      peg$c147 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -615,53 +646,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c145 = function(modifier, params) {
+      peg$c148 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c146 = function(modifier) {
+      peg$c149 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c147 = function() {
+      peg$c150 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c148 = function(params) {
+      peg$c151 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c149 = "this",
-      peg$c150 = peg$literalExpectation("this", false),
-      peg$c151 = function(modifierThis) {
+      peg$c152 = "this",
+      peg$c153 = peg$literalExpectation("this", false),
+      peg$c154 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c152 = function(modifierNew) {
+      peg$c155 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c153 = function(paramsWithComma, lastParam) {
+      peg$c156 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c154 = "{",
-      peg$c155 = peg$literalExpectation("{", false),
-      peg$c156 = "}",
-      peg$c157 = peg$literalExpectation("}", false),
-      peg$c158 = function(entries) {
+      peg$c157 = "{",
+      peg$c158 = peg$literalExpectation("{", false),
+      peg$c159 = "}",
+      peg$c160 = peg$literalExpectation("}", false),
+      peg$c161 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c159 = ";",
-      peg$c160 = peg$literalExpectation(";", false),
-      peg$c161 = function(first, restWithComma) {
+      peg$c162 = ";",
+      peg$c163 = peg$literalExpectation(";", false),
+      peg$c164 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c162 = "readonly",
-      peg$c163 = peg$literalExpectation("readonly", false),
-      peg$c164 = function(readonly, keyInfo, optional, value) {
+      peg$c165 = "readonly",
+      peg$c166 = peg$literalExpectation("readonly", false),
+      peg$c167 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -677,7 +708,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c165 = function(readonly, keyInfo) {
+      peg$c168 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -687,59 +718,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c166 = function(key) {
+      peg$c169 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c167 = function(key) {
+      peg$c170 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c168 = function(key) {
+      peg$c171 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c169 = function(entries) {
+      peg$c172 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c170 = function(restWithComma, last) {
+      peg$c173 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c171 = function(wrapped) {
+      peg$c174 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c172 = function(operand) {
+      peg$c175 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c173 = function(operand) {
+      peg$c176 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c174 = function() {
+      peg$c177 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -888,7 +919,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 0,
+    var key    = peg$currPos * 89 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -976,7 +1007,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 1,
+    var key    = peg$currPos * 89 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1033,7 +1064,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 2,
+    var key    = peg$currPos * 89 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1057,7 +1088,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 3,
+    var key    = peg$currPos * 89 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1085,7 +1116,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 82 + 4,
+    var key    = peg$currPos * 89 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1147,7 +1178,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 5,
+    var key    = peg$currPos * 89 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1286,7 +1317,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 6,
+    var key    = peg$currPos * 89 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1354,7 +1385,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 7,
+    var key    = peg$currPos * 89 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1613,7 +1644,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 82 + 8,
+    var key    = peg$currPos * 89 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1638,7 +1669,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 9,
+    var key    = peg$currPos * 89 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1741,7 +1772,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 10,
+    var key    = peg$currPos * 89 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1772,7 +1803,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 11,
+    var key    = peg$currPos * 89 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1803,7 +1834,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 12,
+    var key    = peg$currPos * 89 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1834,7 +1865,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 13,
+    var key    = peg$currPos * 89 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1859,7 +1890,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 82 + 14,
+    var key    = peg$currPos * 89 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2028,7 +2059,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 15,
+    var key    = peg$currPos * 89 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2092,7 +2123,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 16,
+    var key    = peg$currPos * 89 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2225,7 +2256,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 17,
+    var key    = peg$currPos * 89 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2511,7 +2542,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 18,
+    var key    = peg$currPos * 89 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2542,7 +2573,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 19,
+    var key    = peg$currPos * 89 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2573,7 +2604,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 20,
+    var key    = peg$currPos * 89 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2595,7 +2626,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 21,
+    var key    = peg$currPos * 89 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2845,7 +2876,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 22,
+    var key    = peg$currPos * 89 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2879,7 +2910,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 23,
+    var key    = peg$currPos * 89 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2936,7 +2967,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 24,
+    var key    = peg$currPos * 89 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3166,7 +3197,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 25,
+    var key    = peg$currPos * 89 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3247,7 +3278,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 26,
+    var key    = peg$currPos * 89 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3328,7 +3359,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 27,
+    var key    = peg$currPos * 89 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3409,7 +3440,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 28,
+    var key    = peg$currPos * 89 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3470,7 +3501,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 29,
+    var key    = peg$currPos * 89 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3528,7 +3559,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 30,
+    var key    = peg$currPos * 89 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3589,7 +3620,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 31,
+    var key    = peg$currPos * 89 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3647,7 +3678,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 32,
+    var key    = peg$currPos * 89 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3669,7 +3700,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 33,
+    var key    = peg$currPos * 89 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3691,7 +3722,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 34,
+    var key    = peg$currPos * 89 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3737,7 +3768,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 35,
+    var key    = peg$currPos * 89 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3783,7 +3814,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 36,
+    var key    = peg$currPos * 89 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3853,7 +3884,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 37,
+    var key    = peg$currPos * 89 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3914,7 +3945,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 38,
+    var key    = peg$currPos * 89 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3996,7 +4027,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 39,
+    var key    = peg$currPos * 89 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4042,7 +4073,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 40,
+    var key    = peg$currPos * 89 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4088,7 +4119,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 41,
+    var key    = peg$currPos * 89 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4113,7 +4144,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 42,
+    var key    = peg$currPos * 89 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4162,7 +4193,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 43,
+    var key    = peg$currPos * 89 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4208,7 +4239,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 44,
+    var key    = peg$currPos * 89 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4254,7 +4285,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 45,
+    var key    = peg$currPos * 89 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4306,7 +4337,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 46,
+    var key    = peg$currPos * 89 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4370,7 +4401,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 47,
+    var key    = peg$currPos * 89 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4401,7 +4432,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 48,
+    var key    = peg$currPos * 89 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4465,7 +4496,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 49,
+    var key    = peg$currPos * 89 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4568,7 +4599,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 50,
+    var key    = peg$currPos * 89 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4590,7 +4621,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 51,
+    var key    = peg$currPos * 89 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4621,7 +4652,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 52,
+    var key    = peg$currPos * 89 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4652,7 +4683,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 53,
+    var key    = peg$currPos * 89 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4677,7 +4708,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 54,
+    var key    = peg$currPos * 89 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4796,7 +4827,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 55,
+    var key    = peg$currPos * 89 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4851,7 +4882,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 56,
+    var key    = peg$currPos * 89 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4930,7 +4961,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 57,
+    var key    = peg$currPos * 89 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5027,10 +5058,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseArrowTypeParamIdentifier() {
+  function peg$parseArrowTypeRequiredParamEntry() {
+    var s0, s1;
+
+    var key    = peg$currPos * 89 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c136(s1);
+    }
+    s0 = s1;
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeOptionalParamEntry() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 58,
+    var key    = peg$currPos * 89 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5053,7 +5109,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5067,25 +5123,16 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseJsIdentifier();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137(s1);
-      }
-      s0 = s1;
-    }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
-  function peg$parseArrowTypeExprParams() {
+  function peg$parseArrowOptionalLastParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 82 + 59,
+    var key    = peg$currPos * 89 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5097,7 +5144,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseArrowTypeParamIdentifier();
+    s3 = peg$parseArrowTypeOptionalParamEntry();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
@@ -5165,7 +5212,7 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseArrowTypeParamIdentifier();
+      s3 = peg$parseArrowTypeOptionalParamEntry();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -5232,14 +5279,17 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseVariadicNameExpr();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c138(s1, s2);
-        s0 = s1;
+        s3 = peg$parseOptionalLastParamExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5254,10 +5304,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseVariadicNameExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseFinalParamsExpr() {
+    var s0;
 
-    var key    = peg$currPos * 82 + 60,
+    var key    = peg$currPos * 89 + 61,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseArrowOptionalLastParams();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredLastParamExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 89 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5267,20 +5339,192 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
-      peg$currPos += 3;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeRequiredParamEntry();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeRequiredParamEntry();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseArrowTypeParamIdentifier();
+        s3 = peg$parseFinalParamsExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c139(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseSpreadVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 89 + 63,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
@@ -5300,7 +5544,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c141(s1, s3, s7);
+                  s1 = peg$c142(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5336,10 +5580,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionTypeExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseRequiredVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 61,
+    var key    = peg$currPos * 89 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5349,12 +5593,178 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c142) {
-      s1 = peg$c142;
+    s1 = peg$parseArrowTypeRequiredParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c143(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 89 + 65,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseArrowTypeOptionalParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c144(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 66,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOptionalVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseRequiredLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 67,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFunctionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key    = peg$currPos * 89 + 68,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c145) {
+      s1 = peg$c145;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5395,7 +5805,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3, s5);
+              s1 = peg$c147(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5426,7 +5836,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 62,
+    var key    = peg$currPos * 89 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5473,7 +5883,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c145(s3, s7);
+                      s1 = peg$c148(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5536,7 +5946,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c146(s3);
+                s1 = peg$c149(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5579,7 +5989,7 @@ function peg$parse(input, options) {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147();
+              s1 = peg$c150();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5618,7 +6028,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c148(s3);
+                    s1 = peg$c151(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5652,7 +6062,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 63,
+    var key    = peg$currPos * 89 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5663,12 +6073,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c149) {
-      s2 = peg$c149;
+    if (input.substr(peg$currPos, 4) === peg$c152) {
+      s2 = peg$c152;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -5709,7 +6119,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c151(s1);
+      s1 = peg$c154(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5761,7 +6171,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152(s1);
+        s1 = peg$c155(s1);
       }
       s0 = s1;
     }
@@ -5774,7 +6184,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 64,
+    var key    = peg$currPos * 89 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5864,7 +6274,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c153(s1, s2);
+        s1 = peg$c156(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5883,7 +6293,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 65,
+    var key    = peg$currPos * 89 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5947,7 +6357,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 66,
+    var key    = peg$currPos * 89 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6005,7 +6415,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 67,
+    var key    = peg$currPos * 89 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6016,11 +6426,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c154;
+      s1 = peg$c157;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6033,15 +6443,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c156;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c157); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c158(s3);
+              s1 = peg$c161(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6072,7 +6482,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 68,
+    var key    = peg$currPos * 89 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6112,11 +6522,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c159;
+            s6 = peg$c162;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c163); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -6233,11 +6643,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c159;
+              s6 = peg$c162;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -6353,11 +6763,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c159;
+              s5 = peg$c162;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -6431,7 +6841,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c161(s1, s2);
+          s1 = peg$c164(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6454,7 +6864,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 82 + 69,
+    var key    = peg$currPos * 89 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6465,12 +6875,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c162) {
-      s2 = peg$c162;
+    if (input.substr(peg$currPos, 8) === peg$c165) {
+      s2 = peg$c165;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -6519,7 +6929,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c164(s1, s2, s4, s8);
+                    s1 = peg$c167(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6556,12 +6966,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c162) {
-        s2 = peg$c162;
+      if (input.substr(peg$currPos, 8) === peg$c165) {
+        s2 = peg$c165;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6583,7 +6993,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c165(s1, s2);
+          s1 = peg$c168(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6603,7 +7013,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 70,
+    var key    = peg$currPos * 89 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6713,7 +7123,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s2);
+          s1 = peg$c169(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6829,7 +7239,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s2);
+            s1 = peg$c170(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6857,7 +7267,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c168(s1);
+          s1 = peg$c171(s1);
         }
         s0 = s1;
       }
@@ -6871,7 +7281,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 71,
+    var key    = peg$currPos * 89 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6929,7 +7339,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 72,
+    var key    = peg$currPos * 89 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6962,7 +7372,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c169(s3);
+              s1 = peg$c172(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6993,7 +7403,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 73,
+    var key    = peg$currPos * 89 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7083,7 +7493,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c173(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7102,7 +7512,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 74,
+    var key    = peg$currPos * 89 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7166,7 +7576,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 75,
+    var key    = peg$currPos * 89 + 82,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7199,7 +7609,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c171(s3);
+              s1 = peg$c174(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7230,7 +7640,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 76,
+    var key    = peg$currPos * 89 + 83,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7291,7 +7701,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 77,
+    var key    = peg$currPos * 89 + 84,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7316,7 +7726,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 78,
+    var key    = peg$currPos * 89 + 85,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7326,18 +7736,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s2);
+        s1 = peg$c175(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7356,7 +7766,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 79,
+    var key    = peg$currPos * 89 + 86,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7368,16 +7778,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c139) {
-        s2 = peg$c139;
+      if (input.substr(peg$currPos, 3) === peg$c140) {
+        s2 = peg$c140;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173(s1);
+        s1 = peg$c176(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7396,7 +7806,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 80,
+    var key    = peg$currPos * 89 + 87,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7406,16 +7816,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174();
+      s1 = peg$c177();
     }
     s0 = s1;
 
@@ -7427,7 +7837,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 81,
+    var key    = peg$currPos * 89 + 88,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-jsdoc.js
+++ b/peg_lib/jsdoctype-jsdoc.js
@@ -424,55 +424,89 @@ function peg$parse(input, options) {
       peg$c81 = peg$literalExpectation("0x", false),
       peg$c82 = /^[0-9a-fA-F]/,
       peg$c83 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c84 = "|",
-      peg$c85 = peg$literalExpectation("|", false),
+      peg$c84 = "&",
+      peg$c85 = peg$literalExpectation("&", false),
       peg$c86 = function(left, right) {
+                      return {
+                          type: NodeType.INTERSECTION,
+                          left,
+                          right,
+                      };
+                    },
+      peg$c87 = "|",
+      peg$c88 = peg$literalExpectation("|", false),
+      peg$c89 = function(left, right) {
                       return {
                           type: NodeType.UNION,
                           left,
                           right,
                       };
                     },
-      peg$c87 = function(operator, operand) {
+      peg$c90 = "typeof",
+      peg$c91 = peg$literalExpectation("typeof", false),
+      peg$c92 = function(operator, name) {
+                      return {
+                          type: NodeType.TYPE_QUERY,
+                          name,
+                      };
+                    },
+      peg$c93 = "keyof",
+      peg$c94 = peg$literalExpectation("keyof", false),
+      peg$c95 = function(operator, operand) {
+          return {
+            type: NodeType.KEY_QUERY,
+            value: operand,
+          }
+        },
+      peg$c96 = "import",
+      peg$c97 = peg$literalExpectation("import", false),
+      peg$c98 = "(",
+      peg$c99 = peg$literalExpectation("(", false),
+      peg$c100 = ")",
+      peg$c101 = peg$literalExpectation(")", false),
+      peg$c102 = function(operator, path) {
+                       return { type: NodeType.IMPORT, path };
+                     },
+      peg$c103 = function(operator, operand) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.PREFIX_QUESTION_MARK },
                                };
                              },
-      peg$c88 = "!",
-      peg$c89 = peg$literalExpectation("!", false),
-      peg$c90 = function(operator, operand) {
+      peg$c104 = "!",
+      peg$c105 = peg$literalExpectation("!", false),
+      peg$c106 = function(operator, operand) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.PREFIX_BANG },
                                   };
                                 },
-      peg$c91 = function(operand, operator) {
+      peg$c107 = function(operand, operator) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.SUFFIX_QUESTION_MARK },
                                };
                              },
-      peg$c92 = function(operand, operator) {
+      peg$c108 = function(operand, operator) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.SUFFIX_BANG },
                                   };
                                 },
-      peg$c93 = "=",
-      peg$c94 = peg$literalExpectation("=", false),
-      peg$c95 = function(operand, operator) {
+      peg$c109 = "=",
+      peg$c110 = peg$literalExpectation("=", false),
+      peg$c111 = function(operand, operator) {
                                return {
                                  type: NodeType.OPTIONAL,
                                  value: operand,
                                  meta: { syntax: OptionalTypeSyntax.SUFFIX_EQUALS_SIGN },
                                };
                              },
-      peg$c96 = function(operand, syntax, params) {
+      peg$c112 = function(operand, syntax, params) {
                         return {
                           type: NodeType.GENERIC,
                           subject: operand,
@@ -480,30 +514,30 @@ function peg$parse(input, options) {
                           meta: { syntax },
                         };
                       },
-      peg$c97 = ",",
-      peg$c98 = peg$literalExpectation(",", false),
-      peg$c99 = function(first, restsWithComma) {
+      peg$c113 = ",",
+      peg$c114 = peg$literalExpectation(",", false),
+      peg$c115 = function(first, restsWithComma) {
                                      return restsWithComma.reduce(function(params, tokens) {
                                        return params.concat([tokens[3]]);
                                      }, [first]);
                                    },
-      peg$c100 = ".<",
-      peg$c101 = peg$literalExpectation(".<", false),
-      peg$c102 = function() {
+      peg$c116 = ".<",
+      peg$c117 = peg$literalExpectation(".<", false),
+      peg$c118 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT;
                                               },
-      peg$c103 = "<",
-      peg$c104 = peg$literalExpectation("<", false),
-      peg$c105 = function() {
+      peg$c119 = "<",
+      peg$c120 = peg$literalExpectation("<", false),
+      peg$c121 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET;
                                               },
-      peg$c106 = ">",
-      peg$c107 = peg$literalExpectation(">", false),
-      peg$c108 = "[",
-      peg$c109 = peg$literalExpectation("[", false),
-      peg$c110 = "]",
-      peg$c111 = peg$literalExpectation("]", false),
-      peg$c112 = function(operand, brackets) {
+      peg$c122 = ">",
+      peg$c123 = peg$literalExpectation(">", false),
+      peg$c124 = "[",
+      peg$c125 = peg$literalExpectation("[", false),
+      peg$c126 = "]",
+      peg$c127 = peg$literalExpectation("]", false),
+      peg$c128 = function(operand, brackets) {
                       return brackets.reduce(function(operand) {
                         return {
                           type: NodeType.GENERIC,
@@ -516,9 +550,56 @@ function peg$parse(input, options) {
                         };
                       }, operand);
                     },
-      peg$c113 = "function",
-      peg$c114 = peg$literalExpectation("function", false),
-      peg$c115 = function(paramsPart, returnedTypePart) {
+      peg$c129 = "new",
+      peg$c130 = peg$literalExpectation("new", false),
+      peg$c131 = "=>",
+      peg$c132 = peg$literalExpectation("=>", false),
+      peg$c133 = function(newModifier, paramsPart, returnedTypeNode) {
+                         return {
+                           type: NodeType.ARROW,
+                           params: paramsPart,
+                           returns: returnedTypeNode,
+                           new: newModifier
+                         };
+      },
+      peg$c134 = function() {
+                            return [];
+                          },
+      peg$c135 = function(params) {
+                            return params;
+                          },
+      peg$c136 = function(id) { return { name: id, optional: true } },
+      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c138 = function(paramsWithComma, lastParam) {
+        return paramsWithComma.reduceRight(function(params, tokens) {
+          const param = { 
+              type: tokens[0].optional 
+                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
+                  : NodeType.NAMED_PARAMETER, 
+              name: tokens[0].name, 
+              typeName: tokens[4] 
+          };
+          return [param].concat(params);
+        }, lastParam ? [lastParam] : []);
+      },
+      peg$c139 = "...",
+      peg$c140 = peg$literalExpectation("...", false),
+      peg$c141 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        if (spread) {
+        return {
+          type: NodeType.VARIADIC,
+          value: operand,
+          meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
+        };
+        }
+        else {
+          return operand;
+        }
+      },
+      peg$c142 = "function",
+      peg$c143 = peg$literalExpectation("function", false),
+      peg$c144 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -529,59 +610,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c116 = "(",
-      peg$c117 = peg$literalExpectation("(", false),
-      peg$c118 = ")",
-      peg$c119 = peg$literalExpectation(")", false),
-      peg$c120 = function(modifier, params) {
+      peg$c145 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c121 = function(modifier) {
+      peg$c146 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c122 = function() {
+      peg$c147 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c123 = function(params) {
+      peg$c148 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c124 = "this",
-      peg$c125 = peg$literalExpectation("this", false),
-      peg$c126 = function(modifierThis) {
+      peg$c149 = "this",
+      peg$c150 = peg$literalExpectation("this", false),
+      peg$c151 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c127 = "new",
-      peg$c128 = peg$literalExpectation("new", false),
-      peg$c129 = function(modifierNew) {
+      peg$c152 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c130 = function(paramsWithComma, lastParam) {
+      peg$c153 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c131 = "{",
-      peg$c132 = peg$literalExpectation("{", false),
-      peg$c133 = "}",
-      peg$c134 = peg$literalExpectation("}", false),
-      peg$c135 = function(entries) {
+      peg$c154 = "{",
+      peg$c155 = peg$literalExpectation("{", false),
+      peg$c156 = "}",
+      peg$c157 = peg$literalExpectation("}", false),
+      peg$c158 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c136 = ";",
-      peg$c137 = peg$literalExpectation(";", false),
-      peg$c138 = function(first, restWithComma) {
+      peg$c159 = ";",
+      peg$c160 = peg$literalExpectation(";", false),
+      peg$c161 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c139 = "readonly",
-      peg$c140 = peg$literalExpectation("readonly", false),
-      peg$c141 = function(readonly, keyInfo, optional, value) {
+      peg$c162 = "readonly",
+      peg$c163 = peg$literalExpectation("readonly", false),
+      peg$c164 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -597,7 +672,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c142 = function(readonly, keyInfo) {
+      peg$c165 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -607,49 +682,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c143 = function(key) {
+      peg$c166 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c144 = function(key) {
+      peg$c167 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c145 = function(key) {
+      peg$c168 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c146 = function(wrapped) {
+      peg$c169 = function(entries) {
+        return {
+          type: NodeType.TUPLE,
+          entries,
+        }
+      },
+      peg$c170 = function(restWithComma, last) {
+        return restWithComma.reduceRight((entries, tokens) => {
+          let [entry] = tokens;
+          return [entry].concat(entries);
+        }, last ? [last] : []);
+      },
+      peg$c171 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c147 = "...",
-      peg$c148 = peg$literalExpectation("...", false),
-      peg$c149 = function(operand) {
+      peg$c172 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c150 = function(operand) {
+      peg$c173 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c151 = function() {
+      peg$c174 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -798,7 +883,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 0,
+    var key    = peg$currPos * 82 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -814,25 +899,40 @@ function peg$parse(input, options) {
       if (s2 === peg$FAILED) {
         s2 = peg$parseUnionTypeExpr();
         if (s2 === peg$FAILED) {
-          s2 = peg$parseUnaryUnionTypeExpr();
+          s2 = peg$parseIntersectionTypeExpr();
           if (s2 === peg$FAILED) {
-            s2 = peg$parseArrayTypeExpr();
+            s2 = peg$parseUnaryUnionTypeExpr();
             if (s2 === peg$FAILED) {
-              s2 = peg$parseGenericTypeExpr();
+              s2 = peg$parseArrayTypeExpr();
               if (s2 === peg$FAILED) {
-                s2 = peg$parseRecordTypeExpr();
+                s2 = peg$parseGenericTypeExpr();
                 if (s2 === peg$FAILED) {
-                  s2 = peg$parseFunctionTypeExpr();
+                  s2 = peg$parseRecordTypeExpr();
                   if (s2 === peg$FAILED) {
-                    s2 = peg$parseBroadNamepathExpr();
+                    s2 = peg$parseTupleTypeExpr();
                     if (s2 === peg$FAILED) {
-                      s2 = peg$parseParenthesizedExpr();
+                      s2 = peg$parseArrowTypeExpr();
                       if (s2 === peg$FAILED) {
-                        s2 = peg$parseValueExpr();
+                        s2 = peg$parseFunctionTypeExpr();
                         if (s2 === peg$FAILED) {
-                          s2 = peg$parseAnyTypeExpr();
+                          s2 = peg$parseTypeQueryExpr();
                           if (s2 === peg$FAILED) {
-                            s2 = peg$parseUnknownTypeExpr();
+                            s2 = peg$parseKeyQueryExpr();
+                            if (s2 === peg$FAILED) {
+                              s2 = peg$parseBroadNamepathExpr();
+                              if (s2 === peg$FAILED) {
+                                s2 = peg$parseParenthesizedExpr();
+                                if (s2 === peg$FAILED) {
+                                  s2 = peg$parseValueExpr();
+                                  if (s2 === peg$FAILED) {
+                                    s2 = peg$parseAnyTypeExpr();
+                                    if (s2 === peg$FAILED) {
+                                      s2 = peg$parseUnknownTypeExpr();
+                                    }
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
                       }
@@ -871,7 +971,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 68 + 1,
+    var key    = peg$currPos * 82 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -928,7 +1028,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 2,
+    var key    = peg$currPos * 82 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -952,7 +1052,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 3,
+    var key    = peg$currPos * 82 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -980,7 +1080,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 68 + 4,
+    var key    = peg$currPos * 82 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1042,7 +1142,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 68 + 5,
+    var key    = peg$currPos * 82 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1054,7 +1154,10 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseParenthesizedExpr();
     if (s1 === peg$FAILED) {
-      s1 = peg$parseTypeNameExprJsDocFlavored();
+      s1 = peg$parseImportTypeExpr();
+      if (s1 === peg$FAILED) {
+        s1 = peg$parseTypeNameExprJsDocFlavored();
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = [];
@@ -1178,7 +1281,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 6,
+    var key    = peg$currPos * 82 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1246,7 +1349,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 7,
+    var key    = peg$currPos * 82 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1505,7 +1608,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 68 + 8,
+    var key    = peg$currPos * 82 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1530,7 +1633,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 9,
+    var key    = peg$currPos * 82 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1633,7 +1736,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 10,
+    var key    = peg$currPos * 82 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1664,7 +1767,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 11,
+    var key    = peg$currPos * 82 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1695,7 +1798,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 12,
+    var key    = peg$currPos * 82 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1726,7 +1829,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 68 + 13,
+    var key    = peg$currPos * 82 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1751,7 +1854,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 68 + 14,
+    var key    = peg$currPos * 82 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1920,7 +2023,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 15,
+    var key    = peg$currPos * 82 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1984,7 +2087,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 68 + 16,
+    var key    = peg$currPos * 82 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2117,7 +2220,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 17,
+    var key    = peg$currPos * 82 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2403,7 +2506,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 18,
+    var key    = peg$currPos * 82 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2434,7 +2537,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 19,
+    var key    = peg$currPos * 82 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2465,7 +2568,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 68 + 20,
+    var key    = peg$currPos * 82 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2487,7 +2590,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 21,
+    var key    = peg$currPos * 82 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2737,7 +2840,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 22,
+    var key    = peg$currPos * 82 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2771,7 +2874,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 23,
+    var key    = peg$currPos * 82 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2828,7 +2931,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 24,
+    var key    = peg$currPos * 82 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3058,7 +3161,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 25,
+    var key    = peg$currPos * 82 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3139,7 +3242,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 26,
+    var key    = peg$currPos * 82 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3220,7 +3323,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 27,
+    var key    = peg$currPos * 82 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3298,10 +3401,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnionTypeExpr() {
+  function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 28,
+    var key    = peg$currPos * 82 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3311,11 +3414,11 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    s1 = peg$parseUnionTypeExprOperand();
+    s1 = peg$parseIntersectionTypeExprOperand();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        if (input.charCodeAt(peg$currPos) === 124) {
+        if (input.charCodeAt(peg$currPos) === 38) {
           s3 = peg$c84;
           peg$currPos++;
         } else {
@@ -3325,9 +3428,9 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parseUnionTypeExpr();
+            s5 = peg$parseIntersectionTypeExpr();
             if (s5 === peg$FAILED) {
-              s5 = peg$parseUnionTypeExprOperand();
+              s5 = peg$parseIntersectionTypeExprOperand();
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
@@ -3359,10 +3462,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnionTypeExprOperand() {
+  function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 29,
+    var key    = peg$currPos * 82 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3375,13 +3478,234 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseRecordTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseTupleTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseArrowTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseGenericTypeExpr();
+            s0 = peg$parseFunctionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseArrayTypeExpr();
+              s0 = peg$parseParenthesizedExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseTypeQueryExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseKeyQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseGenericTypeExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 30,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseUnionTypeExprOperand();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 124) {
+          s3 = peg$c87;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseUnionTypeExpr();
+            if (s5 === peg$FAILED) {
+              s5 = peg$parseUnionTypeExprOperand();
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c89(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnionTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 31,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseUnaryUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRecordTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseTupleTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseArrowTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseFunctionTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseParenthesizedExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseTypeQueryExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseKeyQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseGenericTypeExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseUnaryUnionTypeExpr() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 32,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSuffixUnaryUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePrefixUnaryUnionTypeExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parsePrefixUnaryUnionTypeExpr() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 33,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parsePrefixNotNullableTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePrefixNullableTypeExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parsePrefixUnaryUnionTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 34,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseGenericTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRecordTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseTupleTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseArrowTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseFunctionTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
                 s0 = peg$parseBroadNamepathExpr();
                 if (s0 === peg$FAILED) {
@@ -3405,10 +3729,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseUnaryUnionTypeExpr() {
-    var s0;
+  function peg$parseTypeQueryExpr() {
+    var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 30,
+    var key    = peg$currPos * 82 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3417,9 +3741,33 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parseSuffixUnaryUnionTypeExpr();
-    if (s0 === peg$FAILED) {
-      s0 = peg$parsePrefixUnaryUnionTypeExpr();
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c90) {
+      s1 = peg$c90;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseQualifiedMemberName();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c92(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3427,10 +3775,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePrefixUnaryUnionTypeExpr() {
-    var s0;
+  function peg$parseKeyQueryExpr() {
+    var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 31,
+    var key    = peg$currPos * 82 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3439,9 +3787,57 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parsePrefixNotNullableTypeExpr();
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 5) === peg$c93) {
+      s1 = peg$c93;
+      peg$currPos += 5;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse__();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseKeyQueryExprOperand();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c95(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
     if (s0 === peg$FAILED) {
-      s0 = peg$parsePrefixNullableTypeExpr();
+      s0 = peg$currPos;
+      if (input.substr(peg$currPos, 5) === peg$c93) {
+        s1 = peg$c93;
+        peg$currPos += 5;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parseParenthesizedExpr();
+        if (s2 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c95(s1, s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3449,10 +3845,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parsePrefixUnaryUnionTypeExprOperand() {
+  function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 32,
+    var key    = peg$currPos * 82 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3461,21 +3857,42 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parseGenericTypeExpr();
+    s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseRecordTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseBroadNamepathExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseValueExpr();
+              s0 = peg$parseFunctionTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseAnyTypeExpr();
+                s0 = peg$parseParenthesizedExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseUnknownTypeExpr();
+                  s0 = peg$parseTypeQueryExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseKeyQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseArrayTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseGenericTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseBroadNamepathExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseValueExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseAnyTypeExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseUnknownTypeExpr();
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -3489,10 +3906,92 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseImportTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 82 + 38,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c96) {
+      s1 = peg$c96;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 40) {
+          s3 = peg$c98;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseStringLiteralExpr();
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 41) {
+                  s7 = peg$c100;
+                  peg$currPos++;
+                } else {
+                  s7 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c102(s1, s5);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 33,
+    var key    = peg$currPos * 82 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3515,7 +4014,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c87(s1, s3);
+          s1 = peg$c103(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3538,7 +4037,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 34,
+    var key    = peg$currPos * 82 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3549,11 +4048,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c88;
+      s1 = peg$c104;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c89); }
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3561,7 +4060,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c90(s1, s3);
+          s1 = peg$c106(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3584,7 +4083,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 68 + 35,
+    var key    = peg$currPos * 82 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3609,7 +4108,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 36,
+    var key    = peg$currPos * 82 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3624,17 +4123,23 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$parseRecordTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseTupleTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseArrowTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseBroadNamepathExpr();
+              s0 = peg$parseFunctionTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseValueExpr();
+                s0 = peg$parseParenthesizedExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseAnyTypeExpr();
+                  s0 = peg$parseBroadNamepathExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseUnknownTypeExpr();
+                    s0 = peg$parseValueExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseAnyTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseUnknownTypeExpr();
+                      }
+                    }
                   }
                 }
               }
@@ -3652,7 +4157,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 37,
+    var key    = peg$currPos * 82 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3675,7 +4180,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c91(s1, s3);
+          s1 = peg$c107(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3698,7 +4203,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 38,
+    var key    = peg$currPos * 82 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3713,15 +4218,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s3 = peg$c88;
+          s3 = peg$c104;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c89); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s1, s3);
+          s1 = peg$c108(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3744,7 +4249,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 68 + 39,
+    var key    = peg$currPos * 82 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3765,15 +4270,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c93;
+          s3 = peg$c109;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c94); }
+          if (peg$silentFails === 0) { peg$fail(peg$c110); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c95(s1, s3);
+          s1 = peg$c111(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3796,7 +4301,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 40,
+    var key    = peg$currPos * 82 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3821,7 +4326,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseGenericTypeEndToken();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c96(s1, s3, s5);
+                  s1 = peg$c112(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3860,7 +4365,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 41,
+    var key    = peg$currPos * 82 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3891,7 +4396,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 42,
+    var key    = peg$currPos * 82 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3902,25 +4407,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseArrayTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseArrayTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseTypeQueryExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseKeyQueryExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -3940,7 +4460,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 43,
+    var key    = peg$currPos * 82 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3957,11 +4477,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c97;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c98); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -3992,11 +4512,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c97;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -4024,7 +4544,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c99(s1, s2);
+        s1 = peg$c115(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4043,7 +4563,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 68 + 44,
+    var key    = peg$currPos * 82 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4065,7 +4585,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 45,
+    var key    = peg$currPos * 82 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4075,16 +4595,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c100) {
-      s1 = peg$c100;
+    if (input.substr(peg$currPos, 2) === peg$c116) {
+      s1 = peg$c116;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c101); }
+      if (peg$silentFails === 0) { peg$fail(peg$c117); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c102();
+      s1 = peg$c118();
     }
     s0 = s1;
 
@@ -4096,7 +4616,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 46,
+    var key    = peg$currPos * 82 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4107,15 +4627,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c103;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c104); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c105();
+      s1 = peg$c121();
     }
     s0 = s1;
 
@@ -4127,7 +4647,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 68 + 47,
+    var key    = peg$currPos * 82 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4137,11 +4657,11 @@ function peg$parse(input, options) {
     }
 
     if (input.charCodeAt(peg$currPos) === 62) {
-      s0 = peg$c106;
+      s0 = peg$c122;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c107); }
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -4152,7 +4672,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 48,
+    var key    = peg$currPos * 82 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4169,21 +4689,21 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s5 = peg$c108;
+          s5 = peg$c124;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c109); }
+          if (peg$silentFails === 0) { peg$fail(peg$c125); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s7 = peg$c110;
+              s7 = peg$c126;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c111); }
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
             }
             if (s7 !== peg$FAILED) {
               s4 = [s4, s5, s6, s7];
@@ -4211,21 +4731,21 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 91) {
-              s5 = peg$c108;
+              s5 = peg$c124;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c109); }
+              if (peg$silentFails === 0) { peg$fail(peg$c125); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c110;
+                  s7 = peg$c126;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c111); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c127); }
                 }
                 if (s7 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7];
@@ -4252,7 +4772,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c112(s1, s2);
+        s1 = peg$c128(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4271,7 +4791,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 49,
+    var key    = peg$currPos * 82 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4284,19 +4804,31 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseRecordTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseTupleTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseArrowTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseGenericTypeExpr();
+            s0 = peg$parseFunctionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseBroadNamepathExpr();
+              s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseValueExpr();
+                s0 = peg$parseGenericTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseAnyTypeExpr();
+                  s0 = peg$parseTypeQueryExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseUnknownTypeExpr();
+                    s0 = peg$parseKeyQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseBroadNamepathExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseValueExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseAnyTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseUnknownTypeExpr();
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -4311,10 +4843,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionTypeExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseArrowTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 50,
+    var key    = peg$currPos * 82 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4324,12 +4856,500 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c113) {
-      s1 = peg$c113;
+    if (input.substr(peg$currPos, 3) === peg$c129) {
+      s1 = peg$c129;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseArrowTypeExprParamsList();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 2) === peg$c131) {
+              s5 = peg$c131;
+              peg$currPos += 2;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c132); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseFunctionTypeExprReturnableOperand();
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c133(s1, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParamsList() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 57,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 40) {
+      s1 = peg$c98;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 41) {
+          s3 = peg$c100;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c134();
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 40) {
+        s1 = peg$c98;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$parse_();
+        if (s2 !== peg$FAILED) {
+          s3 = peg$parseArrowTypeExprParams();
+          if (s3 !== peg$FAILED) {
+            s4 = peg$parse_();
+            if (s4 !== peg$FAILED) {
+              if (input.charCodeAt(peg$currPos) === 41) {
+                s5 = peg$c100;
+                peg$currPos++;
+              } else {
+                s5 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
+              }
+              if (s5 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c135(s3);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeParamIdentifier() {
+    var s0, s1, s2, s3;
+
+    var key    = peg$currPos * 82 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c58;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseJsIdentifier();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137(s1);
+      }
+      s0 = s1;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 82 + 59,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeParamIdentifier();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeParamIdentifier();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseVariadicNameExpr();
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c138(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 82 + 60,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+    }
+    if (s1 === peg$FAILED) {
+      s1 = null;
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 58) {
+              s5 = peg$c43;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
+            }
+            if (s5 !== peg$FAILED) {
+              s6 = peg$parse_();
+              if (s6 !== peg$FAILED) {
+                s7 = peg$parseFunctionTypeExprParamOperand();
+                if (s7 === peg$FAILED) {
+                  s7 = null;
+                }
+                if (s7 !== peg$FAILED) {
+                  peg$savedPos = s0;
+                  s1 = peg$c141(s1, s3, s7);
+                  s0 = s1;
+                } else {
+                  peg$currPos = s0;
+                  s0 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFunctionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key    = peg$currPos * 82 + 61,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c114); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4370,7 +5390,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c115(s3, s5);
+              s1 = peg$c144(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4401,7 +5421,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 68 + 51,
+    var key    = peg$currPos * 82 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4412,11 +5432,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c116;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c117); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4426,11 +5446,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s5 = peg$c97;
+              s5 = peg$c113;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c98); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
@@ -4440,15 +5460,15 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c118;
+                      s9 = peg$c100;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c119); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c101); }
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c120(s3, s7);
+                      s1 = peg$c145(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4489,11 +5509,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c116;
+        s1 = peg$c98;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c117); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4503,15 +5523,15 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c118;
+                s5 = peg$c100;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c119); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c121(s3);
+                s1 = peg$c146(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4536,25 +5556,25 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c116;
+          s1 = peg$c98;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c117); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s3 = peg$c118;
+              s3 = peg$c100;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c119); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c122();
+              s1 = peg$c147();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4571,11 +5591,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c116;
+            s1 = peg$c98;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c117); }
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -4585,15 +5605,15 @@ function peg$parse(input, options) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c118;
+                    s5 = peg$c100;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c119); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c123(s3);
+                    s1 = peg$c148(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4627,7 +5647,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 52,
+    var key    = peg$currPos * 82 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4638,12 +5658,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c124) {
-      s2 = peg$c124;
+    if (input.substr(peg$currPos, 4) === peg$c149) {
+      s2 = peg$c149;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c125); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -4684,18 +5704,18 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c126(s1);
+      s1 = peg$c151(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c127) {
-        s2 = peg$c127;
+      if (input.substr(peg$currPos, 3) === peg$c129) {
+        s2 = peg$c129;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c128); }
+        if (peg$silentFails === 0) { peg$fail(peg$c130); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
@@ -4736,7 +5756,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c129(s1);
+        s1 = peg$c152(s1);
       }
       s0 = s1;
     }
@@ -4749,7 +5769,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 53,
+    var key    = peg$currPos * 82 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4766,11 +5786,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c97;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c98); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -4801,11 +5821,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c97;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -4839,7 +5859,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c130(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4858,7 +5878,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 54,
+    var key    = peg$currPos * 82 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4869,25 +5889,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseTypeQueryExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseKeyQueryExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseUnaryUnionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseArrayTypeExpr();
+              s0 = peg$parseRecordTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseTupleTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseArrowTypeExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseFunctionTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseParenthesizedExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -4907,7 +5942,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 55,
+    var key    = peg$currPos * 82 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4920,21 +5955,33 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$parseRecordTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseFunctionTypeExpr();
+        s0 = peg$parseTupleTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseParenthesizedExpr();
+          s0 = peg$parseArrowTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseArrayTypeExpr();
+            s0 = peg$parseFunctionTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseBroadNamepathExpr();
+                s0 = peg$parseArrayTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseValueExpr();
+                  s0 = peg$parseTypeQueryExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseAnyTypeExpr();
+                    s0 = peg$parseKeyQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseUnknownTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -4953,7 +6000,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 56,
+    var key    = peg$currPos * 82 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4964,11 +6011,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c131;
+      s1 = peg$c154;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c132); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4981,15 +6028,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c133;
+              s5 = peg$c156;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c134); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c135(s3);
+              s1 = peg$c158(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5020,7 +6067,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 68 + 57,
+    var key    = peg$currPos * 82 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5038,11 +6085,11 @@ function peg$parse(input, options) {
       s5 = peg$parse_();
       if (s5 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s6 = peg$c97;
+          s6 = peg$c113;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c98); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s6 !== peg$FAILED) {
           s5 = [s5, s6];
@@ -5060,11 +6107,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c136;
+            s6 = peg$c159;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c137); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5159,11 +6206,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s6 = peg$c97;
+            s6 = peg$c113;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5181,11 +6228,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c136;
+              s6 = peg$c159;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c137); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -5279,11 +6326,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c97;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c98); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -5301,11 +6348,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c136;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c137); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -5379,7 +6426,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c138(s1, s2);
+          s1 = peg$c161(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5402,7 +6449,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 68 + 58,
+    var key    = peg$currPos * 82 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5413,12 +6460,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c139) {
-      s2 = peg$c139;
+    if (input.substr(peg$currPos, 8) === peg$c162) {
+      s2 = peg$c162;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -5467,7 +6514,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c141(s1, s2, s4, s8);
+                    s1 = peg$c164(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5504,12 +6551,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c139) {
-        s2 = peg$c139;
+      if (input.substr(peg$currPos, 8) === peg$c162) {
+        s2 = peg$c162;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -5531,7 +6578,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c142(s1, s2);
+          s1 = peg$c165(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5551,7 +6598,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 68 + 59,
+    var key    = peg$currPos * 82 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5661,7 +6708,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c143(s2);
+          s1 = peg$c166(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5777,7 +6824,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c144(s2);
+            s1 = peg$c167(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -5805,7 +6852,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c145(s1);
+          s1 = peg$c168(s1);
         }
         s0 = s1;
       }
@@ -5819,7 +6866,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 60,
+    var key    = peg$currPos * 82 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5830,25 +6877,271 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseArrayTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseArrayTypeExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseGenericTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseBroadNamepathExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseValueExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseAnyTypeExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseUnknownTypeExpr();
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 72,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 91) {
+      s1 = peg$c124;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseTupleTypeExprEntries();
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            if (input.charCodeAt(peg$currPos) === 93) {
+              s5 = peg$c126;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c169(s3);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExprEntries() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    var key    = peg$currPos * 82 + 73,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseTupleTypeExprOperand();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 44) {
+          s5 = peg$c113;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s3 = [s3, s4, s5, s6];
+            s2 = s3;
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s2;
+      s2 = peg$FAILED;
+    }
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseTupleTypeExprOperand();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 44) {
+            s5 = peg$c113;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s3 = [s3, s4, s5, s6];
+              s2 = s3;
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parseVariadicTypeExpr();
+      if (s2 === peg$FAILED) {
+        s2 = peg$parseVariadicTypeExprOperand();
+      }
+      if (s2 === peg$FAILED) {
+        s2 = null;
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c170(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseTupleTypeExprOperand() {
+    var s0;
+
+    var key    = peg$currPos * 82 + 74,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseUnionTypeExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseIntersectionTypeExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseUnaryUnionTypeExpr();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseRecordTypeExpr();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseTupleTypeExpr();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseArrowTypeExpr();
+              if (s0 === peg$FAILED) {
+                s0 = peg$parseFunctionTypeExpr();
+                if (s0 === peg$FAILED) {
+                  s0 = peg$parseParenthesizedExpr();
+                  if (s0 === peg$FAILED) {
+                    s0 = peg$parseTypeQueryExpr();
+                    if (s0 === peg$FAILED) {
+                      s0 = peg$parseKeyQueryExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -5868,7 +7161,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 68 + 61,
+    var key    = peg$currPos * 82 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5879,11 +7172,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c116;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c117); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5893,15 +7186,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c118;
+              s5 = peg$c100;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c119); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c146(s3);
+              s1 = peg$c171(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5932,7 +7225,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 62,
+    var key    = peg$currPos * 82 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5943,23 +7236,38 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseArrayTypeExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseGenericTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseBroadNamepathExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseValueExpr();
+                  s0 = peg$parseArrayTypeExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseAnyTypeExpr();
+                    s0 = peg$parseTypeQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseUnknownTypeExpr();
+                      s0 = peg$parseKeyQueryExpr();
+                      if (s0 === peg$FAILED) {
+                        s0 = peg$parseGenericTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseBroadNamepathExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseValueExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseAnyTypeExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseUnknownTypeExpr();
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -5978,7 +7286,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 68 + 63,
+    var key    = peg$currPos * 82 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6003,7 +7311,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 68 + 64,
+    var key    = peg$currPos * 82 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6013,18 +7321,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c147) {
-      s1 = peg$c147;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c149(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6043,7 +7351,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 68 + 65,
+    var key    = peg$currPos * 82 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6055,16 +7363,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c147) {
-        s2 = peg$c147;
+      if (input.substr(peg$currPos, 3) === peg$c139) {
+        s2 = peg$c139;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c148); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1);
+        s1 = peg$c173(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6083,7 +7391,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 68 + 66,
+    var key    = peg$currPos * 82 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6093,16 +7401,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c147) {
-      s1 = peg$c147;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c151();
+      s1 = peg$c174();
     }
     s0 = s1;
 
@@ -6114,7 +7422,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 68 + 67,
+    var key    = peg$currPos * 82 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6125,25 +7433,40 @@ function peg$parse(input, options) {
 
     s0 = peg$parseUnionTypeExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseUnaryUnionTypeExpr();
+      s0 = peg$parseIntersectionTypeExpr();
       if (s0 === peg$FAILED) {
-        s0 = peg$parseRecordTypeExpr();
+        s0 = peg$parseUnaryUnionTypeExpr();
         if (s0 === peg$FAILED) {
-          s0 = peg$parseFunctionTypeExpr();
+          s0 = peg$parseRecordTypeExpr();
           if (s0 === peg$FAILED) {
-            s0 = peg$parseParenthesizedExpr();
+            s0 = peg$parseTupleTypeExpr();
             if (s0 === peg$FAILED) {
-              s0 = peg$parseArrayTypeExpr();
+              s0 = peg$parseArrowTypeExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseGenericTypeExpr();
+                s0 = peg$parseFunctionTypeExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseBroadNamepathExpr();
+                  s0 = peg$parseParenthesizedExpr();
                   if (s0 === peg$FAILED) {
-                    s0 = peg$parseValueExpr();
+                    s0 = peg$parseTypeQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseAnyTypeExpr();
+                      s0 = peg$parseKeyQueryExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseUnknownTypeExpr();
+                        s0 = peg$parseArrayTypeExpr();
+                        if (s0 === peg$FAILED) {
+                          s0 = peg$parseGenericTypeExpr();
+                          if (s0 === peg$FAILED) {
+                            s0 = peg$parseBroadNamepathExpr();
+                            if (s0 === peg$FAILED) {
+                              s0 = peg$parseValueExpr();
+                              if (s0 === peg$FAILED) {
+                                s0 = peg$parseAnyTypeExpr();
+                                if (s0 === peg$FAILED) {
+                                  s0 = peg$parseUnknownTypeExpr();
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }

--- a/peg_lib/jsdoctype-jsdoc.js
+++ b/peg_lib/jsdoctype-jsdoc.js
@@ -568,24 +568,29 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { return { name: id, optional: true } },
-      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c136 = function(id) { 
+              return { 
+                name: id, 
+                meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
+              }; 
+            },
+      peg$c137 = function(id) { return { name: id } },
       peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
           const param = { 
-              type: tokens[0].optional 
-                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
-                  : NodeType.NAMED_PARAMETER, 
-              name: tokens[0].name, 
+              name: tokens[0].name,
+              type: NodeType.NAMED_PARAMETER,
               typeName: tokens[4] 
           };
+          if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
       peg$c139 = "...",
       peg$c140 = peg$literalExpectation("...", false),
       peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
         if (spread) {
         return {
           type: NodeType.VARIADIC,
@@ -5275,7 +5280,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseJsIdentifier();
+        s3 = peg$parseArrowTypeParamIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {

--- a/peg_lib/jsdoctype-jsdoc.js
+++ b/peg_lib/jsdoctype-jsdoc.js
@@ -568,43 +568,74 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { 
+      peg$c136 = function(id) { return { name: id } },
+      peg$c137 = function(id) { 
               return { 
                 name: id, 
                 meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
               }; 
             },
-      peg$c137 = function(id) { return { name: id } },
-      peg$c138 = function(paramsWithComma, lastParam) {
-        return paramsWithComma.reduceRight(function(params, tokens) {
+      peg$c138 = function(optionalParams, lastParam) {
+        const paramsArray = optionalParams.reduce((params, paramTokens) => {
+          const id = paramTokens[0];
           const param = { 
-              name: tokens[0].name,
+            type: NodeType.NAMED_PARAMETER,
+            name: id.name,
+            typeName: paramTokens[4]
+          };
+          if (id.meta) param.meta = id.meta;
+          params.push(param);
+          return params;
+        }, []);
+        if (lastParam) paramsArray.push(lastParam);
+
+        return paramsArray;
+      },
+      peg$c139 = function(requiredParams, finalParams) {
+        const paramsArray = requiredParams.reduce((params, paramTokens) => {
+          const param = {
+            type: NodeType.NAMED_PARAMETER,
+            name: paramTokens[0].name,
+            typeName: paramTokens[4]
+          }
+          params.push(param);
+          return params;
+        }, []);
+        return finalParams ? paramsArray.concat(finalParams) : paramsArray;
+          
+        return requiredParams.reduceRight(function(params, tokens) {
+          const param = { 
               type: NodeType.NAMED_PARAMETER,
+              name: tokens[0].name,
               typeName: tokens[4] 
           };
           if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
-        }, lastParam ? [lastParam] : []);
+        }, finalParams ? [finalParams] : []);
       },
-      peg$c139 = "...",
-      peg$c140 = peg$literalExpectation("...", false),
-      peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
-        if (id.meta) operand.meta = id.meta;
-        if (spread) {
+      peg$c140 = "...",
+      peg$c141 = peg$literalExpectation("...", false),
+      peg$c142 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         return {
           type: NodeType.VARIADIC,
           value: operand,
           meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
         };
-        }
-        else {
-          return operand;
-        }
       },
-      peg$c142 = "function",
-      peg$c143 = peg$literalExpectation("function", false),
-      peg$c144 = function(paramsPart, returnedTypePart) {
+      peg$c143 = function(id, type) { // TODO: Add default value support
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c144 = function(id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c145 = "function",
+      peg$c146 = peg$literalExpectation("function", false),
+      peg$c147 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -615,53 +646,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c145 = function(modifier, params) {
+      peg$c148 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c146 = function(modifier) {
+      peg$c149 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c147 = function() {
+      peg$c150 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c148 = function(params) {
+      peg$c151 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c149 = "this",
-      peg$c150 = peg$literalExpectation("this", false),
-      peg$c151 = function(modifierThis) {
+      peg$c152 = "this",
+      peg$c153 = peg$literalExpectation("this", false),
+      peg$c154 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c152 = function(modifierNew) {
+      peg$c155 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c153 = function(paramsWithComma, lastParam) {
+      peg$c156 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c154 = "{",
-      peg$c155 = peg$literalExpectation("{", false),
-      peg$c156 = "}",
-      peg$c157 = peg$literalExpectation("}", false),
-      peg$c158 = function(entries) {
+      peg$c157 = "{",
+      peg$c158 = peg$literalExpectation("{", false),
+      peg$c159 = "}",
+      peg$c160 = peg$literalExpectation("}", false),
+      peg$c161 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c159 = ";",
-      peg$c160 = peg$literalExpectation(";", false),
-      peg$c161 = function(first, restWithComma) {
+      peg$c162 = ";",
+      peg$c163 = peg$literalExpectation(";", false),
+      peg$c164 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c162 = "readonly",
-      peg$c163 = peg$literalExpectation("readonly", false),
-      peg$c164 = function(readonly, keyInfo, optional, value) {
+      peg$c165 = "readonly",
+      peg$c166 = peg$literalExpectation("readonly", false),
+      peg$c167 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -677,7 +708,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c165 = function(readonly, keyInfo) {
+      peg$c168 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -687,59 +718,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c166 = function(key) {
+      peg$c169 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c167 = function(key) {
+      peg$c170 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c168 = function(key) {
+      peg$c171 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c169 = function(entries) {
+      peg$c172 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c170 = function(restWithComma, last) {
+      peg$c173 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c171 = function(wrapped) {
+      peg$c174 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c172 = function(operand) {
+      peg$c175 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c173 = function(operand) {
+      peg$c176 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c174 = function() {
+      peg$c177 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -888,7 +919,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 0,
+    var key    = peg$currPos * 89 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -976,7 +1007,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 1,
+    var key    = peg$currPos * 89 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1033,7 +1064,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 2,
+    var key    = peg$currPos * 89 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1057,7 +1088,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 3,
+    var key    = peg$currPos * 89 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1085,7 +1116,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 82 + 4,
+    var key    = peg$currPos * 89 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1147,7 +1178,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 5,
+    var key    = peg$currPos * 89 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1286,7 +1317,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 6,
+    var key    = peg$currPos * 89 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1354,7 +1385,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 7,
+    var key    = peg$currPos * 89 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1613,7 +1644,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 82 + 8,
+    var key    = peg$currPos * 89 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1638,7 +1669,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 9,
+    var key    = peg$currPos * 89 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1741,7 +1772,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 10,
+    var key    = peg$currPos * 89 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1772,7 +1803,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 11,
+    var key    = peg$currPos * 89 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1803,7 +1834,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 12,
+    var key    = peg$currPos * 89 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1834,7 +1865,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 13,
+    var key    = peg$currPos * 89 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1859,7 +1890,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 82 + 14,
+    var key    = peg$currPos * 89 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2028,7 +2059,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 15,
+    var key    = peg$currPos * 89 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2092,7 +2123,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 16,
+    var key    = peg$currPos * 89 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2225,7 +2256,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 17,
+    var key    = peg$currPos * 89 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2511,7 +2542,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 18,
+    var key    = peg$currPos * 89 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2542,7 +2573,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 19,
+    var key    = peg$currPos * 89 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2573,7 +2604,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 20,
+    var key    = peg$currPos * 89 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2595,7 +2626,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 21,
+    var key    = peg$currPos * 89 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2845,7 +2876,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 22,
+    var key    = peg$currPos * 89 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2879,7 +2910,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 23,
+    var key    = peg$currPos * 89 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2936,7 +2967,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 24,
+    var key    = peg$currPos * 89 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3166,7 +3197,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 25,
+    var key    = peg$currPos * 89 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3247,7 +3278,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 26,
+    var key    = peg$currPos * 89 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3328,7 +3359,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 27,
+    var key    = peg$currPos * 89 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3409,7 +3440,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 28,
+    var key    = peg$currPos * 89 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3470,7 +3501,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 29,
+    var key    = peg$currPos * 89 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3528,7 +3559,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 30,
+    var key    = peg$currPos * 89 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3589,7 +3620,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 31,
+    var key    = peg$currPos * 89 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3647,7 +3678,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 32,
+    var key    = peg$currPos * 89 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3669,7 +3700,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 33,
+    var key    = peg$currPos * 89 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3691,7 +3722,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 34,
+    var key    = peg$currPos * 89 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3737,7 +3768,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 35,
+    var key    = peg$currPos * 89 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3783,7 +3814,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 36,
+    var key    = peg$currPos * 89 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3853,7 +3884,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 37,
+    var key    = peg$currPos * 89 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3914,7 +3945,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 38,
+    var key    = peg$currPos * 89 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3996,7 +4027,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 39,
+    var key    = peg$currPos * 89 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4042,7 +4073,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 40,
+    var key    = peg$currPos * 89 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4088,7 +4119,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 41,
+    var key    = peg$currPos * 89 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4113,7 +4144,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 42,
+    var key    = peg$currPos * 89 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4162,7 +4193,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 43,
+    var key    = peg$currPos * 89 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4208,7 +4239,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 44,
+    var key    = peg$currPos * 89 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4254,7 +4285,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 45,
+    var key    = peg$currPos * 89 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4306,7 +4337,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 46,
+    var key    = peg$currPos * 89 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4370,7 +4401,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 47,
+    var key    = peg$currPos * 89 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4401,7 +4432,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 48,
+    var key    = peg$currPos * 89 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4465,7 +4496,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 49,
+    var key    = peg$currPos * 89 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4568,7 +4599,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 50,
+    var key    = peg$currPos * 89 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4590,7 +4621,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 51,
+    var key    = peg$currPos * 89 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4621,7 +4652,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 52,
+    var key    = peg$currPos * 89 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4652,7 +4683,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 53,
+    var key    = peg$currPos * 89 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4677,7 +4708,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 54,
+    var key    = peg$currPos * 89 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4796,7 +4827,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 55,
+    var key    = peg$currPos * 89 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4851,7 +4882,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 56,
+    var key    = peg$currPos * 89 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4930,7 +4961,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 57,
+    var key    = peg$currPos * 89 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5027,10 +5058,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseArrowTypeParamIdentifier() {
+  function peg$parseArrowTypeRequiredParamEntry() {
+    var s0, s1;
+
+    var key    = peg$currPos * 89 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c136(s1);
+    }
+    s0 = s1;
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeOptionalParamEntry() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 58,
+    var key    = peg$currPos * 89 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5053,7 +5109,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5067,25 +5123,16 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseJsIdentifier();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137(s1);
-      }
-      s0 = s1;
-    }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
-  function peg$parseArrowTypeExprParams() {
+  function peg$parseArrowOptionalLastParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 82 + 59,
+    var key    = peg$currPos * 89 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5097,7 +5144,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseArrowTypeParamIdentifier();
+    s3 = peg$parseArrowTypeOptionalParamEntry();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
@@ -5165,7 +5212,7 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseArrowTypeParamIdentifier();
+      s3 = peg$parseArrowTypeOptionalParamEntry();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -5232,14 +5279,17 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseVariadicNameExpr();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c138(s1, s2);
-        s0 = s1;
+        s3 = peg$parseOptionalLastParamExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5254,10 +5304,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseVariadicNameExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseFinalParamsExpr() {
+    var s0;
 
-    var key    = peg$currPos * 82 + 60,
+    var key    = peg$currPos * 89 + 61,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseArrowOptionalLastParams();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredLastParamExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 89 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5267,20 +5339,192 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
-      peg$currPos += 3;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeRequiredParamEntry();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeRequiredParamEntry();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseArrowTypeParamIdentifier();
+        s3 = peg$parseFinalParamsExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c139(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseSpreadVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 89 + 63,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
@@ -5300,7 +5544,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c141(s1, s3, s7);
+                  s1 = peg$c142(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5336,10 +5580,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionTypeExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseRequiredVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 61,
+    var key    = peg$currPos * 89 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5349,12 +5593,178 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c142) {
-      s1 = peg$c142;
+    s1 = peg$parseArrowTypeRequiredParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c143(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 89 + 65,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseArrowTypeOptionalParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c144(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 66,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOptionalVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseRequiredLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 67,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFunctionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key    = peg$currPos * 89 + 68,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c145) {
+      s1 = peg$c145;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5395,7 +5805,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3, s5);
+              s1 = peg$c147(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5426,7 +5836,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 62,
+    var key    = peg$currPos * 89 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5473,7 +5883,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c145(s3, s7);
+                      s1 = peg$c148(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5536,7 +5946,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c146(s3);
+                s1 = peg$c149(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5579,7 +5989,7 @@ function peg$parse(input, options) {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147();
+              s1 = peg$c150();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5618,7 +6028,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c148(s3);
+                    s1 = peg$c151(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5652,7 +6062,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 63,
+    var key    = peg$currPos * 89 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5663,12 +6073,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c149) {
-      s2 = peg$c149;
+    if (input.substr(peg$currPos, 4) === peg$c152) {
+      s2 = peg$c152;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -5709,7 +6119,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c151(s1);
+      s1 = peg$c154(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5761,7 +6171,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152(s1);
+        s1 = peg$c155(s1);
       }
       s0 = s1;
     }
@@ -5774,7 +6184,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 64,
+    var key    = peg$currPos * 89 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5864,7 +6274,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c153(s1, s2);
+        s1 = peg$c156(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5883,7 +6293,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 65,
+    var key    = peg$currPos * 89 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5947,7 +6357,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 66,
+    var key    = peg$currPos * 89 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6005,7 +6415,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 67,
+    var key    = peg$currPos * 89 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6016,11 +6426,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c154;
+      s1 = peg$c157;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6033,15 +6443,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c156;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c157); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c158(s3);
+              s1 = peg$c161(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6072,7 +6482,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 68,
+    var key    = peg$currPos * 89 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6112,11 +6522,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c159;
+            s6 = peg$c162;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c163); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -6233,11 +6643,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c159;
+              s6 = peg$c162;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -6353,11 +6763,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c159;
+              s5 = peg$c162;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -6431,7 +6841,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c161(s1, s2);
+          s1 = peg$c164(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6454,7 +6864,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 82 + 69,
+    var key    = peg$currPos * 89 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6465,12 +6875,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c162) {
-      s2 = peg$c162;
+    if (input.substr(peg$currPos, 8) === peg$c165) {
+      s2 = peg$c165;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -6519,7 +6929,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c164(s1, s2, s4, s8);
+                    s1 = peg$c167(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6556,12 +6966,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c162) {
-        s2 = peg$c162;
+      if (input.substr(peg$currPos, 8) === peg$c165) {
+        s2 = peg$c165;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6583,7 +6993,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c165(s1, s2);
+          s1 = peg$c168(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6603,7 +7013,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 70,
+    var key    = peg$currPos * 89 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6713,7 +7123,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s2);
+          s1 = peg$c169(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6829,7 +7239,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s2);
+            s1 = peg$c170(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6857,7 +7267,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c168(s1);
+          s1 = peg$c171(s1);
         }
         s0 = s1;
       }
@@ -6871,7 +7281,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 71,
+    var key    = peg$currPos * 89 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6929,7 +7339,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 72,
+    var key    = peg$currPos * 89 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6962,7 +7372,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c169(s3);
+              s1 = peg$c172(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6993,7 +7403,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 73,
+    var key    = peg$currPos * 89 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7083,7 +7493,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c173(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7102,7 +7512,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 74,
+    var key    = peg$currPos * 89 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7166,7 +7576,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 75,
+    var key    = peg$currPos * 89 + 82,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7199,7 +7609,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c171(s3);
+              s1 = peg$c174(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7230,7 +7640,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 76,
+    var key    = peg$currPos * 89 + 83,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7291,7 +7701,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 77,
+    var key    = peg$currPos * 89 + 84,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7316,7 +7726,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 78,
+    var key    = peg$currPos * 89 + 85,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7326,18 +7736,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s2);
+        s1 = peg$c175(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7356,7 +7766,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 79,
+    var key    = peg$currPos * 89 + 86,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7368,16 +7778,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c139) {
-        s2 = peg$c139;
+      if (input.substr(peg$currPos, 3) === peg$c140) {
+        s2 = peg$c140;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173(s1);
+        s1 = peg$c176(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7396,7 +7806,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 80,
+    var key    = peg$currPos * 89 + 87,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7406,16 +7816,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174();
+      s1 = peg$c177();
     }
     s0 = s1;
 
@@ -7427,7 +7837,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 81,
+    var key    = peg$currPos * 89 + 88,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-permissive.js
+++ b/peg_lib/jsdoctype-permissive.js
@@ -568,24 +568,29 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { return { name: id, optional: true } },
-      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c136 = function(id) { 
+              return { 
+                name: id, 
+                meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
+              }; 
+            },
+      peg$c137 = function(id) { return { name: id } },
       peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
           const param = { 
-              type: tokens[0].optional 
-                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
-                  : NodeType.NAMED_PARAMETER, 
-              name: tokens[0].name, 
+              name: tokens[0].name,
+              type: NodeType.NAMED_PARAMETER,
               typeName: tokens[4] 
           };
+          if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
       peg$c139 = "...",
       peg$c140 = peg$literalExpectation("...", false),
       peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
         if (spread) {
         return {
           type: NodeType.VARIADIC,
@@ -5275,7 +5280,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseJsIdentifier();
+        s3 = peg$parseArrowTypeParamIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {

--- a/peg_lib/jsdoctype-permissive.js
+++ b/peg_lib/jsdoctype-permissive.js
@@ -568,15 +568,23 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(paramsWithComma, lastParam) {
+      peg$c136 = function(id) { return { name: id, optional: true } },
+      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
-          const param = { type: NodeType.NAMED_PARAMETER, name: tokens[0], typeName: tokens[4] };
+          const param = { 
+              type: tokens[0].optional 
+                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
+                  : NodeType.NAMED_PARAMETER, 
+              name: tokens[0].name, 
+              typeName: tokens[4] 
+          };
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
-      peg$c137 = "...",
-      peg$c138 = peg$literalExpectation("...", false),
-      peg$c139 = function(spread, id, type) {
+      peg$c139 = "...",
+      peg$c140 = peg$literalExpectation("...", false),
+      peg$c141 = function(spread, id, type) {
         const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         if (spread) {
         return {
@@ -589,9 +597,9 @@ function peg$parse(input, options) {
           return operand;
         }
       },
-      peg$c140 = "function",
-      peg$c141 = peg$literalExpectation("function", false),
-      peg$c142 = function(paramsPart, returnedTypePart) {
+      peg$c142 = "function",
+      peg$c143 = peg$literalExpectation("function", false),
+      peg$c144 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -602,53 +610,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c143 = function(modifier, params) {
+      peg$c145 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c144 = function(modifier) {
+      peg$c146 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c145 = function() {
+      peg$c147 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c146 = function(params) {
+      peg$c148 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c147 = "this",
-      peg$c148 = peg$literalExpectation("this", false),
-      peg$c149 = function(modifierThis) {
+      peg$c149 = "this",
+      peg$c150 = peg$literalExpectation("this", false),
+      peg$c151 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c150 = function(modifierNew) {
+      peg$c152 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c151 = function(paramsWithComma, lastParam) {
+      peg$c153 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c152 = "{",
-      peg$c153 = peg$literalExpectation("{", false),
-      peg$c154 = "}",
-      peg$c155 = peg$literalExpectation("}", false),
-      peg$c156 = function(entries) {
+      peg$c154 = "{",
+      peg$c155 = peg$literalExpectation("{", false),
+      peg$c156 = "}",
+      peg$c157 = peg$literalExpectation("}", false),
+      peg$c158 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c157 = ";",
-      peg$c158 = peg$literalExpectation(";", false),
-      peg$c159 = function(first, restWithComma) {
+      peg$c159 = ";",
+      peg$c160 = peg$literalExpectation(";", false),
+      peg$c161 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c160 = "readonly",
-      peg$c161 = peg$literalExpectation("readonly", false),
-      peg$c162 = function(readonly, keyInfo, optional, value) {
+      peg$c162 = "readonly",
+      peg$c163 = peg$literalExpectation("readonly", false),
+      peg$c164 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -664,7 +672,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c163 = function(readonly, keyInfo) {
+      peg$c165 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -674,59 +682,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c164 = function(key) {
+      peg$c166 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c165 = function(key) {
+      peg$c167 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c166 = function(key) {
+      peg$c168 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c167 = function(entries) {
+      peg$c169 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c168 = function(restWithComma, last) {
+      peg$c170 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c169 = function(wrapped) {
+      peg$c171 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c170 = function(operand) {
+      peg$c172 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c171 = function(operand) {
+      peg$c173 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c172 = function() {
+      peg$c174 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -875,7 +883,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 0,
+    var key    = peg$currPos * 82 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -963,7 +971,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 81 + 1,
+    var key    = peg$currPos * 82 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1020,7 +1028,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 2,
+    var key    = peg$currPos * 82 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1044,7 +1052,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 3,
+    var key    = peg$currPos * 82 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1072,7 +1080,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 81 + 4,
+    var key    = peg$currPos * 82 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1134,7 +1142,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 81 + 5,
+    var key    = peg$currPos * 82 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1273,7 +1281,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 6,
+    var key    = peg$currPos * 82 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1341,7 +1349,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 7,
+    var key    = peg$currPos * 82 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1600,7 +1608,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 81 + 8,
+    var key    = peg$currPos * 82 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1625,7 +1633,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 9,
+    var key    = peg$currPos * 82 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1728,7 +1736,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 10,
+    var key    = peg$currPos * 82 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1759,7 +1767,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 11,
+    var key    = peg$currPos * 82 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1790,7 +1798,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 12,
+    var key    = peg$currPos * 82 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1821,7 +1829,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 13,
+    var key    = peg$currPos * 82 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1846,7 +1854,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 81 + 14,
+    var key    = peg$currPos * 82 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2015,7 +2023,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 15,
+    var key    = peg$currPos * 82 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2079,7 +2087,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 81 + 16,
+    var key    = peg$currPos * 82 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2212,7 +2220,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 17,
+    var key    = peg$currPos * 82 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2498,7 +2506,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 18,
+    var key    = peg$currPos * 82 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2529,7 +2537,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 19,
+    var key    = peg$currPos * 82 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2560,7 +2568,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 20,
+    var key    = peg$currPos * 82 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2582,7 +2590,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 21,
+    var key    = peg$currPos * 82 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2832,7 +2840,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 22,
+    var key    = peg$currPos * 82 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2866,7 +2874,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 23,
+    var key    = peg$currPos * 82 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2923,7 +2931,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 24,
+    var key    = peg$currPos * 82 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3153,7 +3161,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 25,
+    var key    = peg$currPos * 82 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3234,7 +3242,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 26,
+    var key    = peg$currPos * 82 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3315,7 +3323,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 27,
+    var key    = peg$currPos * 82 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3396,7 +3404,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 28,
+    var key    = peg$currPos * 82 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3457,7 +3465,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 29,
+    var key    = peg$currPos * 82 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3515,7 +3523,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 30,
+    var key    = peg$currPos * 82 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3576,7 +3584,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 31,
+    var key    = peg$currPos * 82 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3634,7 +3642,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 32,
+    var key    = peg$currPos * 82 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3656,7 +3664,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 33,
+    var key    = peg$currPos * 82 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3678,7 +3686,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 34,
+    var key    = peg$currPos * 82 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3724,7 +3732,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 35,
+    var key    = peg$currPos * 82 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3770,7 +3778,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 36,
+    var key    = peg$currPos * 82 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3840,7 +3848,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 37,
+    var key    = peg$currPos * 82 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3901,7 +3909,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 38,
+    var key    = peg$currPos * 82 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3983,7 +3991,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 39,
+    var key    = peg$currPos * 82 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4029,7 +4037,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 40,
+    var key    = peg$currPos * 82 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4075,7 +4083,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 41,
+    var key    = peg$currPos * 82 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4100,7 +4108,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 42,
+    var key    = peg$currPos * 82 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4149,7 +4157,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 43,
+    var key    = peg$currPos * 82 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4195,7 +4203,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 44,
+    var key    = peg$currPos * 82 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4241,7 +4249,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 81 + 45,
+    var key    = peg$currPos * 82 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4293,7 +4301,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 46,
+    var key    = peg$currPos * 82 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4357,7 +4365,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 47,
+    var key    = peg$currPos * 82 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4388,7 +4396,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 48,
+    var key    = peg$currPos * 82 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4452,7 +4460,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 49,
+    var key    = peg$currPos * 82 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4555,7 +4563,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 81 + 50,
+    var key    = peg$currPos * 82 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4577,7 +4585,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 51,
+    var key    = peg$currPos * 82 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4608,7 +4616,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 52,
+    var key    = peg$currPos * 82 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4639,7 +4647,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 81 + 53,
+    var key    = peg$currPos * 82 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4664,7 +4672,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 54,
+    var key    = peg$currPos * 82 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4783,7 +4791,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 55,
+    var key    = peg$currPos * 82 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4838,7 +4846,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 56,
+    var key    = peg$currPos * 82 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4917,7 +4925,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 57,
+    var key    = peg$currPos * 82 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5014,10 +5022,65 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseArrowTypeParamIdentifier() {
+    var s0, s1, s2, s3;
+
+    var key    = peg$currPos * 82 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c58;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseJsIdentifier();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137(s1);
+      }
+      s0 = s1;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
   function peg$parseArrowTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 81 + 58,
+    var key    = peg$currPos * 82 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5029,7 +5092,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseJsIdentifier();
+    s3 = peg$parseArrowTypeParamIdentifier();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
@@ -5097,7 +5160,7 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseJsIdentifier();
+      s3 = peg$parseArrowTypeParamIdentifier();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -5170,7 +5233,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c136(s1, s2);
+        s1 = peg$c138(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5189,7 +5252,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 59,
+    var key    = peg$currPos * 82 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5199,12 +5262,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c137) {
-      s1 = peg$c137;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -5232,7 +5295,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c139(s1, s3, s7);
+                  s1 = peg$c141(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5271,7 +5334,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 81 + 60,
+    var key    = peg$currPos * 82 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5281,12 +5344,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c140) {
-      s1 = peg$c140;
+    if (input.substr(peg$currPos, 8) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5327,7 +5390,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c142(s3, s5);
+              s1 = peg$c144(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5358,7 +5421,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 81 + 61,
+    var key    = peg$currPos * 82 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5405,7 +5468,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c143(s3, s7);
+                      s1 = peg$c145(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5468,7 +5531,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c144(s3);
+                s1 = peg$c146(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5511,7 +5574,7 @@ function peg$parse(input, options) {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c145();
+              s1 = peg$c147();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5550,7 +5613,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c146(s3);
+                    s1 = peg$c148(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5584,7 +5647,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 62,
+    var key    = peg$currPos * 82 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5595,12 +5658,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c147) {
-      s2 = peg$c147;
+    if (input.substr(peg$currPos, 4) === peg$c149) {
+      s2 = peg$c149;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c148); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -5641,7 +5704,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c149(s1);
+      s1 = peg$c151(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5693,7 +5756,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c150(s1);
+        s1 = peg$c152(s1);
       }
       s0 = s1;
     }
@@ -5706,7 +5769,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 63,
+    var key    = peg$currPos * 82 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5796,7 +5859,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c151(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5815,7 +5878,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 64,
+    var key    = peg$currPos * 82 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5879,7 +5942,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 65,
+    var key    = peg$currPos * 82 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5937,7 +6000,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 66,
+    var key    = peg$currPos * 82 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5948,11 +6011,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c152;
+      s1 = peg$c154;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c153); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5965,15 +6028,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c154;
+              s5 = peg$c156;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c155); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c156(s3);
+              s1 = peg$c158(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6004,7 +6067,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 81 + 67,
+    var key    = peg$currPos * 82 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6044,11 +6107,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c157;
+            s6 = peg$c159;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c158); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -6165,11 +6228,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c157;
+              s6 = peg$c159;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c158); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -6285,11 +6348,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c157;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c158); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -6363,7 +6426,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c159(s1, s2);
+          s1 = peg$c161(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6386,7 +6449,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 81 + 68,
+    var key    = peg$currPos * 82 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6397,12 +6460,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c160) {
-      s2 = peg$c160;
+    if (input.substr(peg$currPos, 8) === peg$c162) {
+      s2 = peg$c162;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c161); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -6451,7 +6514,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c162(s1, s2, s4, s8);
+                    s1 = peg$c164(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6488,12 +6551,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c160) {
-        s2 = peg$c160;
+      if (input.substr(peg$currPos, 8) === peg$c162) {
+        s2 = peg$c162;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c161); }
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6515,7 +6578,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c163(s1, s2);
+          s1 = peg$c165(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6535,7 +6598,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 69,
+    var key    = peg$currPos * 82 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6645,7 +6708,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c164(s2);
+          s1 = peg$c166(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6761,7 +6824,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c165(s2);
+            s1 = peg$c167(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6789,7 +6852,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s1);
+          s1 = peg$c168(s1);
         }
         s0 = s1;
       }
@@ -6803,7 +6866,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 70,
+    var key    = peg$currPos * 82 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6861,7 +6924,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 71,
+    var key    = peg$currPos * 82 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6894,7 +6957,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c167(s3);
+              s1 = peg$c169(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6925,7 +6988,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 81 + 72,
+    var key    = peg$currPos * 82 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7015,7 +7078,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c168(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7034,7 +7097,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 73,
+    var key    = peg$currPos * 82 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7098,7 +7161,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 81 + 74,
+    var key    = peg$currPos * 82 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7131,7 +7194,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c169(s3);
+              s1 = peg$c171(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7162,7 +7225,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 75,
+    var key    = peg$currPos * 82 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7223,7 +7286,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 81 + 76,
+    var key    = peg$currPos * 82 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7248,7 +7311,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 81 + 77,
+    var key    = peg$currPos * 82 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7258,18 +7321,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c137) {
-      s1 = peg$c137;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7288,7 +7351,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 81 + 78,
+    var key    = peg$currPos * 82 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7300,16 +7363,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c137) {
-        s2 = peg$c137;
+      if (input.substr(peg$currPos, 3) === peg$c139) {
+        s2 = peg$c139;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c138); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c171(s1);
+        s1 = peg$c173(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7328,7 +7391,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 81 + 79,
+    var key    = peg$currPos * 82 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7338,16 +7401,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c137) {
-      s1 = peg$c137;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c138); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c172();
+      s1 = peg$c174();
     }
     s0 = s1;
 
@@ -7359,7 +7422,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 81 + 80,
+    var key    = peg$currPos * 82 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-permissive.js
+++ b/peg_lib/jsdoctype-permissive.js
@@ -568,43 +568,74 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { 
+      peg$c136 = function(id) { return { name: id } },
+      peg$c137 = function(id) { 
               return { 
                 name: id, 
                 meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
               }; 
             },
-      peg$c137 = function(id) { return { name: id } },
-      peg$c138 = function(paramsWithComma, lastParam) {
-        return paramsWithComma.reduceRight(function(params, tokens) {
+      peg$c138 = function(optionalParams, lastParam) {
+        const paramsArray = optionalParams.reduce((params, paramTokens) => {
+          const id = paramTokens[0];
           const param = { 
-              name: tokens[0].name,
+            type: NodeType.NAMED_PARAMETER,
+            name: id.name,
+            typeName: paramTokens[4]
+          };
+          if (id.meta) param.meta = id.meta;
+          params.push(param);
+          return params;
+        }, []);
+        if (lastParam) paramsArray.push(lastParam);
+
+        return paramsArray;
+      },
+      peg$c139 = function(requiredParams, finalParams) {
+        const paramsArray = requiredParams.reduce((params, paramTokens) => {
+          const param = {
+            type: NodeType.NAMED_PARAMETER,
+            name: paramTokens[0].name,
+            typeName: paramTokens[4]
+          }
+          params.push(param);
+          return params;
+        }, []);
+        return finalParams ? paramsArray.concat(finalParams) : paramsArray;
+          
+        return requiredParams.reduceRight(function(params, tokens) {
+          const param = { 
               type: NodeType.NAMED_PARAMETER,
+              name: tokens[0].name,
               typeName: tokens[4] 
           };
           if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
-        }, lastParam ? [lastParam] : []);
+        }, finalParams ? [finalParams] : []);
       },
-      peg$c139 = "...",
-      peg$c140 = peg$literalExpectation("...", false),
-      peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
-        if (id.meta) operand.meta = id.meta;
-        if (spread) {
+      peg$c140 = "...",
+      peg$c141 = peg$literalExpectation("...", false),
+      peg$c142 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         return {
           type: NodeType.VARIADIC,
           value: operand,
           meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
         };
-        }
-        else {
-          return operand;
-        }
       },
-      peg$c142 = "function",
-      peg$c143 = peg$literalExpectation("function", false),
-      peg$c144 = function(paramsPart, returnedTypePart) {
+      peg$c143 = function(id, type) { // TODO: Add default value support
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c144 = function(id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c145 = "function",
+      peg$c146 = peg$literalExpectation("function", false),
+      peg$c147 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -615,53 +646,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c145 = function(modifier, params) {
+      peg$c148 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c146 = function(modifier) {
+      peg$c149 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c147 = function() {
+      peg$c150 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c148 = function(params) {
+      peg$c151 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c149 = "this",
-      peg$c150 = peg$literalExpectation("this", false),
-      peg$c151 = function(modifierThis) {
+      peg$c152 = "this",
+      peg$c153 = peg$literalExpectation("this", false),
+      peg$c154 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c152 = function(modifierNew) {
+      peg$c155 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c153 = function(paramsWithComma, lastParam) {
+      peg$c156 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c154 = "{",
-      peg$c155 = peg$literalExpectation("{", false),
-      peg$c156 = "}",
-      peg$c157 = peg$literalExpectation("}", false),
-      peg$c158 = function(entries) {
+      peg$c157 = "{",
+      peg$c158 = peg$literalExpectation("{", false),
+      peg$c159 = "}",
+      peg$c160 = peg$literalExpectation("}", false),
+      peg$c161 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c159 = ";",
-      peg$c160 = peg$literalExpectation(";", false),
-      peg$c161 = function(first, restWithComma) {
+      peg$c162 = ";",
+      peg$c163 = peg$literalExpectation(";", false),
+      peg$c164 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c162 = "readonly",
-      peg$c163 = peg$literalExpectation("readonly", false),
-      peg$c164 = function(readonly, keyInfo, optional, value) {
+      peg$c165 = "readonly",
+      peg$c166 = peg$literalExpectation("readonly", false),
+      peg$c167 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -677,7 +708,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c165 = function(readonly, keyInfo) {
+      peg$c168 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -687,59 +718,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c166 = function(key) {
+      peg$c169 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c167 = function(key) {
+      peg$c170 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c168 = function(key) {
+      peg$c171 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c169 = function(entries) {
+      peg$c172 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c170 = function(restWithComma, last) {
+      peg$c173 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c171 = function(wrapped) {
+      peg$c174 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c172 = function(operand) {
+      peg$c175 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c173 = function(operand) {
+      peg$c176 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c174 = function() {
+      peg$c177 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -888,7 +919,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 0,
+    var key    = peg$currPos * 89 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -976,7 +1007,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 1,
+    var key    = peg$currPos * 89 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1033,7 +1064,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 2,
+    var key    = peg$currPos * 89 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1057,7 +1088,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 3,
+    var key    = peg$currPos * 89 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1085,7 +1116,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 82 + 4,
+    var key    = peg$currPos * 89 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1147,7 +1178,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 5,
+    var key    = peg$currPos * 89 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1286,7 +1317,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 6,
+    var key    = peg$currPos * 89 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1354,7 +1385,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 7,
+    var key    = peg$currPos * 89 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1613,7 +1644,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 82 + 8,
+    var key    = peg$currPos * 89 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1638,7 +1669,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 9,
+    var key    = peg$currPos * 89 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1741,7 +1772,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 10,
+    var key    = peg$currPos * 89 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1772,7 +1803,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 11,
+    var key    = peg$currPos * 89 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1803,7 +1834,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 12,
+    var key    = peg$currPos * 89 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1834,7 +1865,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 13,
+    var key    = peg$currPos * 89 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1859,7 +1890,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 82 + 14,
+    var key    = peg$currPos * 89 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2028,7 +2059,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 15,
+    var key    = peg$currPos * 89 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2092,7 +2123,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 16,
+    var key    = peg$currPos * 89 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2225,7 +2256,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 17,
+    var key    = peg$currPos * 89 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2511,7 +2542,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 18,
+    var key    = peg$currPos * 89 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2542,7 +2573,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 19,
+    var key    = peg$currPos * 89 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2573,7 +2604,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 20,
+    var key    = peg$currPos * 89 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2595,7 +2626,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 21,
+    var key    = peg$currPos * 89 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2845,7 +2876,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 22,
+    var key    = peg$currPos * 89 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2879,7 +2910,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 23,
+    var key    = peg$currPos * 89 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2936,7 +2967,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 24,
+    var key    = peg$currPos * 89 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3166,7 +3197,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 25,
+    var key    = peg$currPos * 89 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3247,7 +3278,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 26,
+    var key    = peg$currPos * 89 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3328,7 +3359,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 27,
+    var key    = peg$currPos * 89 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3409,7 +3440,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 28,
+    var key    = peg$currPos * 89 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3470,7 +3501,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 29,
+    var key    = peg$currPos * 89 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3528,7 +3559,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 30,
+    var key    = peg$currPos * 89 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3589,7 +3620,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 31,
+    var key    = peg$currPos * 89 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3647,7 +3678,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 32,
+    var key    = peg$currPos * 89 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3669,7 +3700,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 33,
+    var key    = peg$currPos * 89 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3691,7 +3722,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 34,
+    var key    = peg$currPos * 89 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3737,7 +3768,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 35,
+    var key    = peg$currPos * 89 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3783,7 +3814,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 36,
+    var key    = peg$currPos * 89 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3853,7 +3884,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 37,
+    var key    = peg$currPos * 89 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3914,7 +3945,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 38,
+    var key    = peg$currPos * 89 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3996,7 +4027,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 39,
+    var key    = peg$currPos * 89 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4042,7 +4073,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 40,
+    var key    = peg$currPos * 89 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4088,7 +4119,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 41,
+    var key    = peg$currPos * 89 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4113,7 +4144,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 42,
+    var key    = peg$currPos * 89 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4162,7 +4193,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 43,
+    var key    = peg$currPos * 89 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4208,7 +4239,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 44,
+    var key    = peg$currPos * 89 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4254,7 +4285,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 45,
+    var key    = peg$currPos * 89 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4306,7 +4337,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 46,
+    var key    = peg$currPos * 89 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4370,7 +4401,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 47,
+    var key    = peg$currPos * 89 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4401,7 +4432,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 48,
+    var key    = peg$currPos * 89 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4465,7 +4496,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 49,
+    var key    = peg$currPos * 89 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4568,7 +4599,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 50,
+    var key    = peg$currPos * 89 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4590,7 +4621,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 51,
+    var key    = peg$currPos * 89 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4621,7 +4652,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 52,
+    var key    = peg$currPos * 89 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4652,7 +4683,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 53,
+    var key    = peg$currPos * 89 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4677,7 +4708,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 54,
+    var key    = peg$currPos * 89 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4796,7 +4827,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 55,
+    var key    = peg$currPos * 89 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4851,7 +4882,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 56,
+    var key    = peg$currPos * 89 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4930,7 +4961,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 57,
+    var key    = peg$currPos * 89 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5027,10 +5058,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseArrowTypeParamIdentifier() {
+  function peg$parseArrowTypeRequiredParamEntry() {
+    var s0, s1;
+
+    var key    = peg$currPos * 89 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c136(s1);
+    }
+    s0 = s1;
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeOptionalParamEntry() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 58,
+    var key    = peg$currPos * 89 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5053,7 +5109,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5067,25 +5123,16 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseJsIdentifier();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137(s1);
-      }
-      s0 = s1;
-    }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
-  function peg$parseArrowTypeExprParams() {
+  function peg$parseArrowOptionalLastParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 82 + 59,
+    var key    = peg$currPos * 89 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5097,7 +5144,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseArrowTypeParamIdentifier();
+    s3 = peg$parseArrowTypeOptionalParamEntry();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
@@ -5165,7 +5212,7 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseArrowTypeParamIdentifier();
+      s3 = peg$parseArrowTypeOptionalParamEntry();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -5232,14 +5279,17 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseVariadicNameExpr();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c138(s1, s2);
-        s0 = s1;
+        s3 = peg$parseOptionalLastParamExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5254,10 +5304,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseVariadicNameExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseFinalParamsExpr() {
+    var s0;
 
-    var key    = peg$currPos * 82 + 60,
+    var key    = peg$currPos * 89 + 61,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseArrowOptionalLastParams();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredLastParamExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 89 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5267,20 +5339,192 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
-      peg$currPos += 3;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeRequiredParamEntry();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeRequiredParamEntry();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseArrowTypeParamIdentifier();
+        s3 = peg$parseFinalParamsExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c139(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseSpreadVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 89 + 63,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
@@ -5300,7 +5544,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c141(s1, s3, s7);
+                  s1 = peg$c142(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5336,10 +5580,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionTypeExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseRequiredVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 61,
+    var key    = peg$currPos * 89 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5349,12 +5593,178 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c142) {
-      s1 = peg$c142;
+    s1 = peg$parseArrowTypeRequiredParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c143(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 89 + 65,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseArrowTypeOptionalParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c144(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 66,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOptionalVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseRequiredLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 67,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFunctionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key    = peg$currPos * 89 + 68,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c145) {
+      s1 = peg$c145;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5395,7 +5805,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3, s5);
+              s1 = peg$c147(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5426,7 +5836,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 62,
+    var key    = peg$currPos * 89 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5473,7 +5883,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c145(s3, s7);
+                      s1 = peg$c148(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5536,7 +5946,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c146(s3);
+                s1 = peg$c149(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5579,7 +5989,7 @@ function peg$parse(input, options) {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147();
+              s1 = peg$c150();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5618,7 +6028,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c148(s3);
+                    s1 = peg$c151(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5652,7 +6062,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 63,
+    var key    = peg$currPos * 89 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5663,12 +6073,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c149) {
-      s2 = peg$c149;
+    if (input.substr(peg$currPos, 4) === peg$c152) {
+      s2 = peg$c152;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -5709,7 +6119,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c151(s1);
+      s1 = peg$c154(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5761,7 +6171,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152(s1);
+        s1 = peg$c155(s1);
       }
       s0 = s1;
     }
@@ -5774,7 +6184,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 64,
+    var key    = peg$currPos * 89 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5864,7 +6274,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c153(s1, s2);
+        s1 = peg$c156(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5883,7 +6293,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 65,
+    var key    = peg$currPos * 89 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5947,7 +6357,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 66,
+    var key    = peg$currPos * 89 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6005,7 +6415,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 67,
+    var key    = peg$currPos * 89 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6016,11 +6426,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c154;
+      s1 = peg$c157;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6033,15 +6443,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c156;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c157); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c158(s3);
+              s1 = peg$c161(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6072,7 +6482,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 68,
+    var key    = peg$currPos * 89 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6112,11 +6522,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c159;
+            s6 = peg$c162;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c163); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -6233,11 +6643,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c159;
+              s6 = peg$c162;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -6353,11 +6763,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c159;
+              s5 = peg$c162;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -6431,7 +6841,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c161(s1, s2);
+          s1 = peg$c164(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6454,7 +6864,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 82 + 69,
+    var key    = peg$currPos * 89 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6465,12 +6875,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c162) {
-      s2 = peg$c162;
+    if (input.substr(peg$currPos, 8) === peg$c165) {
+      s2 = peg$c165;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -6519,7 +6929,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c164(s1, s2, s4, s8);
+                    s1 = peg$c167(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6556,12 +6966,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c162) {
-        s2 = peg$c162;
+      if (input.substr(peg$currPos, 8) === peg$c165) {
+        s2 = peg$c165;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6583,7 +6993,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c165(s1, s2);
+          s1 = peg$c168(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6603,7 +7013,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 70,
+    var key    = peg$currPos * 89 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6713,7 +7123,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s2);
+          s1 = peg$c169(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6829,7 +7239,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s2);
+            s1 = peg$c170(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6857,7 +7267,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c168(s1);
+          s1 = peg$c171(s1);
         }
         s0 = s1;
       }
@@ -6871,7 +7281,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 71,
+    var key    = peg$currPos * 89 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6929,7 +7339,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 72,
+    var key    = peg$currPos * 89 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6962,7 +7372,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c169(s3);
+              s1 = peg$c172(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6993,7 +7403,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 73,
+    var key    = peg$currPos * 89 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7083,7 +7493,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c173(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7102,7 +7512,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 74,
+    var key    = peg$currPos * 89 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7166,7 +7576,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 75,
+    var key    = peg$currPos * 89 + 82,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7199,7 +7609,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c171(s3);
+              s1 = peg$c174(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7230,7 +7640,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 76,
+    var key    = peg$currPos * 89 + 83,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7291,7 +7701,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 77,
+    var key    = peg$currPos * 89 + 84,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7316,7 +7726,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 78,
+    var key    = peg$currPos * 89 + 85,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7326,18 +7736,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s2);
+        s1 = peg$c175(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7356,7 +7766,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 79,
+    var key    = peg$currPos * 89 + 86,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7368,16 +7778,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c139) {
-        s2 = peg$c139;
+      if (input.substr(peg$currPos, 3) === peg$c140) {
+        s2 = peg$c140;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173(s1);
+        s1 = peg$c176(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7396,7 +7806,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 80,
+    var key    = peg$currPos * 89 + 87,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7406,16 +7816,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174();
+      s1 = peg$c177();
     }
     s0 = s1;
 
@@ -7427,7 +7837,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 81,
+    var key    = peg$currPos * 89 + 88,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_lib/jsdoctype-typescript.js
+++ b/peg_lib/jsdoctype-typescript.js
@@ -257,17 +257,132 @@ function peg$parse(input, options) {
       peg$c40 = function() {
                                    return NamepathOperatorType.INSTANCE_MEMBER;
                                  },
-      peg$c41 = "*",
-      peg$c42 = peg$literalExpectation("*", false),
-      peg$c43 = function() {
+      peg$c41 = "external",
+      peg$c42 = peg$literalExpectation("external", false),
+      peg$c43 = ":",
+      peg$c44 = peg$literalExpectation(":", false),
+      peg$c45 = function(external, memberPartWithOperators) {
+                return memberPartWithOperators.reduce(function(owner, tokens) {
+                  const operatorType = tokens[1];
+                  const eventNamespace = tokens[3];
+                  const MemberName = tokens[5];
+                  const {quoteStyle, name: memberName} = MemberName;
+
+                  switch (operatorType) {
+                    case NamepathOperatorType.MEMBER:
+                      return {
+                        type: NodeType.MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    case NamepathOperatorType.INSTANCE_MEMBER:
+                      return {
+                        type: NodeType.INSTANCE_MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    case NamepathOperatorType.INNER_MEMBER:
+                      return {
+                        type: NodeType.INNER_MEMBER,
+                        owner,
+                        name: memberName,
+                        quoteStyle,
+                        hasEventPrefix: Boolean(eventNamespace),
+                      };
+                    /* istanbul ignore next */
+                    default:
+                      throw new Error('Unexpected operator type: "' + operatorType + '"');
+                  }
+                }, Object.assign({
+                  type: NodeType.EXTERNAL
+                }, external));
+              },
+      peg$c46 = "module",
+      peg$c47 = peg$literalExpectation("module", false),
+      peg$c48 = function(value) {
+                       return {
+                         type: NodeType.MODULE,
+                         value,
+                       };
+                     },
+      peg$c49 = function(rootOwner, memberPartWithOperators) {
+                       return memberPartWithOperators.reduce(function(owner, tokens) {
+                         const operatorType = tokens[1];
+                         const eventNamespace = tokens[3];
+                         const MemberName = tokens[5];
+                         const {quoteStyle, name: memberName} = MemberName;
+
+                         switch (operatorType) {
+                           case NamepathOperatorType.MEMBER:
+                             return {
+                               type: NodeType.MEMBER,
+                               owner,
+                               name: memberName,
+                               quoteStyle,
+                               hasEventPrefix: Boolean(eventNamespace),
+                             };
+                           case NamepathOperatorType.INSTANCE_MEMBER:
+                             return {
+                               type: NodeType.INSTANCE_MEMBER,
+                               owner,
+                               name: memberName,
+                               quoteStyle,
+                               hasEventPrefix: Boolean(eventNamespace),
+                             };
+                           case NamepathOperatorType.INNER_MEMBER:
+                             return {
+                               type: NodeType.INNER_MEMBER,
+                               owner,
+                               name: memberName,
+                               quoteStyle,
+                               hasEventPrefix: Boolean(eventNamespace),
+                             };
+                           /* istanbul ignore next */
+                           default:
+                             throw new Error('Unexpected operator type: "' + operatorType + '"');
+                         }
+                       }, rootOwner);
+                     },
+      peg$c50 = function(path) {
+                      return {
+                        quoteStyle: 'single',
+                        type: NodeType.FILE_PATH,
+                        path: path.replace(/\\'/g, "'")
+                          .replace(/\\\\/gu, '\\')
+                      };
+                    },
+      peg$c51 = function(path) {
+                      return {
+                        quoteStyle: 'double',
+                        type: NodeType.FILE_PATH,
+                        path: path.replace(/\\"/gu, '"')
+                         .replace(/\\\\/gu, '\\')
+                      };
+                    },
+      peg$c52 = /^[a-zA-Z0-9_$\/\-]/,
+      peg$c53 = peg$classExpectation([["a", "z"], ["A", "Z"], ["0", "9"], "_", "$", "/", "-"], false, false),
+      peg$c54 = function(path) {
+                     return {
+                       quoteStyle: 'none',
+                       type: NodeType.FILE_PATH,
+                       path,
+                     };
+                   },
+      peg$c55 = "*",
+      peg$c56 = peg$literalExpectation("*", false),
+      peg$c57 = function() {
                     return { type: NodeType.ANY };
                   },
-      peg$c44 = "?",
-      peg$c45 = peg$literalExpectation("?", false),
-      peg$c46 = function() {
+      peg$c58 = "?",
+      peg$c59 = peg$literalExpectation("?", false),
+      peg$c60 = function() {
                         return { type: NodeType.UNKNOWN };
                       },
-      peg$c47 = function(value) {
+      peg$c61 = function(value) {
                             return {
                               type: NodeType.STRING_VALUE,
                               quoteStyle: 'double',
@@ -275,7 +390,7 @@ function peg$parse(input, options) {
                                   .replace(/\\\\/gu, '\\')
                             };
                           },
-      peg$c48 = function(value) {
+      peg$c62 = function(value) {
                             return {
                               type: NodeType.STRING_VALUE,
                               quoteStyle: 'single',
@@ -283,115 +398,115 @@ function peg$parse(input, options) {
                                   .replace(/\\\\/gu, '\\')
                             };
                           },
-      peg$c49 = function(value) {
+      peg$c63 = function(value) {
                           return {
                             type: NodeType.NUMBER_VALUE,
                             number: value
                           };
                         },
-      peg$c50 = "+",
-      peg$c51 = peg$literalExpectation("+", false),
-      peg$c52 = "-",
-      peg$c53 = peg$literalExpectation("-", false),
-      peg$c54 = /^[0-9]/,
-      peg$c55 = peg$classExpectation([["0", "9"]], false, false),
-      peg$c56 = "e",
-      peg$c57 = peg$literalExpectation("e", false),
-      peg$c58 = "0b",
-      peg$c59 = peg$literalExpectation("0b", false),
-      peg$c60 = /^[01]/,
-      peg$c61 = peg$classExpectation(["0", "1"], false, false),
-      peg$c62 = "0o",
-      peg$c63 = peg$literalExpectation("0o", false),
-      peg$c64 = /^[0-7]/,
-      peg$c65 = peg$classExpectation([["0", "7"]], false, false),
-      peg$c66 = "0x",
-      peg$c67 = peg$literalExpectation("0x", false),
-      peg$c68 = /^[0-9a-fA-F]/,
-      peg$c69 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
-      peg$c70 = "&",
-      peg$c71 = peg$literalExpectation("&", false),
-      peg$c72 = function(left, right) {
+      peg$c64 = "+",
+      peg$c65 = peg$literalExpectation("+", false),
+      peg$c66 = "-",
+      peg$c67 = peg$literalExpectation("-", false),
+      peg$c68 = /^[0-9]/,
+      peg$c69 = peg$classExpectation([["0", "9"]], false, false),
+      peg$c70 = "e",
+      peg$c71 = peg$literalExpectation("e", false),
+      peg$c72 = "0b",
+      peg$c73 = peg$literalExpectation("0b", false),
+      peg$c74 = /^[01]/,
+      peg$c75 = peg$classExpectation(["0", "1"], false, false),
+      peg$c76 = "0o",
+      peg$c77 = peg$literalExpectation("0o", false),
+      peg$c78 = /^[0-7]/,
+      peg$c79 = peg$classExpectation([["0", "7"]], false, false),
+      peg$c80 = "0x",
+      peg$c81 = peg$literalExpectation("0x", false),
+      peg$c82 = /^[0-9a-fA-F]/,
+      peg$c83 = peg$classExpectation([["0", "9"], ["a", "f"], ["A", "F"]], false, false),
+      peg$c84 = "&",
+      peg$c85 = peg$literalExpectation("&", false),
+      peg$c86 = function(left, right) {
                       return {
                           type: NodeType.INTERSECTION,
                           left,
                           right,
                       };
                     },
-      peg$c73 = "|",
-      peg$c74 = peg$literalExpectation("|", false),
-      peg$c75 = function(left, right) {
+      peg$c87 = "|",
+      peg$c88 = peg$literalExpectation("|", false),
+      peg$c89 = function(left, right) {
                       return {
                           type: NodeType.UNION,
                           left,
                           right,
                       };
                     },
-      peg$c76 = "typeof",
-      peg$c77 = peg$literalExpectation("typeof", false),
-      peg$c78 = function(operator, name) {
+      peg$c90 = "typeof",
+      peg$c91 = peg$literalExpectation("typeof", false),
+      peg$c92 = function(operator, name) {
                       return {
                           type: NodeType.TYPE_QUERY,
                           name,
                       };
                     },
-      peg$c79 = "keyof",
-      peg$c80 = peg$literalExpectation("keyof", false),
-      peg$c81 = function(operator, operand) {
+      peg$c93 = "keyof",
+      peg$c94 = peg$literalExpectation("keyof", false),
+      peg$c95 = function(operator, operand) {
           return {
             type: NodeType.KEY_QUERY,
             value: operand,
           }
         },
-      peg$c82 = "import",
-      peg$c83 = peg$literalExpectation("import", false),
-      peg$c84 = "(",
-      peg$c85 = peg$literalExpectation("(", false),
-      peg$c86 = ")",
-      peg$c87 = peg$literalExpectation(")", false),
-      peg$c88 = function(operator, path) {
+      peg$c96 = "import",
+      peg$c97 = peg$literalExpectation("import", false),
+      peg$c98 = "(",
+      peg$c99 = peg$literalExpectation("(", false),
+      peg$c100 = ")",
+      peg$c101 = peg$literalExpectation(")", false),
+      peg$c102 = function(operator, path) {
                        return { type: NodeType.IMPORT, path };
                      },
-      peg$c89 = function(operator, operand) {
+      peg$c103 = function(operator, operand) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.PREFIX_QUESTION_MARK },
                                };
                              },
-      peg$c90 = "!",
-      peg$c91 = peg$literalExpectation("!", false),
-      peg$c92 = function(operator, operand) {
+      peg$c104 = "!",
+      peg$c105 = peg$literalExpectation("!", false),
+      peg$c106 = function(operator, operand) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.PREFIX_BANG },
                                   };
                                 },
-      peg$c93 = function(operand, operator) {
+      peg$c107 = function(operand, operator) {
                                return {
                                  type: NodeType.NULLABLE,
                                  value: operand,
                                  meta: { syntax: NullableTypeSyntax.SUFFIX_QUESTION_MARK },
                                };
                              },
-      peg$c94 = function(operand, operator) {
+      peg$c108 = function(operand, operator) {
                                   return {
                                     type: NodeType.NOT_NULLABLE,
                                     value: operand,
                                     meta: { syntax: NotNullableTypeSyntax.SUFFIX_BANG },
                                   };
                                 },
-      peg$c95 = "=",
-      peg$c96 = peg$literalExpectation("=", false),
-      peg$c97 = function(operand, operator) {
+      peg$c109 = "=",
+      peg$c110 = peg$literalExpectation("=", false),
+      peg$c111 = function(operand, operator) {
                                return {
                                  type: NodeType.OPTIONAL,
                                  value: operand,
                                  meta: { syntax: OptionalTypeSyntax.SUFFIX_EQUALS_SIGN },
                                };
                              },
-      peg$c98 = function(operand, syntax, params) {
+      peg$c112 = function(operand, syntax, params) {
                         return {
                           type: NodeType.GENERIC,
                           subject: operand,
@@ -399,30 +514,30 @@ function peg$parse(input, options) {
                           meta: { syntax },
                         };
                       },
-      peg$c99 = ",",
-      peg$c100 = peg$literalExpectation(",", false),
-      peg$c101 = function(first, restsWithComma) {
+      peg$c113 = ",",
+      peg$c114 = peg$literalExpectation(",", false),
+      peg$c115 = function(first, restsWithComma) {
                                      return restsWithComma.reduce(function(params, tokens) {
                                        return params.concat([tokens[3]]);
                                      }, [first]);
                                    },
-      peg$c102 = ".<",
-      peg$c103 = peg$literalExpectation(".<", false),
-      peg$c104 = function() {
+      peg$c116 = ".<",
+      peg$c117 = peg$literalExpectation(".<", false),
+      peg$c118 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET_WITH_DOT;
                                               },
-      peg$c105 = "<",
-      peg$c106 = peg$literalExpectation("<", false),
-      peg$c107 = function() {
+      peg$c119 = "<",
+      peg$c120 = peg$literalExpectation("<", false),
+      peg$c121 = function() {
                                                 return GenericTypeSyntax.ANGLE_BRACKET;
                                               },
-      peg$c108 = ">",
-      peg$c109 = peg$literalExpectation(">", false),
-      peg$c110 = "[",
-      peg$c111 = peg$literalExpectation("[", false),
-      peg$c112 = "]",
-      peg$c113 = peg$literalExpectation("]", false),
-      peg$c114 = function(operand, brackets) {
+      peg$c122 = ">",
+      peg$c123 = peg$literalExpectation(">", false),
+      peg$c124 = "[",
+      peg$c125 = peg$literalExpectation("[", false),
+      peg$c126 = "]",
+      peg$c127 = peg$literalExpectation("]", false),
+      peg$c128 = function(operand, brackets) {
                       return brackets.reduce(function(operand) {
                         return {
                           type: NodeType.GENERIC,
@@ -435,11 +550,11 @@ function peg$parse(input, options) {
                         };
                       }, operand);
                     },
-      peg$c115 = "new",
-      peg$c116 = peg$literalExpectation("new", false),
-      peg$c117 = "=>",
-      peg$c118 = peg$literalExpectation("=>", false),
-      peg$c119 = function(newModifier, paramsPart, returnedTypeNode) {
+      peg$c129 = "new",
+      peg$c130 = peg$literalExpectation("new", false),
+      peg$c131 = "=>",
+      peg$c132 = peg$literalExpectation("=>", false),
+      peg$c133 = function(newModifier, paramsPart, returnedTypeNode) {
                          return {
                            type: NodeType.ARROW,
                            params: paramsPart,
@@ -447,23 +562,29 @@ function peg$parse(input, options) {
                            new: newModifier
                          };
       },
-      peg$c120 = function() {
+      peg$c134 = function() {
                             return [];
                           },
-      peg$c121 = function(params) {
+      peg$c135 = function(params) {
                             return params;
                           },
-      peg$c122 = ":",
-      peg$c123 = peg$literalExpectation(":", false),
-      peg$c124 = function(paramsWithComma, lastParam) {
+      peg$c136 = function(id) { return { name: id, optional: true } },
+      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
-          const param = { type: NodeType.NAMED_PARAMETER, name: tokens[0], typeName: tokens[4] };
+          const param = { 
+              type: tokens[0].optional 
+                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
+                  : NodeType.NAMED_PARAMETER, 
+              name: tokens[0].name, 
+              typeName: tokens[4] 
+          };
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
-      peg$c125 = "...",
-      peg$c126 = peg$literalExpectation("...", false),
-      peg$c127 = function(spread, id, type) {
+      peg$c139 = "...",
+      peg$c140 = peg$literalExpectation("...", false),
+      peg$c141 = function(spread, id, type) {
         const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         if (spread) {
         return {
@@ -476,9 +597,9 @@ function peg$parse(input, options) {
           return operand;
         }
       },
-      peg$c128 = "function",
-      peg$c129 = peg$literalExpectation("function", false),
-      peg$c130 = function(paramsPart, returnedTypePart) {
+      peg$c142 = "function",
+      peg$c143 = peg$literalExpectation("function", false),
+      peg$c144 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -489,53 +610,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c131 = function(modifier, params) {
+      peg$c145 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c132 = function(modifier) {
+      peg$c146 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c133 = function() {
+      peg$c147 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c134 = function(params) {
+      peg$c148 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c135 = "this",
-      peg$c136 = peg$literalExpectation("this", false),
-      peg$c137 = function(modifierThis) {
+      peg$c149 = "this",
+      peg$c150 = peg$literalExpectation("this", false),
+      peg$c151 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c138 = function(modifierNew) {
+      peg$c152 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c139 = function(paramsWithComma, lastParam) {
+      peg$c153 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c140 = "{",
-      peg$c141 = peg$literalExpectation("{", false),
-      peg$c142 = "}",
-      peg$c143 = peg$literalExpectation("}", false),
-      peg$c144 = function(entries) {
+      peg$c154 = "{",
+      peg$c155 = peg$literalExpectation("{", false),
+      peg$c156 = "}",
+      peg$c157 = peg$literalExpectation("}", false),
+      peg$c158 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c145 = ";",
-      peg$c146 = peg$literalExpectation(";", false),
-      peg$c147 = function(first, restWithComma) {
+      peg$c159 = ";",
+      peg$c160 = peg$literalExpectation(";", false),
+      peg$c161 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c148 = "readonly",
-      peg$c149 = peg$literalExpectation("readonly", false),
-      peg$c150 = function(readonly, keyInfo, optional, value) {
+      peg$c162 = "readonly",
+      peg$c163 = peg$literalExpectation("readonly", false),
+      peg$c164 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -551,7 +672,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c151 = function(readonly, keyInfo) {
+      peg$c165 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -561,59 +682,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c152 = function(key) {
+      peg$c166 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c153 = function(key) {
+      peg$c167 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c154 = function(key) {
+      peg$c168 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c155 = function(entries) {
+      peg$c169 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c156 = function(restWithComma, last) {
+      peg$c170 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c157 = function(wrapped) {
+      peg$c171 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c158 = function(operand) {
+      peg$c172 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c159 = function(operand) {
+      peg$c173 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c160 = function() {
+      peg$c174 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -762,7 +883,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 0,
+    var key    = peg$currPos * 82 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -798,7 +919,7 @@ function peg$parse(input, options) {
                           if (s2 === peg$FAILED) {
                             s2 = peg$parseKeyQueryExpr();
                             if (s2 === peg$FAILED) {
-                              s2 = peg$parseNamepathExpr();
+                              s2 = peg$parseBroadNamepathExpr();
                               if (s2 === peg$FAILED) {
                                 s2 = peg$parseParenthesizedExpr();
                                 if (s2 === peg$FAILED) {
@@ -850,7 +971,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 77 + 1,
+    var key    = peg$currPos * 82 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -907,7 +1028,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 2,
+    var key    = peg$currPos * 82 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -931,7 +1052,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 3,
+    var key    = peg$currPos * 82 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -959,7 +1080,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 77 + 4,
+    var key    = peg$currPos * 82 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1021,7 +1142,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 77 + 5,
+    var key    = peg$currPos * 82 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1160,7 +1281,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 6,
+    var key    = peg$currPos * 82 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1228,7 +1349,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 7,
+    var key    = peg$currPos * 82 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1487,7 +1608,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 77 + 8,
+    var key    = peg$currPos * 82 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1512,7 +1633,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 9,
+    var key    = peg$currPos * 82 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1615,7 +1736,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 10,
+    var key    = peg$currPos * 82 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1646,7 +1767,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 11,
+    var key    = peg$currPos * 82 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1677,7 +1798,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 12,
+    var key    = peg$currPos * 82 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1708,7 +1829,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 13,
+    var key    = peg$currPos * 82 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1717,7 +1838,665 @@ function peg$parse(input, options) {
       return cached.result;
     }
 
-    s0 = peg$parseNamepathExpr();
+    s0 = peg$parseExternalNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseModuleNameExpr();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parseNamepathExpr();
+      }
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseExternalNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
+
+    var key    = peg$currPos * 82 + 14,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c41) {
+      s1 = peg$c41;
+      peg$currPos += 8;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseMemberName();
+            if (s5 !== peg$FAILED) {
+              s6 = [];
+              s7 = peg$currPos;
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseInfixNamepathOperator();
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    if (input.substr(peg$currPos, 6) === peg$c11) {
+                      s11 = peg$c11;
+                      peg$currPos += 6;
+                    } else {
+                      s11 = peg$FAILED;
+                      if (peg$silentFails === 0) { peg$fail(peg$c12); }
+                    }
+                    if (s11 === peg$FAILED) {
+                      s11 = null;
+                    }
+                    if (s11 !== peg$FAILED) {
+                      s12 = peg$parse_();
+                      if (s12 !== peg$FAILED) {
+                        s13 = peg$parseMemberName();
+                        if (s13 !== peg$FAILED) {
+                          s8 = [s8, s9, s10, s11, s12, s13];
+                          s7 = s8;
+                        } else {
+                          peg$currPos = s7;
+                          s7 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s7;
+                        s7 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s7;
+                      s7 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s7;
+                    s7 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s7;
+                  s7 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s7;
+                s7 = peg$FAILED;
+              }
+              while (s7 !== peg$FAILED) {
+                s6.push(s7);
+                s7 = peg$currPos;
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parseInfixNamepathOperator();
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      if (input.substr(peg$currPos, 6) === peg$c11) {
+                        s11 = peg$c11;
+                        peg$currPos += 6;
+                      } else {
+                        s11 = peg$FAILED;
+                        if (peg$silentFails === 0) { peg$fail(peg$c12); }
+                      }
+                      if (s11 === peg$FAILED) {
+                        s11 = null;
+                      }
+                      if (s11 !== peg$FAILED) {
+                        s12 = peg$parse_();
+                        if (s12 !== peg$FAILED) {
+                          s13 = peg$parseMemberName();
+                          if (s13 !== peg$FAILED) {
+                            s8 = [s8, s9, s10, s11, s12, s13];
+                            s7 = s8;
+                          } else {
+                            peg$currPos = s7;
+                            s7 = peg$FAILED;
+                          }
+                        } else {
+                          peg$currPos = s7;
+                          s7 = peg$FAILED;
+                        }
+                      } else {
+                        peg$currPos = s7;
+                        s7 = peg$FAILED;
+                      }
+                    } else {
+                      peg$currPos = s7;
+                      s7 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s7;
+                    s7 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s7;
+                  s7 = peg$FAILED;
+                }
+              }
+              if (s6 !== peg$FAILED) {
+                peg$savedPos = s0;
+                s1 = peg$c45(s5, s6);
+                s0 = s1;
+              } else {
+                peg$currPos = s0;
+                s0 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseModuleNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 82 + 15,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 6) === peg$c46) {
+      s1 = peg$c46;
+      peg$currPos += 6;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c47); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseModulePathExpr();
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c48(s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseModulePathExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
+
+    var key    = peg$currPos * 82 + 16,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseFilePathExpr();
+    if (s1 !== peg$FAILED) {
+      s2 = [];
+      s3 = peg$currPos;
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        s5 = peg$parseInfixNamepathOperator();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            if (input.substr(peg$currPos, 6) === peg$c11) {
+              s7 = peg$c11;
+              peg$currPos += 6;
+            } else {
+              s7 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c12); }
+            }
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                s9 = peg$parseMemberName();
+                if (s9 !== peg$FAILED) {
+                  s4 = [s4, s5, s6, s7, s8, s9];
+                  s3 = s4;
+                } else {
+                  peg$currPos = s3;
+                  s3 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s3;
+        s3 = peg$FAILED;
+      }
+      while (s3 !== peg$FAILED) {
+        s2.push(s3);
+        s3 = peg$currPos;
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          s5 = peg$parseInfixNamepathOperator();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              if (input.substr(peg$currPos, 6) === peg$c11) {
+                s7 = peg$c11;
+                peg$currPos += 6;
+              } else {
+                s7 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c12); }
+              }
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  s9 = peg$parseMemberName();
+                  if (s9 !== peg$FAILED) {
+                    s4 = [s4, s5, s6, s7, s8, s9];
+                    s3 = s4;
+                  } else {
+                    peg$currPos = s3;
+                    s3 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s3;
+                  s3 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s3;
+                s3 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s3;
+              s3 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s3;
+            s3 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s3;
+          s3 = peg$FAILED;
+        }
+      }
+      if (s2 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c49(s1, s2);
+        s0 = s1;
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFilePathExpr() {
+    var s0, s1, s2, s3, s4, s5, s6;
+
+    var key    = peg$currPos * 82 + 17,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.charCodeAt(peg$currPos) === 39) {
+      s1 = peg$c17;
+      peg$currPos++;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c18); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$currPos;
+      s3 = [];
+      if (peg$c19.test(input.charAt(peg$currPos))) {
+        s4 = input.charAt(peg$currPos);
+        peg$currPos++;
+      } else {
+        s4 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c20); }
+      }
+      if (s4 === peg$FAILED) {
+        s4 = peg$currPos;
+        if (input.charCodeAt(peg$currPos) === 92) {
+          s5 = peg$c21;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c22); }
+        }
+        if (s5 !== peg$FAILED) {
+          if (input.length > peg$currPos) {
+            s6 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s6 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c23); }
+          }
+          if (s6 !== peg$FAILED) {
+            s5 = [s5, s6];
+            s4 = s5;
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
+        }
+      }
+      while (s4 !== peg$FAILED) {
+        s3.push(s4);
+        if (peg$c19.test(input.charAt(peg$currPos))) {
+          s4 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c20); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 92) {
+            s5 = peg$c21;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c22); }
+          }
+          if (s5 !== peg$FAILED) {
+            if (input.length > peg$currPos) {
+              s6 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c23); }
+            }
+            if (s6 !== peg$FAILED) {
+              s5 = [s5, s6];
+              s4 = s5;
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        }
+      }
+      if (s3 !== peg$FAILED) {
+        s2 = input.substring(s2, peg$currPos);
+      } else {
+        s2 = s3;
+      }
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 39) {
+          s3 = peg$c17;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c18); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c50(s2);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      if (input.charCodeAt(peg$currPos) === 34) {
+        s1 = peg$c25;
+        peg$currPos++;
+      } else {
+        s1 = peg$FAILED;
+        if (peg$silentFails === 0) { peg$fail(peg$c26); }
+      }
+      if (s1 !== peg$FAILED) {
+        s2 = peg$currPos;
+        s3 = [];
+        if (peg$c27.test(input.charAt(peg$currPos))) {
+          s4 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s4 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c28); }
+        }
+        if (s4 === peg$FAILED) {
+          s4 = peg$currPos;
+          if (input.charCodeAt(peg$currPos) === 92) {
+            s5 = peg$c21;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c22); }
+          }
+          if (s5 !== peg$FAILED) {
+            if (input.length > peg$currPos) {
+              s6 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s6 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c23); }
+            }
+            if (s6 !== peg$FAILED) {
+              s5 = [s5, s6];
+              s4 = s5;
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        }
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          if (peg$c27.test(input.charAt(peg$currPos))) {
+            s4 = input.charAt(peg$currPos);
+            peg$currPos++;
+          } else {
+            s4 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c28); }
+          }
+          if (s4 === peg$FAILED) {
+            s4 = peg$currPos;
+            if (input.charCodeAt(peg$currPos) === 92) {
+              s5 = peg$c21;
+              peg$currPos++;
+            } else {
+              s5 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c22); }
+            }
+            if (s5 !== peg$FAILED) {
+              if (input.length > peg$currPos) {
+                s6 = input.charAt(peg$currPos);
+                peg$currPos++;
+              } else {
+                s6 = peg$FAILED;
+                if (peg$silentFails === 0) { peg$fail(peg$c23); }
+              }
+              if (s6 !== peg$FAILED) {
+                s5 = [s5, s6];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          }
+        }
+        if (s3 !== peg$FAILED) {
+          s2 = input.substring(s2, peg$currPos);
+        } else {
+          s2 = s3;
+        }
+        if (s2 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 34) {
+            s3 = peg$c25;
+            peg$currPos++;
+          } else {
+            s3 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c26); }
+          }
+          if (s3 !== peg$FAILED) {
+            peg$savedPos = s0;
+            s1 = peg$c51(s2);
+            s0 = s1;
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+      if (s0 === peg$FAILED) {
+        s0 = peg$currPos;
+        s1 = peg$currPos;
+        s2 = [];
+        if (peg$c52.test(input.charAt(peg$currPos))) {
+          s3 = input.charAt(peg$currPos);
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        }
+        if (s3 !== peg$FAILED) {
+          while (s3 !== peg$FAILED) {
+            s2.push(s3);
+            if (peg$c52.test(input.charAt(peg$currPos))) {
+              s3 = input.charAt(peg$currPos);
+              peg$currPos++;
+            } else {
+              s3 = peg$FAILED;
+              if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            }
+          }
+        } else {
+          s2 = peg$FAILED;
+        }
+        if (s2 !== peg$FAILED) {
+          s1 = input.substring(s1, peg$currPos);
+        } else {
+          s1 = s2;
+        }
+        if (s1 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c54(s1);
+        }
+        s0 = s1;
+      }
+    }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
@@ -1727,7 +2506,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 14,
+    var key    = peg$currPos * 82 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1738,15 +2517,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 42) {
-      s1 = peg$c41;
+      s1 = peg$c55;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c42); }
+      if (peg$silentFails === 0) { peg$fail(peg$c56); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c43();
+      s1 = peg$c57();
     }
     s0 = s1;
 
@@ -1758,7 +2537,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 15,
+    var key    = peg$currPos * 82 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1769,15 +2548,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 63) {
-      s1 = peg$c44;
+      s1 = peg$c58;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      if (peg$silentFails === 0) { peg$fail(peg$c59); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c46();
+      s1 = peg$c60();
     }
     s0 = s1;
 
@@ -1789,7 +2568,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 16,
+    var key    = peg$currPos * 82 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1811,7 +2590,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 17,
+    var key    = peg$currPos * 82 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1921,7 +2700,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c47(s2);
+          s1 = peg$c61(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2037,7 +2816,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c48(s2);
+            s1 = peg$c62(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -2061,7 +2840,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 18,
+    var key    = peg$currPos * 82 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2083,7 +2862,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c49(s1);
+      s1 = peg$c63(s1);
     }
     s0 = s1;
 
@@ -2095,7 +2874,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 19,
+    var key    = peg$currPos * 82 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2107,19 +2886,19 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 43) {
-      s2 = peg$c50;
+      s2 = peg$c64;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c51); }
+      if (peg$silentFails === 0) { peg$fail(peg$c65); }
     }
     if (s2 === peg$FAILED) {
       if (input.charCodeAt(peg$currPos) === 45) {
-        s2 = peg$c52;
+        s2 = peg$c66;
         peg$currPos++;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c53); }
+        if (peg$silentFails === 0) { peg$fail(peg$c67); }
       }
     }
     if (s2 === peg$FAILED) {
@@ -2152,7 +2931,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 20,
+    var key    = peg$currPos * 82 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2165,22 +2944,22 @@ function peg$parse(input, options) {
     s1 = peg$currPos;
     s2 = peg$currPos;
     s3 = [];
-    if (peg$c54.test(input.charAt(peg$currPos))) {
+    if (peg$c68.test(input.charAt(peg$currPos))) {
       s4 = input.charAt(peg$currPos);
       peg$currPos++;
     } else {
       s4 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c55); }
+      if (peg$silentFails === 0) { peg$fail(peg$c69); }
     }
     if (s4 !== peg$FAILED) {
       while (s4 !== peg$FAILED) {
         s3.push(s4);
-        if (peg$c54.test(input.charAt(peg$currPos))) {
+        if (peg$c68.test(input.charAt(peg$currPos))) {
           s4 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
       }
     } else {
@@ -2197,22 +2976,22 @@ function peg$parse(input, options) {
       }
       if (s5 !== peg$FAILED) {
         s6 = [];
-        if (peg$c54.test(input.charAt(peg$currPos))) {
+        if (peg$c68.test(input.charAt(peg$currPos))) {
           s7 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s7 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
         if (s7 !== peg$FAILED) {
           while (s7 !== peg$FAILED) {
             s6.push(s7);
-            if (peg$c54.test(input.charAt(peg$currPos))) {
+            if (peg$c68.test(input.charAt(peg$currPos))) {
               s7 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c69); }
             }
           }
         } else {
@@ -2254,22 +3033,22 @@ function peg$parse(input, options) {
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c54.test(input.charAt(peg$currPos))) {
+        if (peg$c68.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c55); }
+          if (peg$silentFails === 0) { peg$fail(peg$c69); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c54.test(input.charAt(peg$currPos))) {
+            if (peg$c68.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c55); }
+              if (peg$silentFails === 0) { peg$fail(peg$c69); }
             }
           }
         } else {
@@ -2290,27 +3069,27 @@ function peg$parse(input, options) {
     if (s2 !== peg$FAILED) {
       s3 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 101) {
-        s4 = peg$c56;
+        s4 = peg$c70;
         peg$currPos++;
       } else {
         s4 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c57); }
+        if (peg$silentFails === 0) { peg$fail(peg$c71); }
       }
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 43) {
-          s5 = peg$c50;
+          s5 = peg$c64;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c51); }
+          if (peg$silentFails === 0) { peg$fail(peg$c65); }
         }
         if (s5 === peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 45) {
-            s5 = peg$c52;
+            s5 = peg$c66;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c53); }
+            if (peg$silentFails === 0) { peg$fail(peg$c67); }
           }
         }
         if (s5 === peg$FAILED) {
@@ -2318,22 +3097,22 @@ function peg$parse(input, options) {
         }
         if (s5 !== peg$FAILED) {
           s6 = [];
-          if (peg$c54.test(input.charAt(peg$currPos))) {
+          if (peg$c68.test(input.charAt(peg$currPos))) {
             s7 = input.charAt(peg$currPos);
             peg$currPos++;
           } else {
             s7 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c55); }
+            if (peg$silentFails === 0) { peg$fail(peg$c69); }
           }
           if (s7 !== peg$FAILED) {
             while (s7 !== peg$FAILED) {
               s6.push(s7);
-              if (peg$c54.test(input.charAt(peg$currPos))) {
+              if (peg$c68.test(input.charAt(peg$currPos))) {
                 s7 = input.charAt(peg$currPos);
                 peg$currPos++;
               } else {
                 s7 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c55); }
+                if (peg$silentFails === 0) { peg$fail(peg$c69); }
               }
             }
           } else {
@@ -2382,7 +3161,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 21,
+    var key    = peg$currPos * 82 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2394,41 +3173,41 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s2 = peg$c52;
+      s2 = peg$c66;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s2 === peg$FAILED) {
       s2 = null;
     }
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c58) {
-        s3 = peg$c58;
+      if (input.substr(peg$currPos, 2) === peg$c72) {
+        s3 = peg$c72;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        if (peg$silentFails === 0) { peg$fail(peg$c73); }
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c60.test(input.charAt(peg$currPos))) {
+        if (peg$c74.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c61); }
+          if (peg$silentFails === 0) { peg$fail(peg$c75); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c60.test(input.charAt(peg$currPos))) {
+            if (peg$c74.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c61); }
+              if (peg$silentFails === 0) { peg$fail(peg$c75); }
             }
           }
         } else {
@@ -2463,7 +3242,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 22,
+    var key    = peg$currPos * 82 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2475,41 +3254,41 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s2 = peg$c52;
+      s2 = peg$c66;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s2 === peg$FAILED) {
       s2 = null;
     }
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c62) {
-        s3 = peg$c62;
+      if (input.substr(peg$currPos, 2) === peg$c76) {
+        s3 = peg$c76;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c63); }
+        if (peg$silentFails === 0) { peg$fail(peg$c77); }
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c64.test(input.charAt(peg$currPos))) {
+        if (peg$c78.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c65); }
+          if (peg$silentFails === 0) { peg$fail(peg$c79); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c64.test(input.charAt(peg$currPos))) {
+            if (peg$c78.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c65); }
+              if (peg$silentFails === 0) { peg$fail(peg$c79); }
             }
           }
         } else {
@@ -2544,7 +3323,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 23,
+    var key    = peg$currPos * 82 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2556,41 +3335,41 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 45) {
-      s2 = peg$c52;
+      s2 = peg$c66;
       peg$currPos++;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c53); }
+      if (peg$silentFails === 0) { peg$fail(peg$c67); }
     }
     if (s2 === peg$FAILED) {
       s2 = null;
     }
     if (s2 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 2) === peg$c66) {
-        s3 = peg$c66;
+      if (input.substr(peg$currPos, 2) === peg$c80) {
+        s3 = peg$c80;
         peg$currPos += 2;
       } else {
         s3 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c67); }
+        if (peg$silentFails === 0) { peg$fail(peg$c81); }
       }
       if (s3 !== peg$FAILED) {
         s4 = [];
-        if (peg$c68.test(input.charAt(peg$currPos))) {
+        if (peg$c82.test(input.charAt(peg$currPos))) {
           s5 = input.charAt(peg$currPos);
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c69); }
+          if (peg$silentFails === 0) { peg$fail(peg$c83); }
         }
         if (s5 !== peg$FAILED) {
           while (s5 !== peg$FAILED) {
             s4.push(s5);
-            if (peg$c68.test(input.charAt(peg$currPos))) {
+            if (peg$c82.test(input.charAt(peg$currPos))) {
               s5 = input.charAt(peg$currPos);
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c69); }
+              if (peg$silentFails === 0) { peg$fail(peg$c83); }
             }
           }
         } else {
@@ -2625,7 +3404,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 24,
+    var key    = peg$currPos * 82 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2640,11 +3419,11 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 38) {
-          s3 = peg$c70;
+          s3 = peg$c84;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c71); }
+          if (peg$silentFails === 0) { peg$fail(peg$c85); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -2655,7 +3434,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c72(s1, s5);
+              s1 = peg$c86(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2686,7 +3465,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 25,
+    var key    = peg$currPos * 82 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2715,7 +3494,7 @@ function peg$parse(input, options) {
                     if (s0 === peg$FAILED) {
                       s0 = peg$parseArrayTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseNamepathExpr();
+                        s0 = peg$parseBroadNamepathExpr();
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseValueExpr();
                           if (s0 === peg$FAILED) {
@@ -2744,7 +3523,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 26,
+    var key    = peg$currPos * 82 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2759,11 +3538,11 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 124) {
-          s3 = peg$c73;
+          s3 = peg$c87;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c74); }
+          if (peg$silentFails === 0) { peg$fail(peg$c88); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -2774,7 +3553,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c75(s1, s5);
+              s1 = peg$c89(s1, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -2805,7 +3584,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 27,
+    var key    = peg$currPos * 82 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2834,7 +3613,7 @@ function peg$parse(input, options) {
                     if (s0 === peg$FAILED) {
                       s0 = peg$parseArrayTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseNamepathExpr();
+                        s0 = peg$parseBroadNamepathExpr();
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseValueExpr();
                           if (s0 === peg$FAILED) {
@@ -2863,7 +3642,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 28,
+    var key    = peg$currPos * 82 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2885,7 +3664,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 29,
+    var key    = peg$currPos * 82 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2907,7 +3686,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 30,
+    var key    = peg$currPos * 82 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2928,7 +3707,7 @@ function peg$parse(input, options) {
             if (s0 === peg$FAILED) {
               s0 = peg$parseParenthesizedExpr();
               if (s0 === peg$FAILED) {
-                s0 = peg$parseNamepathExpr();
+                s0 = peg$parseBroadNamepathExpr();
                 if (s0 === peg$FAILED) {
                   s0 = peg$parseValueExpr();
                   if (s0 === peg$FAILED) {
@@ -2953,7 +3732,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 31,
+    var key    = peg$currPos * 82 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2963,12 +3742,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c76) {
-      s1 = peg$c76;
+    if (input.substr(peg$currPos, 6) === peg$c90) {
+      s1 = peg$c90;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c77); }
+      if (peg$silentFails === 0) { peg$fail(peg$c91); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -2976,7 +3755,7 @@ function peg$parse(input, options) {
         s3 = peg$parseQualifiedMemberName();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c78(s1, s3);
+          s1 = peg$c92(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -2999,7 +3778,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 32,
+    var key    = peg$currPos * 82 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3009,12 +3788,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 5) === peg$c79) {
-      s1 = peg$c79;
+    if (input.substr(peg$currPos, 5) === peg$c93) {
+      s1 = peg$c93;
       peg$currPos += 5;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c80); }
+      if (peg$silentFails === 0) { peg$fail(peg$c94); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
@@ -3022,7 +3801,7 @@ function peg$parse(input, options) {
         s3 = peg$parseKeyQueryExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c81(s1, s3);
+          s1 = peg$c95(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3038,18 +3817,18 @@ function peg$parse(input, options) {
     }
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      if (input.substr(peg$currPos, 5) === peg$c79) {
-        s1 = peg$c79;
+      if (input.substr(peg$currPos, 5) === peg$c93) {
+        s1 = peg$c93;
         peg$currPos += 5;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c80); }
+        if (peg$silentFails === 0) { peg$fail(peg$c94); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parseParenthesizedExpr();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c81(s1, s2);
+          s1 = peg$c95(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3069,7 +3848,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 33,
+    var key    = peg$currPos * 82 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3100,7 +3879,7 @@ function peg$parse(input, options) {
                       if (s0 === peg$FAILED) {
                         s0 = peg$parseGenericTypeExpr();
                         if (s0 === peg$FAILED) {
-                          s0 = peg$parseNamepathExpr();
+                          s0 = peg$parseBroadNamepathExpr();
                           if (s0 === peg$FAILED) {
                             s0 = peg$parseValueExpr();
                             if (s0 === peg$FAILED) {
@@ -3130,7 +3909,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 34,
+    var key    = peg$currPos * 82 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3140,22 +3919,22 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 6) === peg$c82) {
-      s1 = peg$c82;
+    if (input.substr(peg$currPos, 6) === peg$c96) {
+      s1 = peg$c96;
       peg$currPos += 6;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c83); }
+      if (peg$silentFails === 0) { peg$fail(peg$c97); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 40) {
-          s3 = peg$c84;
+          s3 = peg$c98;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
@@ -3165,15 +3944,15 @@ function peg$parse(input, options) {
               s6 = peg$parse_();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 41) {
-                  s7 = peg$c86;
+                  s7 = peg$c100;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c101); }
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c88(s1, s5);
+                  s1 = peg$c102(s1, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3212,7 +3991,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 35,
+    var key    = peg$currPos * 82 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3223,11 +4002,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 63) {
-      s1 = peg$c44;
+      s1 = peg$c58;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c45); }
+      if (peg$silentFails === 0) { peg$fail(peg$c59); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3235,7 +4014,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c89(s1, s3);
+          s1 = peg$c103(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3258,7 +4037,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 36,
+    var key    = peg$currPos * 82 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3269,11 +4048,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 33) {
-      s1 = peg$c90;
+      s1 = peg$c104;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c91); }
+      if (peg$silentFails === 0) { peg$fail(peg$c105); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -3281,7 +4060,7 @@ function peg$parse(input, options) {
         s3 = peg$parsePrefixUnaryUnionTypeExprOperand();
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c92(s1, s3);
+          s1 = peg$c106(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3304,7 +4083,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 37,
+    var key    = peg$currPos * 82 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3329,7 +4108,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 38,
+    var key    = peg$currPos * 82 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3352,7 +4131,7 @@ function peg$parse(input, options) {
               if (s0 === peg$FAILED) {
                 s0 = peg$parseParenthesizedExpr();
                 if (s0 === peg$FAILED) {
-                  s0 = peg$parseNamepathExpr();
+                  s0 = peg$parseBroadNamepathExpr();
                   if (s0 === peg$FAILED) {
                     s0 = peg$parseValueExpr();
                     if (s0 === peg$FAILED) {
@@ -3378,7 +4157,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 39,
+    var key    = peg$currPos * 82 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3393,15 +4172,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 63) {
-          s3 = peg$c44;
+          s3 = peg$c58;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c45); }
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c93(s1, s3);
+          s1 = peg$c107(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3424,7 +4203,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 40,
+    var key    = peg$currPos * 82 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3439,15 +4218,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 33) {
-          s3 = peg$c90;
+          s3 = peg$c104;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c91); }
+          if (peg$silentFails === 0) { peg$fail(peg$c105); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c94(s1, s3);
+          s1 = peg$c108(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3470,7 +4249,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 77 + 41,
+    var key    = peg$currPos * 82 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3491,15 +4270,15 @@ function peg$parse(input, options) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 61) {
-          s3 = peg$c95;
+          s3 = peg$c109;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c96); }
+          if (peg$silentFails === 0) { peg$fail(peg$c110); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c97(s1, s3);
+          s1 = peg$c111(s1, s3);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -3522,7 +4301,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 42,
+    var key    = peg$currPos * 82 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3547,7 +4326,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseGenericTypeEndToken();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c98(s1, s3, s5);
+                  s1 = peg$c112(s1, s3, s5);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -3586,7 +4365,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 43,
+    var key    = peg$currPos * 82 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3597,7 +4376,7 @@ function peg$parse(input, options) {
 
     s0 = peg$parseParenthesizedExpr();
     if (s0 === peg$FAILED) {
-      s0 = peg$parseNamepathExpr();
+      s0 = peg$parseBroadNamepathExpr();
       if (s0 === peg$FAILED) {
         s0 = peg$parseValueExpr();
         if (s0 === peg$FAILED) {
@@ -3617,7 +4396,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 44,
+    var key    = peg$currPos * 82 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3650,7 +4429,7 @@ function peg$parse(input, options) {
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseKeyQueryExpr();
                           if (s0 === peg$FAILED) {
-                            s0 = peg$parseNamepathExpr();
+                            s0 = peg$parseBroadNamepathExpr();
                             if (s0 === peg$FAILED) {
                               s0 = peg$parseValueExpr();
                               if (s0 === peg$FAILED) {
@@ -3681,7 +4460,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 45,
+    var key    = peg$currPos * 82 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3698,11 +4477,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c99;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -3733,11 +4512,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c99;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -3765,7 +4544,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c101(s1, s2);
+        s1 = peg$c115(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -3784,7 +4563,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 77 + 46,
+    var key    = peg$currPos * 82 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3806,7 +4585,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 47,
+    var key    = peg$currPos * 82 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3816,16 +4595,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 2) === peg$c102) {
-      s1 = peg$c102;
+    if (input.substr(peg$currPos, 2) === peg$c116) {
+      s1 = peg$c116;
       peg$currPos += 2;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c103); }
+      if (peg$silentFails === 0) { peg$fail(peg$c117); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c104();
+      s1 = peg$c118();
     }
     s0 = s1;
 
@@ -3837,7 +4616,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 48,
+    var key    = peg$currPos * 82 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3848,15 +4627,15 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 60) {
-      s1 = peg$c105;
+      s1 = peg$c119;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c106); }
+      if (peg$silentFails === 0) { peg$fail(peg$c120); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c107();
+      s1 = peg$c121();
     }
     s0 = s1;
 
@@ -3868,7 +4647,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 77 + 49,
+    var key    = peg$currPos * 82 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3878,11 +4657,11 @@ function peg$parse(input, options) {
     }
 
     if (input.charCodeAt(peg$currPos) === 62) {
-      s0 = peg$c108;
+      s0 = peg$c122;
       peg$currPos++;
     } else {
       s0 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c109); }
+      if (peg$silentFails === 0) { peg$fail(peg$c123); }
     }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
@@ -3893,7 +4672,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 50,
+    var key    = peg$currPos * 82 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3910,21 +4689,21 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 91) {
-          s5 = peg$c110;
+          s5 = peg$c124;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c111); }
+          if (peg$silentFails === 0) { peg$fail(peg$c125); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
           if (s6 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s7 = peg$c112;
+              s7 = peg$c126;
               peg$currPos++;
             } else {
               s7 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c113); }
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
             }
             if (s7 !== peg$FAILED) {
               s4 = [s4, s5, s6, s7];
@@ -3952,21 +4731,21 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 91) {
-              s5 = peg$c110;
+              s5 = peg$c124;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c111); }
+              if (peg$silentFails === 0) { peg$fail(peg$c125); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
               if (s6 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 93) {
-                  s7 = peg$c112;
+                  s7 = peg$c126;
                   peg$currPos++;
                 } else {
                   s7 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c113); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c127); }
                 }
                 if (s7 !== peg$FAILED) {
                   s4 = [s4, s5, s6, s7];
@@ -3993,7 +4772,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c114(s1, s2);
+        s1 = peg$c128(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4012,7 +4791,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 51,
+    var key    = peg$currPos * 82 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4039,7 +4818,7 @@ function peg$parse(input, options) {
                   if (s0 === peg$FAILED) {
                     s0 = peg$parseKeyQueryExpr();
                     if (s0 === peg$FAILED) {
-                      s0 = peg$parseNamepathExpr();
+                      s0 = peg$parseBroadNamepathExpr();
                       if (s0 === peg$FAILED) {
                         s0 = peg$parseValueExpr();
                         if (s0 === peg$FAILED) {
@@ -4067,7 +4846,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 52,
+    var key    = peg$currPos * 82 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4077,12 +4856,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c115) {
-      s1 = peg$c115;
+    if (input.substr(peg$currPos, 3) === peg$c129) {
+      s1 = peg$c129;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c116); }
+      if (peg$silentFails === 0) { peg$fail(peg$c130); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -4094,12 +4873,12 @@ function peg$parse(input, options) {
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
-            if (input.substr(peg$currPos, 2) === peg$c117) {
-              s5 = peg$c117;
+            if (input.substr(peg$currPos, 2) === peg$c131) {
+              s5 = peg$c131;
               peg$currPos += 2;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c118); }
+              if (peg$silentFails === 0) { peg$fail(peg$c132); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
@@ -4107,7 +4886,7 @@ function peg$parse(input, options) {
                 s7 = peg$parseFunctionTypeExprReturnableOperand();
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c119(s1, s3, s7);
+                  s1 = peg$c133(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4146,7 +4925,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 53,
+    var key    = peg$currPos * 82 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4157,25 +4936,25 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c84;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 41) {
-          s3 = peg$c86;
+          s3 = peg$c100;
           peg$currPos++;
         } else {
           s3 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c87); }
+          if (peg$silentFails === 0) { peg$fail(peg$c101); }
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c120();
+          s1 = peg$c134();
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -4192,11 +4971,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c84;
+        s1 = peg$c98;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4206,15 +4985,15 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c86;
+                s5 = peg$c100;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c121(s3);
+                s1 = peg$c135(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4243,10 +5022,65 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseArrowTypeParamIdentifier() {
+    var s0, s1, s2, s3;
+
+    var key    = peg$currPos * 82 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 63) {
+          s3 = peg$c58;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c59); }
+        }
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c136(s1);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+    if (s0 === peg$FAILED) {
+      s0 = peg$currPos;
+      s1 = peg$parseJsIdentifier();
+      if (s1 !== peg$FAILED) {
+        peg$savedPos = s0;
+        s1 = peg$c137(s1);
+      }
+      s0 = s1;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
   function peg$parseArrowTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 77 + 54,
+    var key    = peg$currPos * 82 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4258,16 +5092,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseJsIdentifier();
+    s3 = peg$parseArrowTypeParamIdentifier();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s5 = peg$c122;
+          s5 = peg$c43;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c123); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -4280,11 +5114,11 @@ function peg$parse(input, options) {
               s8 = peg$parse_();
               if (s8 !== peg$FAILED) {
                 if (input.charCodeAt(peg$currPos) === 44) {
-                  s9 = peg$c99;
+                  s9 = peg$c113;
                   peg$currPos++;
                 } else {
                   s9 = peg$FAILED;
-                  if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
                 }
                 if (s9 !== peg$FAILED) {
                   s10 = peg$parse_();
@@ -4326,16 +5160,16 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseJsIdentifier();
+      s3 = peg$parseArrowTypeParamIdentifier();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s5 = peg$c122;
+            s5 = peg$c43;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c123); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -4348,11 +5182,11 @@ function peg$parse(input, options) {
                 s8 = peg$parse_();
                 if (s8 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 44) {
-                    s9 = peg$c99;
+                    s9 = peg$c113;
                     peg$currPos++;
                   } else {
                     s9 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c100); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
                   }
                   if (s9 !== peg$FAILED) {
                     s10 = peg$parse_();
@@ -4399,7 +5233,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c124(s1, s2);
+        s1 = peg$c138(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -4418,7 +5252,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 55,
+    var key    = peg$currPos * 82 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4428,12 +5262,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c125) {
-      s1 = peg$c125;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 === peg$FAILED) {
       s1 = null;
@@ -4446,11 +5280,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 58) {
-              s5 = peg$c122;
+              s5 = peg$c43;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c123); }
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
@@ -4461,7 +5295,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c127(s1, s3, s7);
+                  s1 = peg$c141(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -4500,7 +5334,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 77 + 56,
+    var key    = peg$currPos * 82 + 61,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4510,12 +5344,12 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c128) {
-      s1 = peg$c128;
+    if (input.substr(peg$currPos, 8) === peg$c142) {
+      s1 = peg$c142;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c129); }
+      if (peg$silentFails === 0) { peg$fail(peg$c143); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4526,11 +5360,11 @@ function peg$parse(input, options) {
           if (s4 !== peg$FAILED) {
             s5 = peg$currPos;
             if (input.charCodeAt(peg$currPos) === 58) {
-              s6 = peg$c122;
+              s6 = peg$c43;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c123); }
+              if (peg$silentFails === 0) { peg$fail(peg$c44); }
             }
             if (s6 !== peg$FAILED) {
               s7 = peg$parse_();
@@ -4556,7 +5390,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c130(s3, s5);
+              s1 = peg$c144(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4587,7 +5421,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 77 + 57,
+    var key    = peg$currPos * 82 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4598,11 +5432,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c84;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -4612,11 +5446,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 44) {
-              s5 = peg$c99;
+              s5 = peg$c113;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c100); }
+              if (peg$silentFails === 0) { peg$fail(peg$c114); }
             }
             if (s5 !== peg$FAILED) {
               s6 = peg$parse_();
@@ -4626,15 +5460,15 @@ function peg$parse(input, options) {
                   s8 = peg$parse_();
                   if (s8 !== peg$FAILED) {
                     if (input.charCodeAt(peg$currPos) === 41) {
-                      s9 = peg$c86;
+                      s9 = peg$c100;
                       peg$currPos++;
                     } else {
                       s9 = peg$FAILED;
-                      if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                      if (peg$silentFails === 0) { peg$fail(peg$c101); }
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c131(s3, s7);
+                      s1 = peg$c145(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -4675,11 +5509,11 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       if (input.charCodeAt(peg$currPos) === 40) {
-        s1 = peg$c84;
+        s1 = peg$c98;
         peg$currPos++;
       } else {
         s1 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c85); }
+        if (peg$silentFails === 0) { peg$fail(peg$c99); }
       }
       if (s1 !== peg$FAILED) {
         s2 = peg$parse_();
@@ -4689,15 +5523,15 @@ function peg$parse(input, options) {
             s4 = peg$parse_();
             if (s4 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 41) {
-                s5 = peg$c86;
+                s5 = peg$c100;
                 peg$currPos++;
               } else {
                 s5 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                if (peg$silentFails === 0) { peg$fail(peg$c101); }
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c132(s3);
+                s1 = peg$c146(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -4722,25 +5556,25 @@ function peg$parse(input, options) {
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
         if (input.charCodeAt(peg$currPos) === 40) {
-          s1 = peg$c84;
+          s1 = peg$c98;
           peg$currPos++;
         } else {
           s1 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c85); }
+          if (peg$silentFails === 0) { peg$fail(peg$c99); }
         }
         if (s1 !== peg$FAILED) {
           s2 = peg$parse_();
           if (s2 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s3 = peg$c86;
+              s3 = peg$c100;
               peg$currPos++;
             } else {
               s3 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c87); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c133();
+              s1 = peg$c147();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -4757,11 +5591,11 @@ function peg$parse(input, options) {
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
           if (input.charCodeAt(peg$currPos) === 40) {
-            s1 = peg$c84;
+            s1 = peg$c98;
             peg$currPos++;
           } else {
             s1 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c85); }
+            if (peg$silentFails === 0) { peg$fail(peg$c99); }
           }
           if (s1 !== peg$FAILED) {
             s2 = peg$parse_();
@@ -4771,15 +5605,15 @@ function peg$parse(input, options) {
                 s4 = peg$parse_();
                 if (s4 !== peg$FAILED) {
                   if (input.charCodeAt(peg$currPos) === 41) {
-                    s5 = peg$c86;
+                    s5 = peg$c100;
                     peg$currPos++;
                   } else {
                     s5 = peg$FAILED;
-                    if (peg$silentFails === 0) { peg$fail(peg$c87); }
+                    if (peg$silentFails === 0) { peg$fail(peg$c101); }
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c134(s3);
+                    s1 = peg$c148(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -4813,7 +5647,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 58,
+    var key    = peg$currPos * 82 + 63,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4824,22 +5658,22 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c135) {
-      s2 = peg$c135;
+    if (input.substr(peg$currPos, 4) === peg$c149) {
+      s2 = peg$c149;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c136); }
+      if (peg$silentFails === 0) { peg$fail(peg$c150); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
       if (s3 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 58) {
-          s4 = peg$c122;
+          s4 = peg$c43;
           peg$currPos++;
         } else {
           s4 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c123); }
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
         }
         if (s4 !== peg$FAILED) {
           s5 = peg$parse_();
@@ -4870,28 +5704,28 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c137(s1);
+      s1 = peg$c151(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 3) === peg$c115) {
-        s2 = peg$c115;
+      if (input.substr(peg$currPos, 3) === peg$c129) {
+        s2 = peg$c129;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c116); }
+        if (peg$silentFails === 0) { peg$fail(peg$c130); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 58) {
-            s4 = peg$c122;
+            s4 = peg$c43;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c123); }
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
           }
           if (s4 !== peg$FAILED) {
             s5 = peg$parse_();
@@ -4922,7 +5756,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c138(s1);
+        s1 = peg$c152(s1);
       }
       s0 = s1;
     }
@@ -4935,7 +5769,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 59,
+    var key    = peg$currPos * 82 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4952,11 +5786,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c99;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -4987,11 +5821,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c99;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -5025,7 +5859,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c139(s1, s2);
+        s1 = peg$c153(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5044,7 +5878,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 60,
+    var key    = peg$currPos * 82 + 65,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5077,7 +5911,7 @@ function peg$parse(input, options) {
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseGenericTypeExpr();
                           if (s0 === peg$FAILED) {
-                            s0 = peg$parseNamepathExpr();
+                            s0 = peg$parseBroadNamepathExpr();
                             if (s0 === peg$FAILED) {
                               s0 = peg$parseValueExpr();
                               if (s0 === peg$FAILED) {
@@ -5108,7 +5942,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 61,
+    var key    = peg$currPos * 82 + 66,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5137,7 +5971,7 @@ function peg$parse(input, options) {
                     if (s0 === peg$FAILED) {
                       s0 = peg$parseGenericTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseNamepathExpr();
+                        s0 = peg$parseBroadNamepathExpr();
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseValueExpr();
                           if (s0 === peg$FAILED) {
@@ -5166,7 +6000,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 62,
+    var key    = peg$currPos * 82 + 67,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5177,11 +6011,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c140;
+      s1 = peg$c154;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+      if (peg$silentFails === 0) { peg$fail(peg$c155); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5194,15 +6028,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c142;
+              s5 = peg$c156;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c143); }
+              if (peg$silentFails === 0) { peg$fail(peg$c157); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3);
+              s1 = peg$c158(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5233,7 +6067,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 77 + 63,
+    var key    = peg$currPos * 82 + 68,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5251,11 +6085,11 @@ function peg$parse(input, options) {
       s5 = peg$parse_();
       if (s5 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s6 = peg$c99;
+          s6 = peg$c113;
           peg$currPos++;
         } else {
           s6 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s6 !== peg$FAILED) {
           s5 = [s5, s6];
@@ -5273,11 +6107,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c145;
+            s6 = peg$c159;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c146); }
+            if (peg$silentFails === 0) { peg$fail(peg$c160); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5372,11 +6206,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s6 = peg$c99;
+            s6 = peg$c113;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -5394,11 +6228,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c145;
+              s6 = peg$c159;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c146); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -5492,11 +6326,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c99;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s4 = [s4, s5];
@@ -5514,11 +6348,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c145;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c146); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -5592,7 +6426,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c147(s1, s2);
+          s1 = peg$c161(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5615,7 +6449,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 77 + 64,
+    var key    = peg$currPos * 82 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5626,12 +6460,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c148) {
-      s2 = peg$c148;
+    if (input.substr(peg$currPos, 8) === peg$c162) {
+      s2 = peg$c162;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c149); }
+      if (peg$silentFails === 0) { peg$fail(peg$c163); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -5655,11 +6489,11 @@ function peg$parse(input, options) {
         s3 = peg$parse_();
         if (s3 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 63) {
-            s4 = peg$c44;
+            s4 = peg$c58;
             peg$currPos++;
           } else {
             s4 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c45); }
+            if (peg$silentFails === 0) { peg$fail(peg$c59); }
           }
           if (s4 === peg$FAILED) {
             s4 = null;
@@ -5668,11 +6502,11 @@ function peg$parse(input, options) {
             s5 = peg$parse_();
             if (s5 !== peg$FAILED) {
               if (input.charCodeAt(peg$currPos) === 58) {
-                s6 = peg$c122;
+                s6 = peg$c43;
                 peg$currPos++;
               } else {
                 s6 = peg$FAILED;
-                if (peg$silentFails === 0) { peg$fail(peg$c123); }
+                if (peg$silentFails === 0) { peg$fail(peg$c44); }
               }
               if (s6 !== peg$FAILED) {
                 s7 = peg$parse_();
@@ -5680,7 +6514,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c150(s1, s2, s4, s8);
+                    s1 = peg$c164(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5717,12 +6551,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c148) {
-        s2 = peg$c148;
+      if (input.substr(peg$currPos, 8) === peg$c162) {
+        s2 = peg$c162;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c149); }
+        if (peg$silentFails === 0) { peg$fail(peg$c163); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -5744,7 +6578,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c151(s1, s2);
+          s1 = peg$c165(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5764,7 +6598,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 65,
+    var key    = peg$currPos * 82 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5874,7 +6708,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c152(s2);
+          s1 = peg$c166(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5990,7 +6824,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c153(s2);
+            s1 = peg$c167(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6018,7 +6852,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c154(s1);
+          s1 = peg$c168(s1);
         }
         s0 = s1;
       }
@@ -6032,7 +6866,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 66,
+    var key    = peg$currPos * 82 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6061,7 +6895,7 @@ function peg$parse(input, options) {
                     if (s0 === peg$FAILED) {
                       s0 = peg$parseGenericTypeExpr();
                       if (s0 === peg$FAILED) {
-                        s0 = peg$parseNamepathExpr();
+                        s0 = peg$parseBroadNamepathExpr();
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseValueExpr();
                           if (s0 === peg$FAILED) {
@@ -6090,7 +6924,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 67,
+    var key    = peg$currPos * 82 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6101,11 +6935,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 91) {
-      s1 = peg$c110;
+      s1 = peg$c124;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c111); }
+      if (peg$silentFails === 0) { peg$fail(peg$c125); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6115,15 +6949,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 93) {
-              s5 = peg$c112;
+              s5 = peg$c126;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c113); }
+              if (peg$silentFails === 0) { peg$fail(peg$c127); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c155(s3);
+              s1 = peg$c169(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6154,7 +6988,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 77 + 68,
+    var key    = peg$currPos * 82 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6171,11 +7005,11 @@ function peg$parse(input, options) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
         if (input.charCodeAt(peg$currPos) === 44) {
-          s5 = peg$c99;
+          s5 = peg$c113;
           peg$currPos++;
         } else {
           s5 = peg$FAILED;
-          if (peg$silentFails === 0) { peg$fail(peg$c100); }
+          if (peg$silentFails === 0) { peg$fail(peg$c114); }
         }
         if (s5 !== peg$FAILED) {
           s6 = peg$parse_();
@@ -6206,11 +7040,11 @@ function peg$parse(input, options) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 44) {
-            s5 = peg$c99;
+            s5 = peg$c113;
             peg$currPos++;
           } else {
             s5 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c100); }
+            if (peg$silentFails === 0) { peg$fail(peg$c114); }
           }
           if (s5 !== peg$FAILED) {
             s6 = peg$parse_();
@@ -6244,7 +7078,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c156(s1, s2);
+        s1 = peg$c170(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6263,7 +7097,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 69,
+    var key    = peg$currPos * 82 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6296,7 +7130,7 @@ function peg$parse(input, options) {
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseGenericTypeExpr();
                           if (s0 === peg$FAILED) {
-                            s0 = peg$parseNamepathExpr();
+                            s0 = peg$parseBroadNamepathExpr();
                             if (s0 === peg$FAILED) {
                               s0 = peg$parseValueExpr();
                               if (s0 === peg$FAILED) {
@@ -6327,7 +7161,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 77 + 70,
+    var key    = peg$currPos * 82 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6338,11 +7172,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 40) {
-      s1 = peg$c84;
+      s1 = peg$c98;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c85); }
+      if (peg$silentFails === 0) { peg$fail(peg$c99); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6352,15 +7186,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 41) {
-              s5 = peg$c86;
+              s5 = peg$c100;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c87); }
+              if (peg$silentFails === 0) { peg$fail(peg$c101); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c157(s3);
+              s1 = peg$c171(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6391,7 +7225,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 71,
+    var key    = peg$currPos * 82 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6422,7 +7256,7 @@ function peg$parse(input, options) {
                       if (s0 === peg$FAILED) {
                         s0 = peg$parseGenericTypeExpr();
                         if (s0 === peg$FAILED) {
-                          s0 = peg$parseNamepathExpr();
+                          s0 = peg$parseBroadNamepathExpr();
                           if (s0 === peg$FAILED) {
                             s0 = peg$parseValueExpr();
                             if (s0 === peg$FAILED) {
@@ -6452,7 +7286,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 77 + 72,
+    var key    = peg$currPos * 82 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6477,7 +7311,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 77 + 73,
+    var key    = peg$currPos * 82 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6487,18 +7321,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c125) {
-      s1 = peg$c125;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c158(s2);
+        s1 = peg$c172(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6517,7 +7351,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 77 + 74,
+    var key    = peg$currPos * 82 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6529,16 +7363,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c125) {
-        s2 = peg$c125;
+      if (input.substr(peg$currPos, 3) === peg$c139) {
+        s2 = peg$c139;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c126); }
+        if (peg$silentFails === 0) { peg$fail(peg$c140); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c159(s1);
+        s1 = peg$c173(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -6557,7 +7391,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 77 + 75,
+    var key    = peg$currPos * 82 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6567,16 +7401,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c125) {
-      s1 = peg$c125;
+    if (input.substr(peg$currPos, 3) === peg$c139) {
+      s1 = peg$c139;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c126); }
+      if (peg$silentFails === 0) { peg$fail(peg$c140); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c160();
+      s1 = peg$c174();
     }
     s0 = s1;
 
@@ -6588,7 +7422,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 77 + 76,
+    var key    = peg$currPos * 82 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6621,7 +7455,7 @@ function peg$parse(input, options) {
                         if (s0 === peg$FAILED) {
                           s0 = peg$parseGenericTypeExpr();
                           if (s0 === peg$FAILED) {
-                            s0 = peg$parseNamepathExpr();
+                            s0 = peg$parseBroadNamepathExpr();
                             if (s0 === peg$FAILED) {
                               s0 = peg$parseValueExpr();
                               if (s0 === peg$FAILED) {

--- a/peg_lib/jsdoctype-typescript.js
+++ b/peg_lib/jsdoctype-typescript.js
@@ -568,24 +568,29 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { return { name: id, optional: true } },
-      peg$c137 = function(id) { return { name: id, optional: false } },
+      peg$c136 = function(id) { 
+              return { 
+                name: id, 
+                meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
+              }; 
+            },
+      peg$c137 = function(id) { return { name: id } },
       peg$c138 = function(paramsWithComma, lastParam) {
         return paramsWithComma.reduceRight(function(params, tokens) {
           const param = { 
-              type: tokens[0].optional 
-                  ? NodeType.NAMED_PARAMETER_OPTIONAL 
-                  : NodeType.NAMED_PARAMETER, 
-              name: tokens[0].name, 
+              name: tokens[0].name,
+              type: NodeType.NAMED_PARAMETER,
               typeName: tokens[4] 
           };
+          if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
         }, lastParam ? [lastParam] : []);
       },
       peg$c139 = "...",
       peg$c140 = peg$literalExpectation("...", false),
       peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
         if (spread) {
         return {
           type: NodeType.VARIADIC,
@@ -5275,7 +5280,7 @@ function peg$parse(input, options) {
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseJsIdentifier();
+        s3 = peg$parseArrowTypeParamIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {

--- a/peg_lib/jsdoctype-typescript.js
+++ b/peg_lib/jsdoctype-typescript.js
@@ -568,43 +568,74 @@ function peg$parse(input, options) {
       peg$c135 = function(params) {
                             return params;
                           },
-      peg$c136 = function(id) { 
+      peg$c136 = function(id) { return { name: id } },
+      peg$c137 = function(id) { 
               return { 
                 name: id, 
                 meta: { syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK } 
               }; 
             },
-      peg$c137 = function(id) { return { name: id } },
-      peg$c138 = function(paramsWithComma, lastParam) {
-        return paramsWithComma.reduceRight(function(params, tokens) {
+      peg$c138 = function(optionalParams, lastParam) {
+        const paramsArray = optionalParams.reduce((params, paramTokens) => {
+          const id = paramTokens[0];
           const param = { 
-              name: tokens[0].name,
+            type: NodeType.NAMED_PARAMETER,
+            name: id.name,
+            typeName: paramTokens[4]
+          };
+          if (id.meta) param.meta = id.meta;
+          params.push(param);
+          return params;
+        }, []);
+        if (lastParam) paramsArray.push(lastParam);
+
+        return paramsArray;
+      },
+      peg$c139 = function(requiredParams, finalParams) {
+        const paramsArray = requiredParams.reduce((params, paramTokens) => {
+          const param = {
+            type: NodeType.NAMED_PARAMETER,
+            name: paramTokens[0].name,
+            typeName: paramTokens[4]
+          }
+          params.push(param);
+          return params;
+        }, []);
+        return finalParams ? paramsArray.concat(finalParams) : paramsArray;
+          
+        return requiredParams.reduceRight(function(params, tokens) {
+          const param = { 
               type: NodeType.NAMED_PARAMETER,
+              name: tokens[0].name,
               typeName: tokens[4] 
           };
           if (tokens[0].meta) param.meta = tokens[0].meta;
           return [param].concat(params);
-        }, lastParam ? [lastParam] : []);
+        }, finalParams ? [finalParams] : []);
       },
-      peg$c139 = "...",
-      peg$c140 = peg$literalExpectation("...", false),
-      peg$c141 = function(spread, id, type) {
-        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
-        if (id.meta) operand.meta = id.meta;
-        if (spread) {
+      peg$c140 = "...",
+      peg$c141 = peg$literalExpectation("...", false),
+      peg$c142 = function(spread, id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id, typeName: type };
         return {
           type: NodeType.VARIADIC,
           value: operand,
           meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
         };
-        }
-        else {
-          return operand;
-        }
       },
-      peg$c142 = "function",
-      peg$c143 = peg$literalExpectation("function", false),
-      peg$c144 = function(paramsPart, returnedTypePart) {
+      peg$c143 = function(id, type) { // TODO: Add default value support
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c144 = function(id, type) {
+        const operand = { type: NodeType.NAMED_PARAMETER, name: id.name, typeName: type };
+        if (id.meta) operand.meta = id.meta;
+        return operand;
+      },
+      peg$c145 = "function",
+      peg$c146 = peg$literalExpectation("function", false),
+      peg$c147 = function(paramsPart, returnedTypePart) {
                          const returnedTypeNode = returnedTypePart ? returnedTypePart[2] : null;
 
                          return {
@@ -615,53 +646,53 @@ function peg$parse(input, options) {
                            new: paramsPart.modifier.nodeNew,
                          };
                        },
-      peg$c145 = function(modifier, params) {
+      peg$c148 = function(modifier, params) {
                                      return { params, modifier };
                                    },
-      peg$c146 = function(modifier) {
+      peg$c149 = function(modifier) {
                                      return { params: [], modifier };
                                    },
-      peg$c147 = function() {
+      peg$c150 = function() {
                                      return { params: [], modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c148 = function(params) {
+      peg$c151 = function(params) {
                                      return { params, modifier: { nodeThis: null, nodeNew: null } };
                                    },
-      peg$c149 = "this",
-      peg$c150 = peg$literalExpectation("this", false),
-      peg$c151 = function(modifierThis) {
+      peg$c152 = "this",
+      peg$c153 = peg$literalExpectation("this", false),
+      peg$c154 = function(modifierThis) {
                                    return { nodeThis: modifierThis[4], nodeNew: null };
                                  },
-      peg$c152 = function(modifierNew) {
+      peg$c155 = function(modifierNew) {
                                    return { nodeThis: null, nodeNew: modifierNew[4] };
                                  },
-      peg$c153 = function(paramsWithComma, lastParam) {
+      peg$c156 = function(paramsWithComma, lastParam) {
                                return paramsWithComma.reduceRight(function(params, tokens) {
                                  const [param] = tokens;
                                  return [param].concat(params);
                                }, lastParam ? [lastParam] : []);
                              },
-      peg$c154 = "{",
-      peg$c155 = peg$literalExpectation("{", false),
-      peg$c156 = "}",
-      peg$c157 = peg$literalExpectation("}", false),
-      peg$c158 = function(entries) {
+      peg$c157 = "{",
+      peg$c158 = peg$literalExpectation("{", false),
+      peg$c159 = "}",
+      peg$c160 = peg$literalExpectation("}", false),
+      peg$c161 = function(entries) {
                        return {
                          type: NodeType.RECORD,
                          entries: entries || [],
                        };
                      },
-      peg$c159 = ";",
-      peg$c160 = peg$literalExpectation(";", false),
-      peg$c161 = function(first, restWithComma) {
+      peg$c162 = ";",
+      peg$c163 = peg$literalExpectation(";", false),
+      peg$c164 = function(first, restWithComma) {
                               return restWithComma.reduce(function(entries, tokens) {
                                 const entry = tokens[2];
                                 return entries.concat([entry]);
                               }, [first]);
                             },
-      peg$c162 = "readonly",
-      peg$c163 = peg$literalExpectation("readonly", false),
-      peg$c164 = function(readonly, keyInfo, optional, value) {
+      peg$c165 = "readonly",
+      peg$c166 = peg$literalExpectation("readonly", false),
+      peg$c167 = function(readonly, keyInfo, optional, value) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -677,7 +708,7 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c165 = function(readonly, keyInfo) {
+      peg$c168 = function(readonly, keyInfo) {
                               const {quoteStyle, key} = keyInfo;
                               return {
                                 type: NodeType.RECORD_ENTRY,
@@ -687,59 +718,59 @@ function peg$parse(input, options) {
                                 readonly: Boolean(readonly)
                               };
                             },
-      peg$c166 = function(key) {
+      peg$c169 = function(key) {
                                  return {
                                    quoteStyle: 'double',
                                    key: key.replace(/\\"/gu, '"')
                                      .replace(/\\\\/gu, '\\')
                                  };
                              },
-      peg$c167 = function(key) {
+      peg$c170 = function(key) {
                                  return {
                                    quoteStyle: 'single',
                                    key: key.replace(/\\'/g, "'")
                                      .replace(/\\\\/gu, '\\')
                                  };
                                },
-      peg$c168 = function(key) {
+      peg$c171 = function(key) {
                                  return {
                                    quoteStyle: 'none',
                                    key
                                  };
                              },
-      peg$c169 = function(entries) {
+      peg$c172 = function(entries) {
         return {
           type: NodeType.TUPLE,
           entries,
         }
       },
-      peg$c170 = function(restWithComma, last) {
+      peg$c173 = function(restWithComma, last) {
         return restWithComma.reduceRight((entries, tokens) => {
           let [entry] = tokens;
           return [entry].concat(entries);
         }, last ? [last] : []);
       },
-      peg$c171 = function(wrapped) {
+      peg$c174 = function(wrapped) {
                           return {
                             type: NodeType.PARENTHESIS,
                             value: wrapped,
                           };
                         },
-      peg$c172 = function(operand) {
+      peg$c175 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.PREFIX_DOTS },
                                };
                              },
-      peg$c173 = function(operand) {
+      peg$c176 = function(operand) {
                                return {
                                  type: NodeType.VARIADIC,
                                  value: operand,
                                  meta: { syntax: VariadicTypeSyntax.SUFFIX_DOTS },
                                };
                              },
-      peg$c174 = function() {
+      peg$c177 = function() {
                             return {
                               type: NodeType.VARIADIC,
                               value: { type: NodeType.ANY },
@@ -888,7 +919,7 @@ function peg$parse(input, options) {
   function peg$parseTopTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 0,
+    var key    = peg$currPos * 89 + 0,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -976,7 +1007,7 @@ function peg$parse(input, options) {
   function peg$parseWS() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 1,
+    var key    = peg$currPos * 89 + 1,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1033,7 +1064,7 @@ function peg$parse(input, options) {
   function peg$parse_() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 2,
+    var key    = peg$currPos * 89 + 2,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1057,7 +1088,7 @@ function peg$parse(input, options) {
   function peg$parse__() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 3,
+    var key    = peg$currPos * 89 + 3,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1085,7 +1116,7 @@ function peg$parse(input, options) {
   function peg$parseJsIdentifier() {
     var s0, s1, s2, s3, s4;
 
-    var key    = peg$currPos * 82 + 4,
+    var key    = peg$currPos * 89 + 4,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1147,7 +1178,7 @@ function peg$parse(input, options) {
   function peg$parseNamepathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 5,
+    var key    = peg$currPos * 89 + 5,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1286,7 +1317,7 @@ function peg$parse(input, options) {
   function peg$parseTypeNameExprJsDocFlavored() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 6,
+    var key    = peg$currPos * 89 + 6,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1354,7 +1385,7 @@ function peg$parse(input, options) {
   function peg$parseMemberName() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 7,
+    var key    = peg$currPos * 89 + 7,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1613,7 +1644,7 @@ function peg$parse(input, options) {
   function peg$parseInfixNamepathOperator() {
     var s0;
 
-    var key    = peg$currPos * 82 + 8,
+    var key    = peg$currPos * 89 + 8,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1638,7 +1669,7 @@ function peg$parse(input, options) {
   function peg$parseQualifiedMemberName() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 9,
+    var key    = peg$currPos * 89 + 9,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1741,7 +1772,7 @@ function peg$parse(input, options) {
   function peg$parseMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 10,
+    var key    = peg$currPos * 89 + 10,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1772,7 +1803,7 @@ function peg$parse(input, options) {
   function peg$parseInnerMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 11,
+    var key    = peg$currPos * 89 + 11,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1803,7 +1834,7 @@ function peg$parse(input, options) {
   function peg$parseInstanceMemberTypeOperator() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 12,
+    var key    = peg$currPos * 89 + 12,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1834,7 +1865,7 @@ function peg$parse(input, options) {
   function peg$parseBroadNamepathExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 13,
+    var key    = peg$currPos * 89 + 13,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -1859,7 +1890,7 @@ function peg$parse(input, options) {
   function peg$parseExternalNameExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
 
-    var key    = peg$currPos * 82 + 14,
+    var key    = peg$currPos * 89 + 14,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2028,7 +2059,7 @@ function peg$parse(input, options) {
   function peg$parseModuleNameExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 15,
+    var key    = peg$currPos * 89 + 15,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2092,7 +2123,7 @@ function peg$parse(input, options) {
   function peg$parseModulePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 16,
+    var key    = peg$currPos * 89 + 16,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2225,7 +2256,7 @@ function peg$parse(input, options) {
   function peg$parseFilePathExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 17,
+    var key    = peg$currPos * 89 + 17,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2511,7 +2542,7 @@ function peg$parse(input, options) {
   function peg$parseAnyTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 18,
+    var key    = peg$currPos * 89 + 18,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2542,7 +2573,7 @@ function peg$parse(input, options) {
   function peg$parseUnknownTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 19,
+    var key    = peg$currPos * 89 + 19,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2573,7 +2604,7 @@ function peg$parse(input, options) {
   function peg$parseValueExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 20,
+    var key    = peg$currPos * 89 + 20,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2595,7 +2626,7 @@ function peg$parse(input, options) {
   function peg$parseStringLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 21,
+    var key    = peg$currPos * 89 + 21,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2845,7 +2876,7 @@ function peg$parse(input, options) {
   function peg$parseNumberLiteralExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 22,
+    var key    = peg$currPos * 89 + 22,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2879,7 +2910,7 @@ function peg$parse(input, options) {
   function peg$parseDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 23,
+    var key    = peg$currPos * 89 + 23,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -2936,7 +2967,7 @@ function peg$parse(input, options) {
   function peg$parseUnsignedDecimalNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 24,
+    var key    = peg$currPos * 89 + 24,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3166,7 +3197,7 @@ function peg$parse(input, options) {
   function peg$parseBinNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 25,
+    var key    = peg$currPos * 89 + 25,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3247,7 +3278,7 @@ function peg$parse(input, options) {
   function peg$parseOctNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 26,
+    var key    = peg$currPos * 89 + 26,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3328,7 +3359,7 @@ function peg$parse(input, options) {
   function peg$parseHexNumberLiteralExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 27,
+    var key    = peg$currPos * 89 + 27,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3409,7 +3440,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 28,
+    var key    = peg$currPos * 89 + 28,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3470,7 +3501,7 @@ function peg$parse(input, options) {
   function peg$parseIntersectionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 29,
+    var key    = peg$currPos * 89 + 29,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3528,7 +3559,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 30,
+    var key    = peg$currPos * 89 + 30,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3589,7 +3620,7 @@ function peg$parse(input, options) {
   function peg$parseUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 31,
+    var key    = peg$currPos * 89 + 31,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3647,7 +3678,7 @@ function peg$parse(input, options) {
   function peg$parseUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 32,
+    var key    = peg$currPos * 89 + 32,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3669,7 +3700,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 33,
+    var key    = peg$currPos * 89 + 33,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3691,7 +3722,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 34,
+    var key    = peg$currPos * 89 + 34,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3737,7 +3768,7 @@ function peg$parse(input, options) {
   function peg$parseTypeQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 35,
+    var key    = peg$currPos * 89 + 35,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3783,7 +3814,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 36,
+    var key    = peg$currPos * 89 + 36,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3853,7 +3884,7 @@ function peg$parse(input, options) {
   function peg$parseKeyQueryExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 37,
+    var key    = peg$currPos * 89 + 37,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3914,7 +3945,7 @@ function peg$parse(input, options) {
   function peg$parseImportTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 38,
+    var key    = peg$currPos * 89 + 38,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -3996,7 +4027,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 39,
+    var key    = peg$currPos * 89 + 39,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4042,7 +4073,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 40,
+    var key    = peg$currPos * 89 + 40,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4088,7 +4119,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 41,
+    var key    = peg$currPos * 89 + 41,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4113,7 +4144,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixUnaryUnionTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 42,
+    var key    = peg$currPos * 89 + 42,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4162,7 +4193,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 43,
+    var key    = peg$currPos * 89 + 43,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4208,7 +4239,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixNotNullableTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 44,
+    var key    = peg$currPos * 89 + 44,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4254,7 +4285,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixOptionalTypeExpr() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 45,
+    var key    = peg$currPos * 89 + 45,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4306,7 +4337,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 46,
+    var key    = peg$currPos * 89 + 46,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4370,7 +4401,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 47,
+    var key    = peg$currPos * 89 + 47,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4401,7 +4432,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 48,
+    var key    = peg$currPos * 89 + 48,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4465,7 +4496,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeExprTypeParamList() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 49,
+    var key    = peg$currPos * 89 + 49,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4568,7 +4599,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeStartToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 50,
+    var key    = peg$currPos * 89 + 50,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4590,7 +4621,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEcmaScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 51,
+    var key    = peg$currPos * 89 + 51,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4621,7 +4652,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeTypeScriptFlavoredStartToken() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 52,
+    var key    = peg$currPos * 89 + 52,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4652,7 +4683,7 @@ function peg$parse(input, options) {
   function peg$parseGenericTypeEndToken() {
     var s0;
 
-    var key    = peg$currPos * 82 + 53,
+    var key    = peg$currPos * 89 + 53,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4677,7 +4708,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 54,
+    var key    = peg$currPos * 89 + 54,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4796,7 +4827,7 @@ function peg$parse(input, options) {
   function peg$parseArrayTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 55,
+    var key    = peg$currPos * 89 + 55,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4851,7 +4882,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExpr() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 56,
+    var key    = peg$currPos * 89 + 56,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -4930,7 +4961,7 @@ function peg$parse(input, options) {
   function peg$parseArrowTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 57,
+    var key    = peg$currPos * 89 + 57,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5027,10 +5058,35 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseArrowTypeParamIdentifier() {
+  function peg$parseArrowTypeRequiredParamEntry() {
+    var s0, s1;
+
+    var key    = peg$currPos * 89 + 58,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseJsIdentifier();
+    if (s1 !== peg$FAILED) {
+      peg$savedPos = s0;
+      s1 = peg$c136(s1);
+    }
+    s0 = s1;
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeOptionalParamEntry() {
     var s0, s1, s2, s3;
 
-    var key    = peg$currPos * 82 + 58,
+    var key    = peg$currPos * 89 + 59,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5053,7 +5109,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c136(s1);
+          s1 = peg$c137(s1);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -5067,25 +5123,16 @@ function peg$parse(input, options) {
       peg$currPos = s0;
       s0 = peg$FAILED;
     }
-    if (s0 === peg$FAILED) {
-      s0 = peg$currPos;
-      s1 = peg$parseJsIdentifier();
-      if (s1 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c137(s1);
-      }
-      s0 = s1;
-    }
 
     peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
 
     return s0;
   }
 
-  function peg$parseArrowTypeExprParams() {
+  function peg$parseArrowOptionalLastParams() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
 
-    var key    = peg$currPos * 82 + 59,
+    var key    = peg$currPos * 89 + 60,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5097,7 +5144,7 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = [];
     s2 = peg$currPos;
-    s3 = peg$parseArrowTypeParamIdentifier();
+    s3 = peg$parseArrowTypeOptionalParamEntry();
     if (s3 !== peg$FAILED) {
       s4 = peg$parse_();
       if (s4 !== peg$FAILED) {
@@ -5165,7 +5212,7 @@ function peg$parse(input, options) {
     while (s2 !== peg$FAILED) {
       s1.push(s2);
       s2 = peg$currPos;
-      s3 = peg$parseArrowTypeParamIdentifier();
+      s3 = peg$parseArrowTypeOptionalParamEntry();
       if (s3 !== peg$FAILED) {
         s4 = peg$parse_();
         if (s4 !== peg$FAILED) {
@@ -5232,14 +5279,17 @@ function peg$parse(input, options) {
       }
     }
     if (s1 !== peg$FAILED) {
-      s2 = peg$parseVariadicNameExpr();
-      if (s2 === peg$FAILED) {
-        s2 = null;
-      }
+      s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        peg$savedPos = s0;
-        s1 = peg$c138(s1, s2);
-        s0 = s1;
+        s3 = peg$parseOptionalLastParamExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c138(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
       } else {
         peg$currPos = s0;
         s0 = peg$FAILED;
@@ -5254,10 +5304,32 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseVariadicNameExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7;
+  function peg$parseFinalParamsExpr() {
+    var s0;
 
-    var key    = peg$currPos * 82 + 60,
+    var key    = peg$currPos * 89 + 61,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseArrowOptionalLastParams();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredLastParamExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseArrowTypeExprParams() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10;
+
+    var key    = peg$currPos * 89 + 62,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5267,20 +5339,192 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
-      peg$currPos += 3;
+    s1 = [];
+    s2 = peg$currPos;
+    s3 = peg$parseArrowTypeRequiredParamEntry();
+    if (s3 !== peg$FAILED) {
+      s4 = peg$parse_();
+      if (s4 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s5 = peg$c43;
+          peg$currPos++;
+        } else {
+          s5 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parse_();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parseFunctionTypeExprParamOperand();
+            if (s7 === peg$FAILED) {
+              s7 = null;
+            }
+            if (s7 !== peg$FAILED) {
+              s8 = peg$parse_();
+              if (s8 !== peg$FAILED) {
+                if (input.charCodeAt(peg$currPos) === 44) {
+                  s9 = peg$c113;
+                  peg$currPos++;
+                } else {
+                  s9 = peg$FAILED;
+                  if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                }
+                if (s9 !== peg$FAILED) {
+                  s10 = peg$parse_();
+                  if (s10 !== peg$FAILED) {
+                    s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                    s2 = s3;
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     } else {
-      s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      peg$currPos = s2;
+      s2 = peg$FAILED;
     }
-    if (s1 === peg$FAILED) {
-      s1 = null;
+    while (s2 !== peg$FAILED) {
+      s1.push(s2);
+      s2 = peg$currPos;
+      s3 = peg$parseArrowTypeRequiredParamEntry();
+      if (s3 !== peg$FAILED) {
+        s4 = peg$parse_();
+        if (s4 !== peg$FAILED) {
+          if (input.charCodeAt(peg$currPos) === 58) {
+            s5 = peg$c43;
+            peg$currPos++;
+          } else {
+            s5 = peg$FAILED;
+            if (peg$silentFails === 0) { peg$fail(peg$c44); }
+          }
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parse_();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parseFunctionTypeExprParamOperand();
+              if (s7 === peg$FAILED) {
+                s7 = null;
+              }
+              if (s7 !== peg$FAILED) {
+                s8 = peg$parse_();
+                if (s8 !== peg$FAILED) {
+                  if (input.charCodeAt(peg$currPos) === 44) {
+                    s9 = peg$c113;
+                    peg$currPos++;
+                  } else {
+                    s9 = peg$FAILED;
+                    if (peg$silentFails === 0) { peg$fail(peg$c114); }
+                  }
+                  if (s9 !== peg$FAILED) {
+                    s10 = peg$parse_();
+                    if (s10 !== peg$FAILED) {
+                      s3 = [s3, s4, s5, s6, s7, s8, s9, s10];
+                      s2 = s3;
+                    } else {
+                      peg$currPos = s2;
+                      s2 = peg$FAILED;
+                    }
+                  } else {
+                    peg$currPos = s2;
+                    s2 = peg$FAILED;
+                  }
+                } else {
+                  peg$currPos = s2;
+                  s2 = peg$FAILED;
+                }
+              } else {
+                peg$currPos = s2;
+                s2 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s2;
+              s2 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s2;
+            s2 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s2;
+          s2 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s2;
+        s2 = peg$FAILED;
+      }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseArrowTypeParamIdentifier();
+        s3 = peg$parseFinalParamsExpr();
+        if (s3 !== peg$FAILED) {
+          peg$savedPos = s0;
+          s1 = peg$c139(s1, s3);
+          s0 = s1;
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseSpreadVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7;
+
+    var key    = peg$currPos * 89 + 63,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
+      peg$currPos += 3;
+    } else {
+      s1 = peg$FAILED;
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
+    }
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        s3 = peg$parseJsIdentifier();
         if (s3 !== peg$FAILED) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
@@ -5300,7 +5544,7 @@ function peg$parse(input, options) {
                 }
                 if (s7 !== peg$FAILED) {
                   peg$savedPos = s0;
-                  s1 = peg$c141(s1, s3, s7);
+                  s1 = peg$c142(s1, s3, s7);
                   s0 = s1;
                 } else {
                   peg$currPos = s0;
@@ -5336,10 +5580,10 @@ function peg$parse(input, options) {
     return s0;
   }
 
-  function peg$parseFunctionTypeExpr() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+  function peg$parseRequiredVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 61,
+    var key    = peg$currPos * 89 + 64,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5349,12 +5593,178 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c142) {
-      s1 = peg$c142;
+    s1 = peg$parseArrowTypeRequiredParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c143(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalVariadicNameExpr() {
+    var s0, s1, s2, s3, s4, s5;
+
+    var key    = peg$currPos * 89 + 65,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    s1 = peg$parseArrowTypeOptionalParamEntry();
+    if (s1 !== peg$FAILED) {
+      s2 = peg$parse_();
+      if (s2 !== peg$FAILED) {
+        if (input.charCodeAt(peg$currPos) === 58) {
+          s3 = peg$c43;
+          peg$currPos++;
+        } else {
+          s3 = peg$FAILED;
+          if (peg$silentFails === 0) { peg$fail(peg$c44); }
+        }
+        if (s3 !== peg$FAILED) {
+          s4 = peg$parse_();
+          if (s4 !== peg$FAILED) {
+            s5 = peg$parseFunctionTypeExprParamOperand();
+            if (s5 === peg$FAILED) {
+              s5 = null;
+            }
+            if (s5 !== peg$FAILED) {
+              peg$savedPos = s0;
+              s1 = peg$c144(s1, s5);
+              s0 = s1;
+            } else {
+              peg$currPos = s0;
+              s0 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s0;
+            s0 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s0;
+          s0 = peg$FAILED;
+        }
+      } else {
+        peg$currPos = s0;
+        s0 = peg$FAILED;
+      }
+    } else {
+      peg$currPos = s0;
+      s0 = peg$FAILED;
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseOptionalLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 66,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseOptionalVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseRequiredLastParamExpr() {
+    var s0;
+
+    var key    = peg$currPos * 89 + 67,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$parseSpreadVariadicNameExpr();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parseRequiredVariadicNameExpr();
+    }
+
+    peg$resultsCache[key] = { nextPos: peg$currPos, result: s0 };
+
+    return s0;
+  }
+
+  function peg$parseFunctionTypeExpr() {
+    var s0, s1, s2, s3, s4, s5, s6, s7, s8;
+
+    var key    = peg$currPos * 89 + 68,
+        cached = peg$resultsCache[key];
+
+    if (cached) {
+      peg$currPos = cached.nextPos;
+
+      return cached.result;
+    }
+
+    s0 = peg$currPos;
+    if (input.substr(peg$currPos, 8) === peg$c145) {
+      s1 = peg$c145;
       peg$currPos += 8;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c143); }
+      if (peg$silentFails === 0) { peg$fail(peg$c146); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -5395,7 +5805,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c144(s3, s5);
+              s1 = peg$c147(s3, s5);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5426,7 +5836,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamsList() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9;
 
-    var key    = peg$currPos * 82 + 62,
+    var key    = peg$currPos * 89 + 69,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5473,7 +5883,7 @@ function peg$parse(input, options) {
                     }
                     if (s9 !== peg$FAILED) {
                       peg$savedPos = s0;
-                      s1 = peg$c145(s3, s7);
+                      s1 = peg$c148(s3, s7);
                       s0 = s1;
                     } else {
                       peg$currPos = s0;
@@ -5536,7 +5946,7 @@ function peg$parse(input, options) {
               }
               if (s5 !== peg$FAILED) {
                 peg$savedPos = s0;
-                s1 = peg$c146(s3);
+                s1 = peg$c149(s3);
                 s0 = s1;
               } else {
                 peg$currPos = s0;
@@ -5579,7 +5989,7 @@ function peg$parse(input, options) {
             }
             if (s3 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c147();
+              s1 = peg$c150();
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -5618,7 +6028,7 @@ function peg$parse(input, options) {
                   }
                   if (s5 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c148(s3);
+                    s1 = peg$c151(s3);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -5652,7 +6062,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprModifier() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 63,
+    var key    = peg$currPos * 89 + 70,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5663,12 +6073,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 4) === peg$c149) {
-      s2 = peg$c149;
+    if (input.substr(peg$currPos, 4) === peg$c152) {
+      s2 = peg$c152;
       peg$currPos += 4;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c150); }
+      if (peg$silentFails === 0) { peg$fail(peg$c153); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse_();
@@ -5709,7 +6119,7 @@ function peg$parse(input, options) {
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c151(s1);
+      s1 = peg$c154(s1);
     }
     s0 = s1;
     if (s0 === peg$FAILED) {
@@ -5761,7 +6171,7 @@ function peg$parse(input, options) {
       }
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c152(s1);
+        s1 = peg$c155(s1);
       }
       s0 = s1;
     }
@@ -5774,7 +6184,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParams() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 64,
+    var key    = peg$currPos * 89 + 71,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5864,7 +6274,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c153(s1, s2);
+        s1 = peg$c156(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -5883,7 +6293,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprParamOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 65,
+    var key    = peg$currPos * 89 + 72,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -5947,7 +6357,7 @@ function peg$parse(input, options) {
   function peg$parseFunctionTypeExprReturnableOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 66,
+    var key    = peg$currPos * 89 + 73,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6005,7 +6415,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 67,
+    var key    = peg$currPos * 89 + 74,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6016,11 +6426,11 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     if (input.charCodeAt(peg$currPos) === 123) {
-      s1 = peg$c154;
+      s1 = peg$c157;
       peg$currPos++;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c155); }
+      if (peg$silentFails === 0) { peg$fail(peg$c158); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parse_();
@@ -6033,15 +6443,15 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 125) {
-              s5 = peg$c156;
+              s5 = peg$c159;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c157); }
+              if (peg$silentFails === 0) { peg$fail(peg$c160); }
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c158(s3);
+              s1 = peg$c161(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6072,7 +6482,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6, s7;
 
-    var key    = peg$currPos * 82 + 68,
+    var key    = peg$currPos * 89 + 75,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6112,11 +6522,11 @@ function peg$parse(input, options) {
         s5 = peg$parse_();
         if (s5 !== peg$FAILED) {
           if (input.charCodeAt(peg$currPos) === 59) {
-            s6 = peg$c159;
+            s6 = peg$c162;
             peg$currPos++;
           } else {
             s6 = peg$FAILED;
-            if (peg$silentFails === 0) { peg$fail(peg$c160); }
+            if (peg$silentFails === 0) { peg$fail(peg$c163); }
           }
           if (s6 !== peg$FAILED) {
             s5 = [s5, s6];
@@ -6233,11 +6643,11 @@ function peg$parse(input, options) {
           s5 = peg$parse_();
           if (s5 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s6 = peg$c159;
+              s6 = peg$c162;
               peg$currPos++;
             } else {
               s6 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s6 !== peg$FAILED) {
               s5 = [s5, s6];
@@ -6353,11 +6763,11 @@ function peg$parse(input, options) {
           s4 = peg$parse_();
           if (s4 !== peg$FAILED) {
             if (input.charCodeAt(peg$currPos) === 59) {
-              s5 = peg$c159;
+              s5 = peg$c162;
               peg$currPos++;
             } else {
               s5 = peg$FAILED;
-              if (peg$silentFails === 0) { peg$fail(peg$c160); }
+              if (peg$silentFails === 0) { peg$fail(peg$c163); }
             }
             if (s5 !== peg$FAILED) {
               s4 = [s4, s5];
@@ -6431,7 +6841,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c161(s1, s2);
+          s1 = peg$c164(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6454,7 +6864,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntry() {
     var s0, s1, s2, s3, s4, s5, s6, s7, s8;
 
-    var key    = peg$currPos * 82 + 69,
+    var key    = peg$currPos * 89 + 76,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6465,12 +6875,12 @@ function peg$parse(input, options) {
 
     s0 = peg$currPos;
     s1 = peg$currPos;
-    if (input.substr(peg$currPos, 8) === peg$c162) {
-      s2 = peg$c162;
+    if (input.substr(peg$currPos, 8) === peg$c165) {
+      s2 = peg$c165;
       peg$currPos += 8;
     } else {
       s2 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c163); }
+      if (peg$silentFails === 0) { peg$fail(peg$c166); }
     }
     if (s2 !== peg$FAILED) {
       s3 = peg$parse__();
@@ -6519,7 +6929,7 @@ function peg$parse(input, options) {
                   s8 = peg$parseRecordTypeExprEntryOperand();
                   if (s8 !== peg$FAILED) {
                     peg$savedPos = s0;
-                    s1 = peg$c164(s1, s2, s4, s8);
+                    s1 = peg$c167(s1, s2, s4, s8);
                     s0 = s1;
                   } else {
                     peg$currPos = s0;
@@ -6556,12 +6966,12 @@ function peg$parse(input, options) {
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
       s1 = peg$currPos;
-      if (input.substr(peg$currPos, 8) === peg$c162) {
-        s2 = peg$c162;
+      if (input.substr(peg$currPos, 8) === peg$c165) {
+        s2 = peg$c165;
         peg$currPos += 8;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c163); }
+        if (peg$silentFails === 0) { peg$fail(peg$c166); }
       }
       if (s2 !== peg$FAILED) {
         s3 = peg$parse__();
@@ -6583,7 +6993,7 @@ function peg$parse(input, options) {
         s2 = peg$parseRecordTypeExprEntryKey();
         if (s2 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c165(s1, s2);
+          s1 = peg$c168(s1, s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6603,7 +7013,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryKey() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 70,
+    var key    = peg$currPos * 89 + 77,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6713,7 +7123,7 @@ function peg$parse(input, options) {
         }
         if (s3 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c166(s2);
+          s1 = peg$c169(s2);
           s0 = s1;
         } else {
           peg$currPos = s0;
@@ -6829,7 +7239,7 @@ function peg$parse(input, options) {
           }
           if (s3 !== peg$FAILED) {
             peg$savedPos = s0;
-            s1 = peg$c167(s2);
+            s1 = peg$c170(s2);
             s0 = s1;
           } else {
             peg$currPos = s0;
@@ -6857,7 +7267,7 @@ function peg$parse(input, options) {
         }
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
-          s1 = peg$c168(s1);
+          s1 = peg$c171(s1);
         }
         s0 = s1;
       }
@@ -6871,7 +7281,7 @@ function peg$parse(input, options) {
   function peg$parseRecordTypeExprEntryOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 71,
+    var key    = peg$currPos * 89 + 78,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6929,7 +7339,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 72,
+    var key    = peg$currPos * 89 + 79,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -6962,7 +7372,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c169(s3);
+              s1 = peg$c172(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -6993,7 +7403,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprEntries() {
     var s0, s1, s2, s3, s4, s5, s6;
 
-    var key    = peg$currPos * 82 + 73,
+    var key    = peg$currPos * 89 + 80,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7083,7 +7493,7 @@ function peg$parse(input, options) {
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c170(s1, s2);
+        s1 = peg$c173(s1, s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7102,7 +7512,7 @@ function peg$parse(input, options) {
   function peg$parseTupleTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 74,
+    var key    = peg$currPos * 89 + 81,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7166,7 +7576,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExpr() {
     var s0, s1, s2, s3, s4, s5;
 
-    var key    = peg$currPos * 82 + 75,
+    var key    = peg$currPos * 89 + 82,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7199,7 +7609,7 @@ function peg$parse(input, options) {
             }
             if (s5 !== peg$FAILED) {
               peg$savedPos = s0;
-              s1 = peg$c171(s3);
+              s1 = peg$c174(s3);
               s0 = s1;
             } else {
               peg$currPos = s0;
@@ -7230,7 +7640,7 @@ function peg$parse(input, options) {
   function peg$parseParenthesizedExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 76,
+    var key    = peg$currPos * 89 + 83,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7291,7 +7701,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExpr() {
     var s0;
 
-    var key    = peg$currPos * 82 + 77,
+    var key    = peg$currPos * 89 + 84,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7316,7 +7726,7 @@ function peg$parse(input, options) {
   function peg$parsePrefixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 78,
+    var key    = peg$currPos * 89 + 85,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7326,18 +7736,18 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       s2 = peg$parseVariadicTypeExprOperand();
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c172(s2);
+        s1 = peg$c175(s2);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7356,7 +7766,7 @@ function peg$parse(input, options) {
   function peg$parseSuffixVariadicTypeExpr() {
     var s0, s1, s2;
 
-    var key    = peg$currPos * 82 + 79,
+    var key    = peg$currPos * 89 + 86,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7368,16 +7778,16 @@ function peg$parse(input, options) {
     s0 = peg$currPos;
     s1 = peg$parseVariadicTypeExprOperand();
     if (s1 !== peg$FAILED) {
-      if (input.substr(peg$currPos, 3) === peg$c139) {
-        s2 = peg$c139;
+      if (input.substr(peg$currPos, 3) === peg$c140) {
+        s2 = peg$c140;
         peg$currPos += 3;
       } else {
         s2 = peg$FAILED;
-        if (peg$silentFails === 0) { peg$fail(peg$c140); }
+        if (peg$silentFails === 0) { peg$fail(peg$c141); }
       }
       if (s2 !== peg$FAILED) {
         peg$savedPos = s0;
-        s1 = peg$c173(s1);
+        s1 = peg$c176(s1);
         s0 = s1;
       } else {
         peg$currPos = s0;
@@ -7396,7 +7806,7 @@ function peg$parse(input, options) {
   function peg$parseAnyVariadicTypeExpr() {
     var s0, s1;
 
-    var key    = peg$currPos * 82 + 80,
+    var key    = peg$currPos * 89 + 87,
         cached = peg$resultsCache[key];
 
     if (cached) {
@@ -7406,16 +7816,16 @@ function peg$parse(input, options) {
     }
 
     s0 = peg$currPos;
-    if (input.substr(peg$currPos, 3) === peg$c139) {
-      s1 = peg$c139;
+    if (input.substr(peg$currPos, 3) === peg$c140) {
+      s1 = peg$c140;
       peg$currPos += 3;
     } else {
       s1 = peg$FAILED;
-      if (peg$silentFails === 0) { peg$fail(peg$c140); }
+      if (peg$silentFails === 0) { peg$fail(peg$c141); }
     }
     if (s1 !== peg$FAILED) {
       peg$savedPos = s0;
-      s1 = peg$c174();
+      s1 = peg$c177();
     }
     s0 = s1;
 
@@ -7427,7 +7837,7 @@ function peg$parse(input, options) {
   function peg$parseVariadicTypeExprOperand() {
     var s0;
 
-    var key    = peg$currPos * 82 + 81,
+    var key    = peg$currPos * 89 + 88,
         cached = peg$resultsCache[key];
 
     if (cached) {

--- a/peg_src/jsdoctype.pegjs
+++ b/peg_src/jsdoctype.pegjs
@@ -821,9 +821,16 @@ ArrowTypeExprParamsList = "(" _ ")" {
                     "(" _ params:ArrowTypeExprParams _ ")" {
                       return params;
                     }
-ArrowTypeExprParams = paramsWithComma:(JsIdentifier _ ":" _ FunctionTypeExprParamOperand? _ "," _)* lastParam:VariadicNameExpr? {
+ArrowTypeParamIdentifier = id:JsIdentifier _ "?" { return { name: id, optional: true } } / id:JsIdentifier { return { name: id, optional: false } }
+ArrowTypeExprParams = paramsWithComma:(ArrowTypeParamIdentifier _ ":" _ FunctionTypeExprParamOperand? _ "," _)* lastParam:VariadicNameExpr? {
   return paramsWithComma.reduceRight(function(params, tokens) {
-    const param = { type: NodeType.NAMED_PARAMETER, name: tokens[0], typeName: tokens[4] };
+    const param = { 
+        type: tokens[0].optional 
+            ? NodeType.NAMED_PARAMETER_OPTIONAL 
+            : NodeType.NAMED_PARAMETER, 
+        name: tokens[0].name, 
+        typeName: tokens[4] 
+    };
     return [param].concat(params);
   }, lastParam ? [lastParam] : []);
 }

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -2175,7 +2175,7 @@ describe('Parser modes', function() {
       expect(function () {
         const typeExprStr = '(test?: boolean, input: string) => string';
         parse(typeExprStr, {mode: 'typescript'});
-      }).to.throw('or end of input but "<" found.');
+      }).to.throw('but ":" found');
     });
     it('should return a function type node when "function()" arrived', function() {
       const typeExprStr = 'function()';

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -2132,6 +2132,51 @@ describe('Parser modes', function() {
 
       expect(node).to.deep.equal(expectedNode);
     });
+    it('should return an arrow function type node when "(input: string) => string" arrived', function() {
+      const typeExprStr = '(input: string) => string';
+      const node = parse(typeExprStr, {mode: 'typescript'});
+
+      const expectedNode = createArrowFunctionTypeNode(
+        [createNamedParameter('input', 'string')], createTypeNameNode('string'),
+        { 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+    it('should return an arrow function type node when "(value1: boolean, input?: string) => string" arrived', function() {
+      const typeExprStr = '(value1: boolean, input?: string) => string';
+      const node = parse(typeExprStr, {mode: 'typescript'});
+
+      const expectedNode = createArrowFunctionTypeNode(
+        [
+          createNamedParameter('value1', 'boolean'),
+          createOptionalNamedParameter('input', 'string'),
+        ], createTypeNameNode('string'),
+        { 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+    it('should return an arrow function type node when "(test?: boolean, input?: string) => string" arrived', function() {
+      const typeExprStr = '(test?: boolean, input?: string) => string';
+      const node = parse(typeExprStr, {mode: 'typescript'});
+
+      const expectedNode = createArrowFunctionTypeNode(
+        [
+          createOptionalNamedParameter('test', 'boolean'),
+          createOptionalNamedParameter('input', 'string'),
+        ], createTypeNameNode('string'),
+        { 'new': null }
+      );
+
+      expect(node).to.deep.equal(expectedNode);
+    });
+    it('should throw when an arrow function type node "(test?: boolean, input: string) => string" arrived', function() {
+      expect(function () {
+        const typeExprStr = '(test?: boolean, input: string) => string';
+        parse(typeExprStr, {mode: 'typescript'});
+      }).to.throw('or end of input but "<" found.');
+    });
     it('should return a function type node when "function()" arrived', function() {
       const typeExprStr = 'function()';
       const node = parse(typeExprStr, {mode: 'typescript'});
@@ -2412,6 +2457,25 @@ function createFunctionTypeNode(paramNodes, returnedNode, modifierMap) {
     this: modifierMap.this,
     new: modifierMap.new,
   };
+}
+
+function createNamedParameter(name, type) {
+  return {
+    name,
+    type: NodeType.NAMED_PARAMETER,
+    typeName: createTypeNameNode(type),
+ };
+}
+
+function createOptionalNamedParameter(name, type) {
+  return {
+    meta: {
+      syntax: 'SUFFIX_KEY_QUESTION_MARK',
+    },
+    name,
+    type: NodeType.NAMED_PARAMETER,
+    typeName: createTypeNameNode(type),
+ };
 }
 
 function createNumberValueNode(numberLiteral) {

--- a/tests/test_parsing.js
+++ b/tests/test_parsing.js
@@ -2288,7 +2288,7 @@ function createTypeNameNode(typeName) {
 function createTypeOptionalNode(typeName) {
   return {
     meta: {
-      syntax: 'SUFFIX_KEY_QUESTION_MARK',
+      syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK,
     },
     type: NodeType.OPTIONAL,
     value: {
@@ -2470,7 +2470,7 @@ function createNamedParameter(name, type) {
 function createOptionalNamedParameter(name, type) {
   return {
     meta: {
-      syntax: 'SUFFIX_KEY_QUESTION_MARK',
+      syntax: OptionalTypeSyntax.SUFFIX_KEY_QUESTION_MARK,
     },
     name,
     type: NodeType.NAMED_PARAMETER,

--- a/tests/test_publishing.js
+++ b/tests/test_publishing.js
@@ -293,6 +293,16 @@ describe('publish', function() {
       expect(publish(node)).to.equal('(x: true, y: false) => string');
     });
 
+    it('should return an arrow type with one two optional parameters', function() {
+      const node = parse('(x?: string, y?: number) => string');
+      expect(publish(node)).to.equal('(x?: string, y?: number) => string');
+    });
+
+    it('should return an arrow type with one regular parameter and one optional', function() {
+      const node = parse('(x: string, y?: number) => string');
+      expect(publish(node)).to.equal('(x: string, y?: number) => string');
+    });
+
     it('should return an arrow type with one parameter', function() {
       const node = parse('(x: true) => string');
       expect(publish(node)).to.equal('(x: true) => string');


### PR DESCRIPTION
As the title mentions, this adds initial support for optional parameters in arrow functions. Probably related to #50

One shortcoming is that it doesn't error when optional parameters are placed before required parameters (eg `test?: number, test2: boolean`).

I'm really new to this code base so I apologize if I did anything wrong. Just let me know and I'll make any necessary changes.